### PR TITLE
ci: add OpenCodeReview workflow

### DIFF
--- a/.github/workflows/open-code-review.yml
+++ b/.github/workflows/open-code-review.yml
@@ -1,0 +1,34 @@
+# Required Actions secrets:
+#   OCR_LLM_URL: LLM API endpoint
+#   OCR_LLM_AUTH_TOKEN: LLM API key
+#   OCR_LLM_MODEL: model name
+
+name: OpenCodeReview
+
+on:
+  # Required for fork PRs to access the base repository's OCR secrets. The OCR
+  # action fetches the PR diff without executing contributor-controlled code.
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: open-code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  code-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Review pull request
+        uses: alibaba/open-code-review@main
+        with:
+          llm_url: ${{ secrets.OCR_LLM_URL }}
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          llm_model: ${{ secrets.OCR_LLM_MODEL }}
+          llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC || 'false' }}


### PR DESCRIPTION
## Summary

- add automated OpenCodeReview reviews for non-draft pull requests
- use `ubuntu-latest` and track `alibaba/open-code-review@main`, including its default latest CLI
- cancel stale reviews when a pull request is updated
- grant only read access to contents and write access to pull-request reviews

## Configuration

Define these repository Actions secrets after merge:

- `OCR_LLM_URL`: LLM API endpoint
- `OCR_LLM_AUTH_TOKEN`: LLM API key
- `OCR_LLM_MODEL`: model name

The optional `OCR_LLM_USE_ANTHROPIC` repository variable selects the Anthropic protocol; it defaults to `false` for OpenAI-compatible endpoints.

## Security

The workflow uses `pull_request_target` for fork pull requests. Tracking `alibaba/open-code-review@main` intentionally follows upstream changes without pinning.
