### PR TITLE
feat(overlaybd): concurrent coalesced zfile read path with read-path metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4494,7 +4494,9 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.13.1",
  "metrics",
+ "ordered-float",
  "quanta",
  "rand 0.9.5",
  "rand_xoshiro",
@@ -5209,6 +5211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5236,13 +5247,15 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "crc",
+ "crc32c",
+ "criterion",
  "dashmap",
  "futures-util",
  "io-uring",
  "libc",
  "lz4_flex",
  "metrics",
+ "metrics-util",
  "nix 0.30.1",
  "object-store-operator",
  "parking_lot",

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use axum::http::{header::CONTENT_TYPE, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::{routing::get, Router};
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
 const TEXT_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 
@@ -13,6 +13,19 @@ const TEXT_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 const DURATION_BUCKETS: &[f64] = &[
     0.001, 0.002, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
     120.0, 300.0, 600.0, 900.0, 1200.0, 1800.0,
+];
+
+/// Fine-grained buckets for the two sampled ZFile read-path duration
+/// histograms: 1µs..500µs in 1/2/5 steps, then the standard
+/// `DURATION_BUCKETS` ladder from 1ms to 30s. Values are seconds, strictly
+/// increasing; the exporter appends the implicit `+Inf` bucket itself.
+/// Attached only to the two exact metric names in
+/// [`init_prometheus_recorder`] via [`Matcher::Full`], so every other (and
+/// any future) histogram keeps `DURATION_BUCKETS`.
+const ZFILE_FINE_DURATION_BUCKETS: &[f64] = &[
+    0.000_001, 0.000_002, 0.000_005, 0.000_010, 0.000_025, 0.000_050, 0.000_100, 0.000_250,
+    0.000_500, 0.001, 0.002, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0, 2.5, 5.0, 10.0,
+    30.0,
 ];
 
 static PROMETHEUS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
@@ -26,6 +39,17 @@ pub fn init_prometheus_recorder() -> anyhow::Result<()> {
 
     let handle = PrometheusBuilder::new()
         .set_buckets(DURATION_BUCKETS)?
+        // Per-metric overrides take precedence over the global buckets
+        // above (full match beats the default); both ZFile histograms share
+        // the same microsecond-resolution bucket set.
+        .set_buckets_for_metric(
+            Matcher::Full("agentenv_overlaybd_zfile_pread_duration_seconds".to_owned()),
+            ZFILE_FINE_DURATION_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full("agentenv_overlaybd_zfile_decompress_duration_seconds".to_owned()),
+            ZFILE_FINE_DURATION_BUCKETS,
+        )?
         .install_recorder()?;
     if let Ok(runtime) = tokio::runtime::Handle::try_current() {
         let upkeep = handle.clone();

--- a/storage/overlaybd/Cargo.toml
+++ b/storage/overlaybd/Cargo.toml
@@ -20,7 +20,7 @@ bytes = "1.11.0"
 parking_lot = "0.12.5"
 zerocopy = { version = "0.8.36", features = ["derive"] }
 uuid = { version = "1.0", features = ["v4", "fast-rng"] }
-crc = "3.3.0"
+crc32c = "0.6"
 lz4_flex = "0.11.5"
 zstd = "0.13.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -50,7 +50,14 @@ axum = "0.8.6"
 clap = { version = "4.5.38", features = ["derive"] }
 agentenv-test-support = { path = "../../crates/test-support" }
 tar = "0.4"
+criterion = "0.8"
+metrics-util = { version = "0.20.4", default-features = false, features = ["debugging"] }
 
 [[example]]
 name = "generate_image_config"
 required-features = ["full"]
+
+[[bench]]
+name = "zfile_read"
+path = "benches/zfile_read_benchmark.rs"
+harness = false

--- a/storage/overlaybd/benches/zfile_read_benchmark.rs
+++ b/storage/overlaybd/benches/zfile_read_benchmark.rs
@@ -1,0 +1,778 @@
+//! Criterion benchmark harness for the zfile read and compress paths.
+//!
+//! Read-path groups measure steady-state `read_at_into` throughput of the
+//! shared handle from [`zfile_open_ro_vfile`] over an instrumented in-memory
+//! backing file that records lower-file read calls, requested/returned bytes,
+//! and the in-flight high-water mark (`max_in_flight`) — so serialization
+//! shows up as data. The `compress_throughput` group times the full
+//! `zfile_compress` pipeline, and a post-run table reports compression ratio
+//! (raw bytes vs. the honest zfile artifact size: header + data + jump table
+//! + trailer).
+//!
+//! Determinism: source data and offsets come from fixed seeds; all data,
+//! buffers, and the zfile artifact are built outside the timed region;
+//! backing counters are reset after open so header/index reads never pollute
+//! steady-state numbers. Only non-timing invariants are asserted, never
+//! wall-clock thresholds. All benchmarks use a current-thread Tokio runtime
+//! and go through `read_at_into` to avoid the `read_at` `Bytes` allocation.
+
+use anyhow::{ensure, Context, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+use criterion::{Criterion, Throughput};
+use futures_util::future::join_all;
+use overlaybd::virtual_file::VirtualFile;
+use overlaybd::zfile::{zfile_compress, zfile_open_ro_vfile, CompressArgs, CompressOptions};
+use rand::{rngs::StdRng, Rng, RngExt, SeedableRng};
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::runtime::Runtime;
+
+const DATASET_SIZE: usize = 8 * 1024 * 1024;
+const COMPRESS_DATASET_SIZE: usize = 16 * 1024 * 1024;
+const MIXED_CHUNK_SIZE: usize = 4096;
+const SEED_SOURCE: u64 = 0x5eed_5eed_0000_0001;
+const SEED_OFFSETS: u64 = 0x5eed_5eed_0000_0002;
+const RANDOM_OFFSET_COUNT: usize = 256;
+const RANDOM_OFFSET_ALIGN: u64 = 4096;
+
+// ---------------------------------------------------------------------------
+// InstrumentedMemoryFile — in-memory VirtualFile with read-path counters.
+// Bench-local on purpose: the zfile unit tests keep their own minimal probes
+// inside the zfile test module.
+// ---------------------------------------------------------------------------
+
+/// Read-path counters of [`InstrumentedMemoryFile`]. Everything is atomic so
+/// [`InstrumentedMemoryFile::reset_counters`] works through the shared `Arc`
+/// while zfile holds its own `Arc<dyn VirtualFile>` reference.
+#[derive(Debug, Default)]
+struct ReadCounters {
+    read_calls: AtomicU64,
+    requested_bytes: AtomicU64,
+    returned_bytes: AtomicU64,
+    in_flight: AtomicU64,
+    max_in_flight: AtomicU64,
+}
+
+/// RAII guard that keeps `in_flight` balanced across awaits and early
+/// returns, and raises the `max_in_flight` high-water mark on entry.
+struct InFlightGuard<'a> {
+    counters: &'a ReadCounters,
+}
+
+impl<'a> InFlightGuard<'a> {
+    fn enter(counters: &'a ReadCounters, requested: u64) -> Self {
+        counters.read_calls.fetch_add(1, Ordering::SeqCst);
+        counters
+            .requested_bytes
+            .fetch_add(requested, Ordering::SeqCst);
+        let current = counters.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        counters.max_in_flight.fetch_max(current, Ordering::SeqCst);
+        Self { counters }
+    }
+
+    fn record_returned(&self, returned: u64) {
+        self.counters
+            .returned_bytes
+            .fetch_add(returned, Ordering::SeqCst);
+    }
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.counters.in_flight.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// In-memory [`VirtualFile`] that counts lower-file reads: read calls,
+/// requested/returned bytes, and the in-flight high-water mark. Writes grow
+/// the in-memory buffer so `zfile_compress` can build the fixture artifact
+/// directly into it.
+#[derive(Debug)]
+struct InstrumentedMemoryFile {
+    data: Mutex<Vec<u8>>,
+    counters: ReadCounters,
+}
+
+impl InstrumentedMemoryFile {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            data: Mutex::new(Vec::new()),
+            counters: ReadCounters::default(),
+        })
+    }
+
+    fn reset_counters(&self) {
+        let counters = &self.counters;
+        counters.read_calls.store(0, Ordering::SeqCst);
+        counters.requested_bytes.store(0, Ordering::SeqCst);
+        counters.returned_bytes.store(0, Ordering::SeqCst);
+        counters.in_flight.store(0, Ordering::SeqCst);
+        counters.max_in_flight.store(0, Ordering::SeqCst);
+    }
+
+    fn read_vec(&self, offset: u64, len: usize) -> Vec<u8> {
+        let data = self.data.lock().expect("data mutex poisoned");
+        if len == 0 || offset >= data.len() as u64 {
+            return Vec::new();
+        }
+        let end = offset.saturating_add(len as u64).min(data.len() as u64) as usize;
+        data[offset as usize..end].to_vec()
+    }
+
+    fn read_into(&self, offset: u64, dst: &mut [u8]) -> usize {
+        let data = self.data.lock().expect("data mutex poisoned");
+        if dst.is_empty() || offset >= data.len() as u64 {
+            return 0;
+        }
+        let end = offset
+            .saturating_add(dst.len() as u64)
+            .min(data.len() as u64) as usize;
+        let n = end - offset as usize;
+        dst[..n].copy_from_slice(&data[offset as usize..end]);
+        n
+    }
+}
+
+#[async_trait]
+impl VirtualFile for InstrumentedMemoryFile {
+    async fn read_at(&self, offset: u64, len: usize) -> Result<Bytes> {
+        let guard = InFlightGuard::enter(&self.counters, len as u64);
+        let bytes = self.read_vec(offset, len);
+        guard.record_returned(bytes.len() as u64);
+        Ok(Bytes::from(bytes))
+    }
+
+    async fn read_at_into(&self, offset: u64, dst: &mut [u8]) -> Result<usize> {
+        let guard = InFlightGuard::enter(&self.counters, dst.len() as u64);
+        let n = self.read_into(offset, dst);
+        guard.record_returned(n as u64);
+        Ok(n)
+    }
+
+    async fn write_at(&self, offset: u64, data: &[u8]) -> Result<usize> {
+        let mut inner = self.data.lock().expect("data mutex poisoned");
+        let end = usize::try_from(offset)
+            .context("write offset overflow")?
+            .checked_add(data.len())
+            .context("write offset overflow")?;
+        if end > inner.len() {
+            inner.resize(end, 0);
+        }
+        inner[offset as usize..end].copy_from_slice(data);
+        Ok(data.len())
+    }
+
+    async fn size(&self) -> Result<u64> {
+        Ok(self.data.lock().expect("data mutex poisoned").len() as u64)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Workload matrix.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+enum DataKind {
+    /// Seeded pseudo-random bytes (effectively incompressible).
+    Random,
+    /// Highly compressible repeating byte pattern.
+    Compressible,
+    /// 50/50 mix: alternating 4 KiB chunks of compressible pattern and
+    /// seeded random bytes. Used by the compression benchmarks only.
+    Mixed,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Pattern {
+    /// Random 4 KiB-aligned reads of `len` bytes, `qd` in flight per op on
+    /// one shared zfile handle.
+    Random { len: usize, qd: usize },
+    /// Sequential full-chunk reads of `len` bytes, one in flight per op.
+    Sequential { len: usize },
+}
+
+impl Pattern {
+    const fn read_len(&self) -> usize {
+        match *self {
+            Pattern::Random { len, .. } => len,
+            Pattern::Sequential { len } => len,
+        }
+    }
+
+    const fn qd(&self) -> usize {
+        match *self {
+            Pattern::Random { qd, .. } => qd,
+            Pattern::Sequential { .. } => 1,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CaseSpec {
+    /// Criterion case label; combines with the group name into the
+    /// `BenchmarkId` used as baseline key.
+    label: &'static str,
+    algo: u8,
+    data: DataKind,
+    block_size: u32,
+    pattern: Pattern,
+}
+
+const fn spec(
+    label: &'static str,
+    algo: u8,
+    data: DataKind,
+    block_size: u32,
+    pattern: Pattern,
+) -> CaseSpec {
+    CaseSpec {
+        label,
+        algo,
+        data,
+        block_size,
+        pattern,
+    }
+}
+
+/// `throughput` group: LZ4/ZSTD x {4 KiB random QD1, 128 KiB sequential QD1,
+/// QD16 on one shared handle}, plus one compressible-dataset contrast case
+/// per algorithm. All with 4 KiB blocks. Labels are fixed literals so they
+/// stay stable as baseline keys.
+fn throughput_specs() -> Vec<CaseSpec> {
+    let mut specs = Vec::new();
+    for (algo, name) in [
+        (CompressOptions::LZ4, "lz4"),
+        (CompressOptions::ZSTD, "zstd"),
+    ] {
+        let random4k_qd1: &'static str = match name {
+            "lz4" => "lz4_random4k_qd1",
+            _ => "zstd_random4k_qd1",
+        };
+        let seq128k_qd1: &'static str = match name {
+            "lz4" => "lz4_seq128k_qd1",
+            _ => "zstd_seq128k_qd1",
+        };
+        let random4k_qd16: &'static str = match name {
+            "lz4" => "lz4_random4k_qd16_shared",
+            _ => "zstd_random4k_qd16_shared",
+        };
+        let compressible_qd1: &'static str = match name {
+            "lz4" => "lz4_compressible_random4k_qd1",
+            _ => "zstd_compressible_random4k_qd1",
+        };
+        specs.push(spec(
+            random4k_qd1,
+            algo,
+            DataKind::Random,
+            4096,
+            Pattern::Random { len: 4096, qd: 1 },
+        ));
+        specs.push(spec(
+            seq128k_qd1,
+            algo,
+            DataKind::Random,
+            4096,
+            Pattern::Sequential { len: 128 * 1024 },
+        ));
+        specs.push(spec(
+            random4k_qd16,
+            algo,
+            DataKind::Random,
+            4096,
+            Pattern::Random { len: 4096, qd: 16 },
+        ));
+        specs.push(spec(
+            compressible_qd1,
+            algo,
+            DataKind::Compressible,
+            4096,
+            Pattern::Random { len: 4096, qd: 1 },
+        ));
+    }
+    specs
+}
+
+/// `block_size` group: 4 KiB vs 64 KiB zfile blocks on the same base case.
+fn block_size_specs() -> Vec<CaseSpec> {
+    vec![
+        spec(
+            "lz4_random4k_qd1_bs4k",
+            CompressOptions::LZ4,
+            DataKind::Random,
+            4096,
+            Pattern::Random { len: 4096, qd: 1 },
+        ),
+        spec(
+            "lz4_random4k_qd1_bs64k",
+            CompressOptions::LZ4,
+            DataKind::Random,
+            64 * 1024,
+            Pattern::Random { len: 4096, qd: 1 },
+        ),
+    ]
+}
+
+/// Compression case: times the full `zfile_compress` pipeline and feeds the
+/// post-run compression-ratio table.
+#[derive(Clone, Copy, Debug)]
+struct CompressCaseSpec {
+    /// Criterion case label; combines with the group name into the
+    /// `BenchmarkId` used as baseline key.
+    label: &'static str,
+    algo: u8,
+    data: DataKind,
+    block_size: u32,
+}
+
+/// `compress_throughput` group: LZ4/ZSTD x {compressible, random} x
+/// {4 KiB, 64 KiB blocks}, plus one 50/50 mixed-dataset case per algorithm
+/// at 4 KiB blocks (mixed skips 64 KiB to keep the matrix small). Labels are
+/// fixed literals so they stay stable as baseline keys.
+fn compress_specs() -> Vec<CompressCaseSpec> {
+    vec![
+        CompressCaseSpec {
+            label: "lz4_compressible_bs4k",
+            algo: CompressOptions::LZ4,
+            data: DataKind::Compressible,
+            block_size: 4096,
+        },
+        CompressCaseSpec {
+            label: "lz4_compressible_bs64k",
+            algo: CompressOptions::LZ4,
+            data: DataKind::Compressible,
+            block_size: 64 * 1024,
+        },
+        CompressCaseSpec {
+            label: "lz4_random_bs4k",
+            algo: CompressOptions::LZ4,
+            data: DataKind::Random,
+            block_size: 4096,
+        },
+        CompressCaseSpec {
+            label: "lz4_random_bs64k",
+            algo: CompressOptions::LZ4,
+            data: DataKind::Random,
+            block_size: 64 * 1024,
+        },
+        CompressCaseSpec {
+            label: "lz4_mixed_bs4k",
+            algo: CompressOptions::LZ4,
+            data: DataKind::Mixed,
+            block_size: 4096,
+        },
+        CompressCaseSpec {
+            label: "zstd_compressible_bs4k",
+            algo: CompressOptions::ZSTD,
+            data: DataKind::Compressible,
+            block_size: 4096,
+        },
+        CompressCaseSpec {
+            label: "zstd_compressible_bs64k",
+            algo: CompressOptions::ZSTD,
+            data: DataKind::Compressible,
+            block_size: 64 * 1024,
+        },
+        CompressCaseSpec {
+            label: "zstd_random_bs4k",
+            algo: CompressOptions::ZSTD,
+            data: DataKind::Random,
+            block_size: 4096,
+        },
+        CompressCaseSpec {
+            label: "zstd_random_bs64k",
+            algo: CompressOptions::ZSTD,
+            data: DataKind::Random,
+            block_size: 64 * 1024,
+        },
+        CompressCaseSpec {
+            label: "zstd_mixed_bs4k",
+            algo: CompressOptions::ZSTD,
+            data: DataKind::Mixed,
+            block_size: 4096,
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Fixture construction and validation (all outside Criterion timed regions).
+// ---------------------------------------------------------------------------
+
+fn source_bytes(kind: DataKind, size: usize) -> Vec<u8> {
+    let mut rng = StdRng::seed_from_u64(SEED_SOURCE);
+    match kind {
+        DataKind::Random => {
+            let mut data = vec![0u8; size];
+            rng.fill_bytes(&mut data);
+            data
+        }
+        DataKind::Compressible => {
+            // 64-byte period seeded tile repeated over the whole buffer.
+            let mut tile = [0u8; 64];
+            rng.fill_bytes(&mut tile);
+            (0..size).map(|i| tile[i % tile.len()]).collect()
+        }
+        DataKind::Mixed => {
+            // Random base, with every even 4 KiB chunk overwritten by the
+            // repeating tile: half the logical blocks compress well, half
+            // do not.
+            let mut data = vec![0u8; size];
+            rng.fill_bytes(&mut data);
+            let mut tile = [0u8; 64];
+            rng.fill_bytes(&mut tile);
+            for (chunk_idx, chunk) in data.chunks_mut(MIXED_CHUNK_SIZE).enumerate() {
+                if chunk_idx % 2 == 0 {
+                    for (i, byte) in chunk.iter_mut().enumerate() {
+                        *byte = tile[i % tile.len()];
+                    }
+                }
+            }
+            data
+        }
+    }
+}
+
+fn make_offsets(pattern: &Pattern, source_len: usize) -> Vec<u64> {
+    match *pattern {
+        Pattern::Random { len, .. } => {
+            let mut rng = StdRng::seed_from_u64(SEED_OFFSETS);
+            let slots = ((source_len - len) / RANDOM_OFFSET_ALIGN as usize) as u64;
+            (0..RANDOM_OFFSET_COUNT)
+                .map(|_| rng.random_range(0..=slots) * RANDOM_OFFSET_ALIGN)
+                .collect()
+        }
+        Pattern::Sequential { len } => {
+            let chunks = source_len / len;
+            (0..chunks).map(|i| (i * len) as u64).collect()
+        }
+    }
+}
+
+struct Fixture {
+    /// Shared zfile handle under test (`zfile_open_ro_vfile` output).
+    vf: Arc<dyn VirtualFile>,
+    /// Instrumented backing file holding the compressed artifact.
+    backing: Arc<InstrumentedMemoryFile>,
+    /// Decompressed source bytes for correctness comparison.
+    source: Vec<u8>,
+    /// Pre-generated offset sequence replayed by the measured ops.
+    offsets: Vec<u64>,
+}
+
+async fn build_fixture(spec: &CaseSpec) -> Result<Fixture> {
+    let source = source_bytes(spec.data, DATASET_SIZE);
+
+    let src_file: Arc<dyn VirtualFile> = InstrumentedMemoryFile::new();
+    let written = src_file
+        .write_at(0, &source)
+        .await
+        .context("write source")?;
+    ensure!(written == source.len(), "short source write");
+
+    let backing = InstrumentedMemoryFile::new();
+    let backing_file: Arc<dyn VirtualFile> = backing.clone();
+    let args = CompressArgs {
+        opt: CompressOptions::new(spec.algo, spec.block_size, 1),
+        overwrite_header: false,
+        workers: 1,
+    };
+    zfile_compress(src_file, backing_file.clone(), &args)
+        .await
+        .context("compress fixture")?;
+    let vf = zfile_open_ro_vfile(backing_file, false)
+        .await
+        .context("open fixture zfile")?;
+    let offsets = make_offsets(&spec.pattern, source.len());
+    Ok(Fixture {
+        vf,
+        backing,
+        source,
+        offsets,
+    })
+}
+
+/// Non-timing correctness invariant: every replayed offset must return the
+/// exact source bytes. Runs before the counter reset, so these validation
+/// reads never pollute steady-state numbers.
+async fn validate_fixture(fixture: &Fixture, read_len: usize) -> Result<()> {
+    let mut buf = vec![0u8; read_len];
+    for &offset in &fixture.offsets {
+        let n = fixture
+            .vf
+            .read_at_into(offset, &mut buf)
+            .await
+            .with_context(|| format!("validation read at {offset}"))?;
+        ensure!(n == read_len, "validation short read at {offset}: {n}");
+        let begin = offset as usize;
+        ensure!(
+            buf[..] == fixture.source[begin..begin + read_len],
+            "validation data mismatch at {offset}"
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Measured section and reporting.
+// ---------------------------------------------------------------------------
+
+struct CaseSummary {
+    id: String,
+    ops: u64,
+    read_calls: u64,
+    requested_bytes: u64,
+    returned_bytes: u64,
+    max_in_flight: u64,
+    in_flight_end: u64,
+}
+
+fn run_group(
+    criterion: &mut Criterion,
+    rt: &Runtime,
+    group_name: &str,
+    specs: &[CaseSpec],
+    summaries: &mut Vec<CaseSummary>,
+) {
+    let mut group = criterion.benchmark_group(group_name);
+    for spec in specs {
+        let fixture = rt.block_on(build_fixture(spec)).expect("build fixture");
+        let read_len = spec.pattern.read_len();
+        let qd = spec.pattern.qd();
+        rt.block_on(validate_fixture(&fixture, read_len))
+            .expect("validate fixture");
+        fixture.backing.reset_counters();
+
+        let ops = Rc::new(Cell::new(0u64));
+        group.throughput(Throughput::Bytes((read_len * qd) as u64));
+        group.bench_function(spec.label, |b| {
+            let vf = fixture.vf.clone();
+            let offsets = Rc::new(fixture.offsets.clone());
+            let ops = ops.clone();
+            b.iter_custom(move |iters| {
+                // Per-invocation setup: fresh output buffers, allocated
+                // before the timed span starts.
+                let mut bufs: Vec<Vec<u8>> = (0..qd).map(|_| vec![0u8; read_len]).collect();
+                let mut offs: Vec<u64> = Vec::with_capacity(qd);
+                let mut cursor = 0usize;
+                let vf = vf.clone();
+                let offsets = offsets.clone();
+                let ops = ops.clone();
+                rt.block_on(async move {
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        offs.clear();
+                        offs.extend((0..bufs.len()).map(|k| offsets[(cursor + k) % offsets.len()]));
+                        cursor = (cursor + bufs.len()) % offsets.len();
+                        let results = join_all(
+                            bufs.iter_mut()
+                                .zip(offs.iter())
+                                .map(|(buf, &off)| vf.read_at_into(off, &mut buf[..])),
+                        )
+                        .await;
+                        for (result, buf) in results.into_iter().zip(bufs.iter()) {
+                            let n = result.expect("zfile read_at_into");
+                            assert_eq!(n, buf.len(), "fixture short read");
+                        }
+                        ops.set(ops.get() + 1);
+                    }
+                    start.elapsed()
+                })
+            });
+        });
+
+        let counters = &fixture.backing.counters;
+        let summary = CaseSummary {
+            id: format!("{group_name}/{}", spec.label),
+            ops: ops.get(),
+            read_calls: counters.read_calls.load(Ordering::SeqCst),
+            requested_bytes: counters.requested_bytes.load(Ordering::SeqCst),
+            returned_bytes: counters.returned_bytes.load(Ordering::SeqCst),
+            max_in_flight: counters.max_in_flight.load(Ordering::SeqCst),
+            in_flight_end: counters.in_flight.load(Ordering::SeqCst),
+        };
+        if summary.ops == 0 {
+            // Analysis-only criterion modes (e.g. `--load-baseline`
+            // comparison runs) never execute a measured iteration, so the
+            // probe counters stay at zero. Skip the invariant assertions
+            // and the summary row for such cases instead of panicking.
+            continue;
+        }
+        // Non-timing invariants only; no wall-clock thresholds.
+        assert!(
+            summary.max_in_flight >= 1,
+            "{}: max_in_flight must be >= 1",
+            summary.id
+        );
+        assert_eq!(
+            summary.in_flight_end, 0,
+            "{}: in_flight not drained after case",
+            summary.id
+        );
+        summaries.push(summary);
+    }
+    group.finish();
+}
+
+fn print_summary(summaries: &[CaseSummary]) {
+    println!();
+    println!(
+        "=== zfile read-path lower-file probe summary (post-run, counters sampled outside timing) ==="
+    );
+    println!(
+        "{:<44} {:>8} {:>9} {:>11} {:>11} {:>10}",
+        "case", "ops", "calls/op", "req B/op", "ret B/op", "max_inflt"
+    );
+    for s in summaries {
+        println!(
+            "{:<44} {:>8} {:>9.2} {:>11.1} {:>11.1} {:>10}",
+            s.id,
+            s.ops,
+            s.read_calls as f64 / s.ops as f64,
+            s.requested_bytes as f64 / s.ops as f64,
+            s.returned_bytes as f64 / s.ops as f64,
+            s.max_in_flight,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compression throughput and compression ratio.
+// ---------------------------------------------------------------------------
+
+struct CompressSummary {
+    id: String,
+    raw_bytes: u64,
+    artifact_bytes: u64,
+}
+
+impl CompressSummary {
+    fn ratio(&self) -> f64 {
+        self.artifact_bytes as f64 / self.raw_bytes as f64
+    }
+}
+
+/// Times the full `zfile_compress` pipeline per case and records one untimed
+/// ratio probe per case. The timed span covers exactly one `zfile_compress`
+/// call per iteration; the destination file is allocated outside the timed
+/// span so allocation of the output buffer never distorts compress numbers.
+fn run_compress_group(
+    criterion: &mut Criterion,
+    rt: &Runtime,
+    specs: &[CompressCaseSpec],
+    ratios: &mut Vec<CompressSummary>,
+) {
+    let mut group = criterion.benchmark_group("compress_throughput");
+    for spec in specs {
+        let source = source_bytes(spec.data, COMPRESS_DATASET_SIZE);
+        let src_file: Arc<dyn VirtualFile> = InstrumentedMemoryFile::new();
+        let written = rt
+            .block_on(src_file.write_at(0, &source))
+            .expect("write compress source");
+        assert_eq!(written, source.len(), "short compress source write");
+        let args = CompressArgs {
+            opt: CompressOptions::new(spec.algo, spec.block_size, 1),
+            overwrite_header: false,
+            workers: 1,
+        };
+
+        // Untimed ratio probe: honest artifact size, i.e. the whole zfile
+        // (header + compressed data + jump table + trailer).
+        let artifact_bytes = rt
+            .block_on(async {
+                let dst: Arc<dyn VirtualFile> = InstrumentedMemoryFile::new();
+                zfile_compress(src_file.clone(), dst.clone(), &args).await?;
+                dst.size().await
+            })
+            .expect("ratio probe compress");
+        let summary = CompressSummary {
+            id: format!("compress_throughput/{}", spec.label),
+            raw_bytes: source.len() as u64,
+            artifact_bytes,
+        };
+        // Sanity guard on the ratio accounting itself, not a perf threshold:
+        // the highly compressible dataset must actually shrink.
+        if matches!(spec.data, DataKind::Compressible) {
+            assert!(
+                summary.ratio() < 1.0,
+                "{}: compressible dataset did not shrink (ratio {:.4})",
+                summary.id,
+                summary.ratio()
+            );
+        }
+        ratios.push(summary);
+
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_function(spec.label, |b| {
+            let src_file = src_file.clone();
+            b.iter_custom(move |iters| {
+                let src_file = src_file.clone();
+                rt.block_on(async move {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        // Fresh destination per iteration, allocated outside
+                        // the timed span.
+                        let dst: Arc<dyn VirtualFile> = InstrumentedMemoryFile::new();
+                        let start = Instant::now();
+                        zfile_compress(src_file.clone(), dst.clone(), &args)
+                            .await
+                            .expect("bench zfile_compress");
+                        total += start.elapsed();
+                    }
+                    total
+                })
+            });
+        });
+    }
+    group.finish();
+}
+
+fn print_compression_ratios(rows: &[CompressSummary]) {
+    println!();
+    println!(
+        "=== zfile compression ratio (post-run, artifact = full zfile incl. header/index/trailer) ==="
+    );
+    println!(
+        "{:<44} {:>12} {:>14} {:>8}",
+        "case", "raw bytes", "artifact bytes", "ratio"
+    );
+    for r in rows {
+        println!(
+            "{:<44} {:>12} {:>14} {:>8.4}",
+            r.id,
+            r.raw_bytes,
+            r.artifact_bytes,
+            r.ratio(),
+        );
+    }
+}
+
+fn main() {
+    // All benchmarks run on a current-thread Tokio runtime.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build current-thread runtime");
+    let mut criterion = Criterion::default().configure_from_args();
+    let mut summaries = Vec::new();
+    run_group(
+        &mut criterion,
+        &rt,
+        "throughput",
+        &throughput_specs(),
+        &mut summaries,
+    );
+    run_group(
+        &mut criterion,
+        &rt,
+        "block_size",
+        &block_size_specs(),
+        &mut summaries,
+    );
+    let mut ratios = Vec::new();
+    run_compress_group(&mut criterion, &rt, &compress_specs(), &mut ratios);
+    print_summary(&summaries);
+    print_compression_ratios(&ratios);
+}

--- a/storage/overlaybd/src/backend/cache/meta.rs
+++ b/storage/overlaybd/src/backend/cache/meta.rs
@@ -1,6 +1,5 @@
 use anyhow::anyhow;
 use anyhow::{ensure, Context, Result};
-use crc::{Crc, CRC_32_ISCSI};
 use nix::errno::Errno;
 use roaring::RoaringBitmap;
 use std::io::Write;
@@ -107,8 +106,7 @@ impl CacheMetaDisk {
             .serialize_into(&mut out)
             .context("failed to serialize bitmap")?;
 
-        let crc = Crc::<u32>::new(&CRC_32_ISCSI);
-        let checksum = crc.checksum(&out);
+        let checksum = crc32c::crc32c(&out);
         out.write_all(&checksum.to_le_bytes())?;
 
         Ok(out)
@@ -160,8 +158,7 @@ impl CacheMetaDisk {
             .context("failed to deserialize bitmap")?;
 
         let stored_crc = u32::from_le_bytes(crc_bytes.try_into().context("read meta crc failed")?);
-        let crc = Crc::<u32>::new(&CRC_32_ISCSI);
-        let computed = crc.checksum(&raw[..raw.len() - 4]);
+        let computed = crc32c::crc32c(&raw[..raw.len() - 4]);
         ensure!(
             stored_crc == computed,
             "meta CRC mismatch: stored 0x{stored_crc:08X}, computed 0x{computed:08X}"

--- a/storage/overlaybd/src/compression/zfile.rs
+++ b/storage/overlaybd/src/compression/zfile.rs
@@ -1,14 +1,111 @@
 use crate::io::vfile_io::{read_exact, CtxRead, DirectRead, FileReader};
 use crate::io::virtual_file::{IoCtx, LocalBoxFuture, VirtualFile};
+use crate::metrics::{ZFileCodec, ZFileReadMetrics, ZFileReadStats, ZFileReadStatus};
 use anyhow::{bail, ensure, Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
-use crc::{Algorithm, Crc};
 use futures_util::stream::{self, StreamExt};
+use std::cell::{Cell, RefCell};
 use std::cmp::min;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 pub const MAX_READ_SIZE: usize = 65_536;
+
+/// Maximum combined encoded span read from the backing file in one
+/// coalesced batch. Semantically separate from [`MAX_READ_SIZE`] (the
+/// maximum *logical* block size): a batch only ever covers complete
+/// encoded blocks whose combined span fits this budget, and a single
+/// encoded block larger than the budget still forms its own one-block
+/// batch so 64 KiB incompressible blocks stay readable.
+const MAX_COALESCED_READ_SIZE: usize = 64 * 1024;
+
+/// One logical pread in this many per thread is sampled for the duration
+/// histograms. The counter is thread-local, so an unsampled pread pays only
+/// a `Cell` increment for observability: no shared atomic, no
+/// `Instant::now()`, no tracing span, no label work.
+const ZFILE_PREAD_SAMPLE_INTERVAL: u64 = 1024;
+
+std::thread_local! {
+    /// Per-thread logical-pread counter driving [`sample_zfile_pread`].
+    static ZFILE_PREAD_COUNTER: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Return true for one pread in [`ZFILE_PREAD_SAMPLE_INTERVAL`] on each
+/// thread. Histograms fed only by sampled preads export a `_count` that is
+/// a SAMPLE COUNT, not an operation count.
+fn sample_zfile_pread() -> bool {
+    ZFILE_PREAD_COUNTER.with(|counter| {
+        let next = counter.get().wrapping_add(1);
+        counter.set(next);
+        next % ZFILE_PREAD_SAMPLE_INTERVAL == 0
+    })
+}
+
+/// Observation collected over one logical [`ZFileRO::pread`]: the exact
+/// counters plus, for sampled preads only, the durations. Handed to the
+/// metrics recorder exactly once per pread by [`ZFileRO::pread_generic`].
+#[derive(Debug, Default)]
+struct ZFilePreadObservation {
+    stats: ZFileReadStats,
+    /// Total pread wall time; `Some` only when this pread was sampled.
+    pread_elapsed: Option<Duration>,
+    /// Sum of all per-block decode times within this pread (retry decodes
+    /// included). Stays `Duration::ZERO` for unsampled preads, whose block
+    /// loop never calls `Instant::now()`.
+    decompress_elapsed: Duration,
+}
+
+std::thread_local! {
+    /// Per-thread free list of merged-batch buffers. Buffers move out by
+    /// value, so no pool borrow is ever held across an `.await`.
+    static COMPRESSED_BUFFER_POOL: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Merged-batch buffer checked out of [`COMPRESSED_BUFFER_POOL`]; returns
+/// to the pool on drop (error exits included), so steady-state preads on
+/// one thread neither allocate nor re-zero.
+struct PooledBatchBuffer(Vec<u8>);
+
+impl PooledBatchBuffer {
+    fn take() -> Self {
+        Self(
+            COMPRESSED_BUFFER_POOL
+                .with(|pool| pool.borrow_mut().pop())
+                .unwrap_or_default(),
+        )
+    }
+}
+
+impl std::ops::Deref for PooledBatchBuffer {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PooledBatchBuffer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for PooledBatchBuffer {
+    fn drop(&mut self) {
+        let buf = std::mem::take(&mut self.0);
+        // Retain only a few reasonably-sized buffers per thread.
+        if buf.capacity() == 0 || buf.capacity() > 2 * MAX_COALESCED_READ_SIZE {
+            return;
+        }
+        COMPRESSED_BUFFER_POOL.with(|pool| {
+            let mut pool = pool.borrow_mut();
+            if pool.len() < 4 {
+                pool.push(buf);
+            }
+        });
+    }
+}
 
 const HEADER_TRAILER_SPACE: usize = 512;
 const HEADER_TRAILER_BODY_SIZE: usize = 96;
@@ -17,29 +114,22 @@ const NOI_WELL_KNOWN_PRIME: u32 = 100_007;
 const ZSTD_C_LEVEL: i32 = 3;
 const JUMP_TABLE_READ_CHUNK_SIZE: usize = 1 << 20;
 const JUMP_TABLE_READ_PARALLELISM: usize = 32;
-const CRC32C_RAW_ALG: Algorithm<u32> = Algorithm {
-    width: 32,
-    poly: 0x1EDC6F41,
-    init: 0,
-    refin: true,
-    refout: true,
-    xorout: 0,
-    check: 0,
-    residue: 0,
-};
-const CRC32C_RAW: Crc<u32> = Crc::<u32>::new(&CRC32C_RAW_ALG);
+
+// ZFile checksums use the "raw" CRC-32C variant (poly 0x1EDC6F41, reflected,
+// init 0, no output xor), matching upstream overlaybd's crc32c_extend().
+// The `crc32c` crate computes hardware-accelerated *standard* CRC-32C, whose
+// `crc32c_append(seed, data)` complements the seed on entry and the state on
+// exit; complementing at both ends therefore chains the raw internal state
+// directly: raw(state, data) == !crc32c_append(!state, data).
 
 fn crc32c(data: &[u8]) -> u32 {
-    CRC32C_RAW.checksum(data)
+    !::crc32c::crc32c_append(!0, data)
 }
 
 fn crc32c_salt(data: &[u8]) -> u32 {
-    // Upstream crc32c_extend() consumes the running CRC state directly.
-    // `crc`'s digest_with_initial() applies reflected init preprocessing,
-    // so reverse the seed bits to reconstruct the same internal state.
-    let mut digest = CRC32C_RAW.digest_with_initial(NOI_WELL_KNOWN_PRIME.reverse_bits());
-    digest.update(data);
-    digest.finalize()
+    // Upstream crc32c_extend() seeds the running CRC state with the salt
+    // prime directly, so chain from that raw state.
+    !::crc32c::crc32c_append(!NOI_WELL_KNOWN_PRIME, data)
 }
 
 /// Thin wrapper around [`read_exact`] preserving the historical
@@ -224,12 +314,20 @@ impl Default for CompressArgs {
     }
 }
 
-pub trait Compressor: Send {
+/// Block compressor for the zfile format.
+///
+/// Thread-safety contract: the decode side ([`Self::decompress`]) takes
+/// `&self` and the trait is `Send + Sync`, so one shared instance must decode
+/// blocks concurrently — keep decoders stateless, with any per-call scratch on
+/// the stack or in caller-provided buffers. The encode side
+/// ([`Self::compress`] / [`Self::compress_batch`]) stays `&mut self` and is
+/// only used on the single-owner write path.
+pub trait Compressor: Send + Sync {
     fn max_dst_size(&self) -> usize;
     fn src_block_size(&self) -> usize;
 
     fn compress(&mut self, src: &[u8], dst: &mut [u8]) -> Result<usize>;
-    fn decompress(&mut self, src: &[u8], dst: &mut [u8]) -> Result<usize>;
+    fn decompress(&self, src: &[u8], dst: &mut [u8]) -> Result<usize>;
 
     fn nbatch(&self) -> usize {
         1
@@ -272,49 +370,6 @@ pub trait Compressor: Send {
                 .context("destination offset overflow")?;
 
             let nout = self.compress(&src[src_offset..end], &mut dst[dst_begin..dst_end])?;
-            dst_chunk_len[i] = nout;
-            src_offset = end;
-        }
-        Ok(())
-    }
-
-    fn decompress_batch(
-        &mut self,
-        src: &[u8],
-        src_chunk_len: &[usize],
-        dst: &mut [u8],
-        dst_chunk_len: &mut [usize],
-        n: usize,
-    ) -> Result<()> {
-        if n == 0 {
-            return Ok(());
-        }
-        ensure!(
-            src_chunk_len.len() >= n && dst_chunk_len.len() >= n,
-            "chunk length arrays are smaller than n"
-        );
-        let each_dst_capacity = dst.len() / n;
-        ensure!(
-            each_dst_capacity >= self.src_block_size(),
-            "destination chunk capacity ({each_dst_capacity}) smaller than src_block_size ({})",
-            self.src_block_size()
-        );
-
-        let mut src_offset = 0usize;
-        for i in 0..n {
-            let chunk_len = src_chunk_len[i];
-            let end = src_offset
-                .checked_add(chunk_len)
-                .context("source offset overflow")?;
-            ensure!(end <= src.len(), "source chunk exceeds source buffer");
-            let dst_begin = i
-                .checked_mul(each_dst_capacity)
-                .context("destination offset overflow")?;
-            let dst_end = dst_begin
-                .checked_add(each_dst_capacity)
-                .context("destination offset overflow")?;
-
-            let nout = self.decompress(&src[src_offset..end], &mut dst[dst_begin..dst_end])?;
             dst_chunk_len[i] = nout;
             src_offset = end;
         }
@@ -383,7 +438,7 @@ impl Compressor for Lz4Compressor {
         Ok(compressed.len())
     }
 
-    fn decompress(&mut self, src: &[u8], dst: &mut [u8]) -> Result<usize> {
+    fn decompress(&self, src: &[u8], dst: &mut [u8]) -> Result<usize> {
         let out_len =
             lz4_flex::block::decompress_into(src, dst).context("lz4 decompress failed")?;
         ensure!(out_len != 0, "lz4 decompress returned zero bytes");
@@ -413,6 +468,16 @@ impl ZstdCompressor {
     }
 }
 
+thread_local! {
+    /// Per-thread reusable ZSTD contexts. Creating a context costs more than
+    /// (de)compressing one small block, and `decompress(&self)` must stay
+    /// shareable across concurrent readers, so contexts are thread-local
+    /// rather than compressor-instance fields (which would also break the
+    /// `Compressor: Send + Sync` contract — the raw contexts are not `Sync`).
+    static ZSTD_CCTX: RefCell<Option<zstd::bulk::Compressor<'static>>> = const { RefCell::new(None) };
+    static ZSTD_DCTX: RefCell<Option<zstd::bulk::Decompressor<'static>>> = const { RefCell::new(None) };
+}
+
 impl Compressor for ZstdCompressor {
     fn max_dst_size(&self) -> usize {
         self.max_dst_size
@@ -429,32 +494,46 @@ impl Compressor for ZstdCompressor {
             dst.len(),
             self.max_dst_size
         );
-        let compressed = zstd::bulk::compress(src, ZSTD_C_LEVEL).context("zstd compress failed")?;
-        ensure!(!compressed.is_empty(), "zstd returned empty output");
-        ensure!(
-            compressed.len() <= dst.len(),
-            "compressed data larger than destination buffer"
-        );
-        dst[..compressed.len()].copy_from_slice(&compressed);
-        Ok(compressed.len())
+        let compressed_len = ZSTD_CCTX.with(|cell| -> Result<usize> {
+            let mut guard = cell.borrow_mut();
+            if guard.is_none() {
+                *guard = Some(
+                    zstd::bulk::Compressor::new(ZSTD_C_LEVEL)
+                        .context("create zstd compression context")?,
+                );
+            }
+            let ctx = guard.as_mut().expect("context initialized above");
+            ctx.compress_to_buffer(src, dst)
+                .context("zstd compress failed")
+        })?;
+        ensure!(compressed_len != 0, "zstd returned empty output");
+        Ok(compressed_len)
     }
 
-    fn decompress(&mut self, src: &[u8], dst: &mut [u8]) -> Result<usize> {
+    fn decompress(&self, src: &[u8], dst: &mut [u8]) -> Result<usize> {
         ensure!(
             dst.len() >= self.src_blk_size,
             "destination buffer too small ({}), expected at least {}",
             dst.len(),
             self.src_blk_size
         );
-        let decompressed =
-            zstd::bulk::decompress(src, dst.len()).context("zstd decompress failed")?;
-        ensure!(!decompressed.is_empty(), "zstd returned empty output");
+        let out_len = ZSTD_DCTX.with(|cell| -> Result<usize> {
+            let mut guard = cell.borrow_mut();
+            if guard.is_none() {
+                *guard = Some(
+                    zstd::bulk::Decompressor::new().context("create zstd decompression context")?,
+                );
+            }
+            let ctx = guard.as_mut().expect("context initialized above");
+            ctx.decompress_to_buffer(src, dst)
+                .context("zstd decompress failed")
+        })?;
+        ensure!(out_len != 0, "zstd decompress returned zero bytes");
         ensure!(
-            decompressed.len() <= dst.len(),
-            "decompressed data larger than destination buffer"
+            out_len <= self.src_blk_size,
+            "zstd decompress returned more than the block size: {out_len}"
         );
-        dst[..decompressed.len()].copy_from_slice(&decompressed);
-        Ok(decompressed.len())
+        Ok(out_len)
     }
 }
 
@@ -756,6 +835,7 @@ pub struct ZFileRO {
     compressor: Box<dyn Compressor>,
     valid_mode: ValidMode,
     data_verify: bool,
+    metrics: ZFileReadMetrics,
 }
 
 impl ZFileRO {
@@ -771,7 +851,7 @@ impl ZFileRO {
         self.valid_mode = ValidMode::CrcOnly;
     }
 
-    pub async fn pread(&mut self, buf: &mut [u8], offset: u64) -> Result<usize> {
+    pub async fn pread(&self, buf: &mut [u8], offset: u64) -> Result<usize> {
         self.pread_generic(&DirectRead, buf, offset).await
     }
 
@@ -780,7 +860,7 @@ impl ZFileRO {
     /// the disk IO submission on its own io_uring thread. The decompression
     /// path is unchanged.
     pub async fn pread_with_ctx<'a>(
-        &'a mut self,
+        &'a self,
         ctx: IoCtx<'a>,
         buf: &mut [u8],
         offset: u64,
@@ -788,16 +868,117 @@ impl ZFileRO {
         self.pread_generic(&CtxRead { ctx }, buf, offset).await
     }
 
+    /// Plan the coalesced read batch starting at block `begin_idx`: return
+    /// the exclusive end index of the longest run of *complete* encoded
+    /// blocks whose combined encoded span fits within
+    /// [`MAX_COALESCED_READ_SIZE`]. The first block always belongs to the
+    /// batch, even when its encoded span alone exceeds the budget, so
+    /// oversized blocks (e.g. 64 KiB incompressible) stay readable. Unlike
+    /// upstream's `min(MAX_READ_SIZE, full span)` C++ read, a batch never
+    /// extends into part of the next block, so no byte is read twice.
+    fn plan_coalesced_batch(&self, begin_idx: usize, end_idx: usize) -> Result<usize> {
+        let batch_begin = self.jump_table.offset_at(begin_idx)?;
+        let mut next = begin_idx + 1;
+        while next < end_idx {
+            let candidate_end = self.jump_table.offset_at(next + 1)?;
+            let span = candidate_end
+                .checked_sub(batch_begin)
+                .context("invalid block offsets")?;
+            if span > MAX_COALESCED_READ_SIZE as u64 {
+                break;
+            }
+            next += 1;
+        }
+        Ok(next)
+    }
+
     /// Body shared by [`Self::pread`] and [`Self::pread_with_ctx`]; the
-    /// per-block reader read is provided by `reader`. Send-ness of the returned
+    /// backing read is provided by `reader`. Send-ness of the returned
     /// future is monomorphised from `R`: [`DirectRead`] yields a `Send`
     /// future for background callers; [`CtxRead`] yields a `!Send`
     /// future for ublk-queue callers.
+    ///
+    /// This is the observation wrapper around [`Self::pread_observed`]: it
+    /// maps the codec label, decides duration sampling, and records the
+    /// exact counters (plus, for sampled preads, the duration histograms)
+    /// exactly once per logical pread — on success and on every error exit
+    /// alike. The block loop itself only ever touches plain stack integers.
     async fn pread_generic<R: FileReader>(
-        &mut self,
+        &self,
         reader: &R,
         buf: &mut [u8],
         offset: u64,
+    ) -> Result<usize> {
+        let sampled = sample_zfile_pread();
+        let (result, observation) = self.pread_observed(reader, buf, offset, sampled).await;
+        self.metrics.record(&observation.stats);
+        if let Some(pread_elapsed) = observation.pread_elapsed {
+            let status = if result.is_ok() {
+                ZFileReadStatus::Ok
+            } else {
+                ZFileReadStatus::Error
+            };
+            self.metrics
+                .record_durations(status, pread_elapsed, observation.decompress_elapsed);
+        }
+        result
+    }
+
+    /// Run one logical pread and collect its [`ZFilePreadObservation`].
+    /// Split from [`Self::pread_generic`] — with an explicit `sampled` flag
+    /// instead of the thread-local sampler — so tests can drive
+    /// success/retry/error flows and assert the aggregated counters without
+    /// installing a metrics recorder.
+    async fn pread_observed<R: FileReader>(
+        &self,
+        reader: &R,
+        buf: &mut [u8],
+        offset: u64,
+        sampled: bool,
+    ) -> (Result<usize>, ZFilePreadObservation) {
+        let pread_start = sampled.then(Instant::now);
+        let mut observation = ZFilePreadObservation::default();
+        let result = self
+            .pread_inner(
+                reader,
+                buf,
+                offset,
+                &mut observation.stats,
+                if sampled {
+                    Some(&mut observation.decompress_elapsed)
+                } else {
+                    None
+                },
+            )
+            .await;
+        if let Ok(n) = &result {
+            // Only bytes actually returned to the caller count as output.
+            observation.stats.output_bytes = *n as u64;
+        }
+        observation.pread_elapsed = pread_start.map(|start| start.elapsed());
+        (result, observation)
+    }
+
+    /// Read implementation behind [`Self::pread_observed`].
+    ///
+    /// Encoded blocks are fetched in coalesced batches planned by
+    /// [`Self::plan_coalesced_batch`]: one merged backing read per batch,
+    /// then each block is CRC-checked, decoded, and copied out
+    /// individually. A block that fails CRC or decompression is evicted at
+    /// its exact encoded range and re-read on its own (at most 3 retries,
+    /// as before); blocks already consumed from the same batch are never
+    /// re-read.
+    ///
+    /// Observability stays on the stack: the loop only increments plain
+    /// `u64` fields of `stats`, and only when `decompress_clock` is `Some`
+    /// (a sampled pread) does it time decodes into that pread-level sum.
+    async fn pread_inner<R: FileReader>(
+        &self,
+        reader: &R,
+        buf: &mut [u8],
+        offset: u64,
+        stats: &mut ZFileReadStats,
+        mut decompress_clock: Option<&mut Duration>,
     ) -> Result<usize> {
         let block_size = usize::try_from(self.ht.opt.block_size).context("invalid block_size")?;
         ensure!(
@@ -817,110 +998,201 @@ impl ZFileRO {
         let begin_idx = (offset / block_size as u64) as usize;
         let end = offset + clamped as u64 - 1;
         let end_idx = (end / block_size as u64) as usize + 1;
+        // The initial request touches exactly these logical blocks; retry
+        // re-reads never re-increment this.
+        stats.blocks = (end_idx - begin_idx) as u64;
 
         let mut written = 0usize;
-        let mut compressed = Vec::new();
-        let mut raw = vec![0u8; block_size];
+        // Merged encoded-block buffer covering one coalesced batch; pooled
+        // per thread, so steady-state preads neither allocate nor re-zero.
+        let mut compressed = PooledBatchBuffer::take();
+        // Single-block buffer backing CRC/decompress retries, allocated
+        // lazily on the first failed block so clean reads never pay for it.
+        let mut retry_block: Option<Vec<u8>> = None;
+        // Scratch for partial first/last blocks only; full-block decodes
+        // write straight into the caller's buffer. Allocated lazily so
+        // block-aligned reads pay no per-request scratch allocation.
+        let mut raw: Option<Vec<u8>> = None;
 
-        for idx in begin_idx..end_idx {
-            let block_begin = self.jump_table.offset_at(idx)?;
-            let block_end = self.jump_table.offset_at(idx + 1)?;
-            let encoded_len_u64 = block_end
-                .checked_sub(block_begin)
-                .context("invalid block offsets")?;
-            let encoded_len = u64_to_usize(encoded_len_u64, "encoded_len")?;
+        let mut batch_begin_idx = begin_idx;
+        while batch_begin_idx < end_idx {
+            let batch_end_idx = self.plan_coalesced_batch(batch_begin_idx, end_idx)?;
+            let batch_begin = self.jump_table.offset_at(batch_begin_idx)?;
+            let batch_end = self.jump_table.offset_at(batch_end_idx)?;
+            let batch_len = u64_to_usize(
+                batch_end
+                    .checked_sub(batch_begin)
+                    .context("invalid block offsets")?,
+                "batch_len",
+            )?;
 
-            let compressed_size = if self.data_verify {
-                encoded_len
-                    .checked_sub(std::mem::size_of::<u32>())
-                    .context("encoded block smaller than crc32 trailer")?
-            } else {
-                encoded_len
-            };
+            compressed.clear();
+            compressed.reserve(batch_len);
+            // SAFETY: `read_exact` fills the whole `batch_len` span before
+            // the buffer is read below; a short read errors out and the
+            // contents are never observed.
+            unsafe { compressed.set_len(batch_len) };
+            // One merged-range exact read per batch: counted at submission,
+            // so a failed read still accounts its submitted bytes.
+            stats.read_batches += 1;
+            stats.encoded_bytes += batch_len as u64;
+            read_exact(reader, self.file.as_ref(), batch_begin, &mut compressed).await?;
 
-            let cp_begin = if idx == begin_idx {
-                (offset % block_size as u64) as usize
-            } else {
-                0
-            };
-            let mut cp_len = if idx == end_idx - 1 {
-                (end % block_size as u64) as usize + 1
-            } else {
-                block_size
-            };
-            cp_len = cp_len.checked_sub(cp_begin).context("invalid cp_len")?;
+            for idx in batch_begin_idx..batch_end_idx {
+                let block_begin = self.jump_table.offset_at(idx)?;
+                let block_end = self.jump_table.offset_at(idx + 1)?;
+                let encoded_len_u64 = block_end
+                    .checked_sub(block_begin)
+                    .context("invalid block offsets")?;
+                let encoded_len = u64_to_usize(encoded_len_u64, "encoded_len")?;
+                let merged_begin = u64_to_usize(
+                    block_begin
+                        .checked_sub(batch_begin)
+                        .context("invalid block offsets")?,
+                    "merged_begin",
+                )?;
 
-            let mut retry = 3;
-            loop {
-                compressed.resize(encoded_len, 0);
-                read_exact(reader, self.file.as_ref(), block_begin, &mut compressed).await?;
-
-                if self.data_verify {
-                    let expected = u32::from_le_bytes(
-                        compressed[compressed_size..compressed_size + 4]
-                            .try_into()
-                            .expect("crc32 size"),
-                    );
-                    let got = crc32c_salt(&compressed[..compressed_size]);
-                    if got != expected {
-                        if retry > 0 {
-                            retry -= 1;
-                            self.file.evict_range(block_begin, encoded_len_u64).await?;
-                            continue;
-                        }
-                        bail!(
-                            "checksum verification failed: idx={idx}, got={got:#010x}, expected={expected:#010x}"
-                        );
-                    }
-                }
-
-                if self.valid_mode == ValidMode::CrcOnly {
-                    break;
-                }
-
-                let decomp = if cp_begin == 0 && cp_len == block_size {
-                    let dst_slice = &mut buf[written..written + cp_len];
-                    let n = self
-                        .compressor
-                        .decompress(&compressed[..compressed_size], dst_slice)?;
-                    if n != cp_len {
-                        Err(anyhow::anyhow!(
-                            "unexpected decompressed size: got {n}, expected {cp_len}"
-                        ))
-                    } else {
-                        Ok(())
-                    }
+                let compressed_size = if self.data_verify {
+                    encoded_len
+                        .checked_sub(std::mem::size_of::<u32>())
+                        .context("encoded block smaller than crc32 trailer")?
                 } else {
-                    let n = self
-                        .compressor
-                        .decompress(&compressed[..compressed_size], &mut raw)?;
-                    let end_pos = cp_begin
-                        .checked_add(cp_len)
-                        .context("copy range overflow")?;
-                    if end_pos > n {
-                        Err(anyhow::anyhow!(
-                            "decompressed range out of bounds: n={n}, begin={cp_begin}, len={cp_len}"
-                        ))
-                    } else {
-                        buf[written..written + cp_len].copy_from_slice(&raw[cp_begin..end_pos]);
-                        Ok(())
-                    }
+                    encoded_len
                 };
 
-                match decomp {
-                    Ok(()) => break,
-                    Err(e) => {
-                        if retry > 0 {
-                            retry -= 1;
-                            self.file.evict_range(block_begin, encoded_len_u64).await?;
-                            continue;
+                let cp_begin = if idx == begin_idx {
+                    (offset % block_size as u64) as usize
+                } else {
+                    0
+                };
+                let mut cp_len = if idx == end_idx - 1 {
+                    (end % block_size as u64) as usize + 1
+                } else {
+                    block_size
+                };
+                cp_len = cp_len.checked_sub(cp_begin).context("invalid cp_len")?;
+
+                let mut retry = 3;
+                // The first attempt decodes from the merged batch buffer;
+                // after a CRC/decompress failure the block is evicted and
+                // re-read on its own into `retry_block`, which backs every
+                // subsequent attempt of this block.
+                let mut from_retry_buffer = false;
+                loop {
+                    if self.data_verify {
+                        let (expected, got) = {
+                            let block: &[u8] = if from_retry_buffer {
+                                retry_block.as_deref().expect("retry buffer allocated")
+                            } else {
+                                &compressed[merged_begin..merged_begin + encoded_len]
+                            };
+                            (
+                                u32::from_le_bytes(
+                                    block[compressed_size..compressed_size + 4]
+                                        .try_into()
+                                        .expect("crc32 size"),
+                                ),
+                                crc32c_salt(&block[..compressed_size]),
+                            )
+                        };
+                        if got != expected {
+                            if retry > 0 {
+                                retry -= 1;
+                                self.file.evict_range(block_begin, encoded_len_u64).await?;
+                                let slot = retry_block.get_or_insert_with(Vec::new);
+                                slot.resize(encoded_len, 0);
+                                // A retry counts only once its exact re-read
+                                // is submitted (a failed evict above records
+                                // nothing).
+                                stats.checksum_retries += 1;
+                                stats.read_batches += 1;
+                                stats.encoded_bytes += encoded_len_u64;
+                                read_exact(reader, self.file.as_ref(), block_begin, slot).await?;
+                                from_retry_buffer = true;
+                                continue;
+                            }
+                            bail!(
+                                "checksum verification failed: idx={idx}, got={got:#010x}, expected={expected:#010x}"
+                            );
                         }
-                        return Err(e);
+                    }
+
+                    if self.valid_mode == ValidMode::CrcOnly {
+                        break;
+                    }
+
+                    // Sampled preads only: time this block's whole decode
+                    // (either copy-out shape) and add it to the pread-level
+                    // sum. Unsampled preads never call `Instant::now()`.
+                    let decode_start = decompress_clock.is_some().then(Instant::now);
+                    let decomp = {
+                        let block: &[u8] = if from_retry_buffer {
+                            retry_block.as_deref().expect("retry buffer allocated")
+                        } else {
+                            &compressed[merged_begin..merged_begin + encoded_len]
+                        };
+                        if cp_begin == 0 && cp_len == block_size {
+                            let dst_slice = &mut buf[written..written + cp_len];
+                            let n = self
+                                .compressor
+                                .decompress(&block[..compressed_size], dst_slice)?;
+                            if n != cp_len {
+                                Err(anyhow::anyhow!(
+                                    "unexpected decompressed size: got {n}, expected {cp_len}"
+                                ))
+                            } else {
+                                Ok(())
+                            }
+                        } else {
+                            let raw = raw.get_or_insert_with(|| vec![0u8; block_size]);
+                            let n = self.compressor.decompress(&block[..compressed_size], raw)?;
+                            let end_pos = cp_begin
+                                .checked_add(cp_len)
+                                .context("copy range overflow")?;
+                            if end_pos > n {
+                                Err(anyhow::anyhow!(
+                                    "decompressed range out of bounds: n={n}, begin={cp_begin}, len={cp_len}"
+                                ))
+                            } else {
+                                buf[written..written + cp_len]
+                                    .copy_from_slice(&raw[cp_begin..end_pos]);
+                                Ok(())
+                            }
+                        }
+                    };
+                    if let (Some(clock), Some(start)) =
+                        (decompress_clock.as_deref_mut(), decode_start)
+                    {
+                        *clock += start.elapsed();
+                    }
+
+                    match decomp {
+                        Ok(()) => break,
+                        Err(e) => {
+                            if retry > 0 {
+                                retry -= 1;
+                                self.file.evict_range(block_begin, encoded_len_u64).await?;
+                                let slot = retry_block.get_or_insert_with(Vec::new);
+                                slot.resize(encoded_len, 0);
+                                // Same accounting rule as the checksum
+                                // branch: count once the re-read is
+                                // submitted.
+                                stats.decompress_retries += 1;
+                                stats.read_batches += 1;
+                                stats.encoded_bytes += encoded_len_u64;
+                                read_exact(reader, self.file.as_ref(), block_begin, slot).await?;
+                                from_retry_buffer = true;
+                                continue;
+                            }
+                            return Err(e);
+                        }
                     }
                 }
+
+                written += cp_len;
             }
 
-            written += cp_len;
+            batch_begin_idx = batch_end_idx;
         }
 
         Ok(written)
@@ -928,18 +1200,16 @@ impl ZFileRO {
 }
 
 #[async_trait]
-impl VirtualFile for tokio::sync::Mutex<ZFileRO> {
+impl VirtualFile for ZFileRO {
     async fn read_at(&self, offset: u64, len: usize) -> Result<Bytes> {
-        let mut ro = self.lock().await;
         let mut buf = vec![0u8; len];
-        let n = ro.pread(&mut buf, offset).await?;
+        let n = self.pread(&mut buf, offset).await?;
         buf.truncate(n);
         Ok(Bytes::from(buf))
     }
 
     async fn read_at_into(&self, offset: u64, dst: &mut [u8]) -> Result<usize> {
-        let mut ro = self.lock().await;
-        ro.pread(dst, offset).await
+        self.pread(dst, offset).await
     }
 
     async fn write_at(&self, _offset: u64, _data: &[u8]) -> Result<usize> {
@@ -947,8 +1217,7 @@ impl VirtualFile for tokio::sync::Mutex<ZFileRO> {
     }
 
     async fn size(&self) -> Result<u64> {
-        let ro = self.lock().await;
-        Ok(ro.original_size())
+        Ok(self.original_size())
     }
 
     fn read_at_with_ctx<'a>(
@@ -958,9 +1227,8 @@ impl VirtualFile for tokio::sync::Mutex<ZFileRO> {
         len: usize,
     ) -> LocalBoxFuture<'a, Result<Bytes>> {
         Box::pin(async move {
-            let mut ro = self.lock().await;
             let mut buf = vec![0u8; len];
-            let n = ro.pread_with_ctx(ctx, &mut buf, offset).await?;
+            let n = self.pread_with_ctx(ctx, &mut buf, offset).await?;
             buf.truncate(n);
             Ok(Bytes::from(buf))
         })
@@ -972,10 +1240,7 @@ impl VirtualFile for tokio::sync::Mutex<ZFileRO> {
         offset: u64,
         dst: &'a mut [u8],
     ) -> LocalBoxFuture<'a, Result<usize>> {
-        Box::pin(async move {
-            let mut ro = self.lock().await;
-            ro.pread_with_ctx(ctx, dst, offset).await
-        })
+        Box::pin(async move { self.pread_with_ctx(ctx, dst, offset).await })
     }
 }
 
@@ -1082,6 +1347,12 @@ pub async fn zfile_open_ro(file: Arc<dyn VirtualFile>, verify: bool) -> Result<Z
     let args = CompressArgs::new(ht.opt);
     let compressor = create_compressor(&args)?;
     let data_verify = ht.opt.verify != 0;
+    // `create_compressor` accepts only LZ4 and ZSTD, so an open reader
+    // always maps to one of the two `codec` label values.
+    let codec = match ht.opt.algo {
+        CompressOptions::LZ4 => ZFileCodec::Lz4,
+        _ => ZFileCodec::Zstd,
+    };
 
     Ok(ZFileRO {
         file,
@@ -1090,6 +1361,7 @@ pub async fn zfile_open_ro(file: Arc<dyn VirtualFile>, verify: bool) -> Result<Z
         compressor,
         valid_mode: ValidMode::Normal,
         data_verify,
+        metrics: ZFileReadMetrics::new(codec),
     })
 }
 
@@ -1098,7 +1370,7 @@ pub async fn zfile_open_ro_vfile(
     verify: bool,
 ) -> Result<Arc<dyn VirtualFile>> {
     let ro = zfile_open_ro(file, verify).await?;
-    Ok(Arc::new(tokio::sync::Mutex::new(ro)))
+    Ok(Arc::new(ro))
 }
 
 async fn write_header_trailer(
@@ -1526,7 +1798,7 @@ pub async fn zfile_compress(
 }
 
 pub async fn zfile_decompress(src: Arc<dyn VirtualFile>, dst: Arc<dyn VirtualFile>) -> Result<()> {
-    let mut zf = zfile_open_ro(src, true).await?;
+    let zf = zfile_open_ro(src, true).await?;
     let raw_data_size = zf.original_size();
     let block_size = zf.options().block_size as usize;
 
@@ -1635,7 +1907,7 @@ mod tests {
         data
     }
 
-    async fn seqread_compare(src: &[u8], ro: &mut ZFileRO) {
+    async fn seqread_compare(src: &[u8], ro: &ZFileRO) {
         let mut buf = vec![0u8; 16 * 1024];
         let mut offset = 0usize;
         while offset < src.len() {
@@ -1654,7 +1926,7 @@ mod tests {
         }
     }
 
-    async fn randread_compare(src: &[u8], ro: &mut ZFileRO, seed: u64) {
+    async fn randread_compare(src: &[u8], ro: &ZFileRO, seed: u64) {
         if src.len() < 512 {
             return;
         }
@@ -1764,16 +2036,12 @@ mod tests {
                         "dst should be zfile for {case_tag}"
                     );
 
-                    let mut ro = zfile_open_ro(dst.clone(), enable_crc != 0)
+                    let ro = zfile_open_ro(dst.clone(), enable_crc != 0)
                         .await
                         .unwrap_or_else(|e| panic!("open ro failed for {case_tag}: {e}"));
-                    seqread_compare(&data, &mut ro).await;
-                    randread_compare(
-                        &data,
-                        &mut ro,
-                        0x77aa_5511 + block_size as u64 + algo as u64,
-                    )
-                    .await;
+                    seqread_compare(&data, &ro).await;
+                    randread_compare(&data, &ro, 0x77aa_5511 + block_size as u64 + algo as u64)
+                        .await;
 
                     zfile_decompress(dst.clone(), dec.clone())
                         .await
@@ -1860,11 +2128,11 @@ mod tests {
         let bytes_sp = read_all(&zfile_sp).await;
         assert_eq!(bytes_mp, bytes_sp, "builder output byte mismatch");
 
-        let mut ro = zfile_open_ro(zfile_mp.clone(), true)
+        let ro = zfile_open_ro(zfile_mp.clone(), true)
             .await
             .expect("open mp zfile");
-        seqread_compare(&data, &mut ro).await;
-        randread_compare(&data, &mut ro, 0x9abc_dd01).await;
+        seqread_compare(&data, &ro).await;
+        randread_compare(&data, &ro, 0x9abc_dd01).await;
     }
 
     #[tokio::test]
@@ -1891,11 +2159,11 @@ mod tests {
             .await
             .expect("corrupt trailer");
 
-        let mut ro = zfile_open_ro(dst.clone(), true)
+        let ro = zfile_open_ro(dst.clone(), true)
             .await
             .expect("open zfile by overwritten header");
-        seqread_compare(&data, &mut ro).await;
-        randread_compare(&data, &mut ro, 0x5566_aabb).await;
+        seqread_compare(&data, &ro).await;
+        randread_compare(&data, &ro, 0x5566_aabb).await;
     }
 
     #[tokio::test]
@@ -1910,146 +2178,666 @@ mod tests {
             rng.fill_bytes(&mut buf);
             let direct = crc32c(&buf);
 
+            // Chaining the raw CRC state across an arbitrary split must
+            // reproduce the one-shot value; this pins the same
+            // complement-in/complement-out identity that crc32c_salt()
+            // relies on for its seeded initial state.
             let split = (rng.next_u32() as usize) % buf.len();
-            let mut digest = CRC32C_RAW.digest();
-            digest.update(&buf[..split]);
-            digest.update(&buf[split..]);
-            let incremental = digest.finalize();
+            let first = crc32c(&buf[..split]);
+            let incremental = !::crc32c::crc32c_append(!first, &buf[split..]);
 
             assert_eq!(direct, incremental);
         }
     }
 
-    #[tokio::test]
-    async fn test_compress_block_sizes() {
-        let data = sample_data(128 * 1024);
-        for block_size in [4096, 8192, 16384, 32768, 65536] {
-            let src = new_local_vfile().await;
-            let dst = new_local_vfile().await;
-            write_all(&src, &data).await;
+    // -----------------------------------------------------------------------
+    // CountingMemoryFile — deterministic read-path probe for zfile unit
+    // tests: backing call count, requested bytes, and in-flight reads, with
+    // a gate that can park reads. Test-module local on purpose.
+    // -----------------------------------------------------------------------
 
-            let args = CompressArgs {
-                opt: CompressOptions::new(CompressOptions::LZ4, block_size, 1),
-                overwrite_header: false,
-                workers: 1,
-            };
-            zfile_compress(src, dst.clone(), &args).await.unwrap();
-            let mut ro = zfile_open_ro(dst, false).await.unwrap();
-            seqread_compare(&data, &mut ro).await;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use tokio::sync::watch;
+
+    /// Read-path counters shared by the probe files below. Atomics keep
+    /// `reset` usable through a shared reference while reads are in flight.
+    #[derive(Debug, Default)]
+    struct ProbeCounters {
+        read_calls: AtomicU64,
+        requested_bytes: AtomicU64,
+        in_flight: AtomicU64,
+    }
+
+    impl ProbeCounters {
+        fn reset(&self) {
+            self.read_calls.store(0, Ordering::SeqCst);
+            self.requested_bytes.store(0, Ordering::SeqCst);
+            self.in_flight.store(0, Ordering::SeqCst);
+        }
+
+        fn read_calls(&self) -> u64 {
+            self.read_calls.load(Ordering::SeqCst)
+        }
+
+        fn requested_bytes(&self) -> u64 {
+            self.requested_bytes.load(Ordering::SeqCst)
+        }
+
+        fn in_flight(&self) -> u64 {
+            self.in_flight.load(Ordering::SeqCst)
+        }
+    }
+
+    /// RAII guard that counts one backing read and keeps `in_flight`
+    /// balanced across awaits and early returns.
+    struct InFlightGuard<'a> {
+        counters: &'a ProbeCounters,
+    }
+
+    impl<'a> InFlightGuard<'a> {
+        fn enter(counters: &'a ProbeCounters, requested: u64) -> Self {
+            counters.read_calls.fetch_add(1, Ordering::SeqCst);
+            counters
+                .requested_bytes
+                .fetch_add(requested, Ordering::SeqCst);
+            counters.in_flight.fetch_add(1, Ordering::SeqCst);
+            Self { counters }
+        }
+    }
+
+    impl Drop for InFlightGuard<'_> {
+        fn drop(&mut self) {
+            self.counters.in_flight.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    /// In-memory [`VirtualFile`][crate::io::virtual_file::VirtualFile] that
+    /// counts reads and parks them while its gate is closed. Writes grow
+    /// the buffer and never consult the gate.
+    struct CountingMemoryFile {
+        data: Mutex<Vec<u8>>,
+        counters: ProbeCounters,
+        gate: watch::Sender<bool>,
+    }
+
+    impl CountingMemoryFile {
+        /// New file with the gate open: reads complete until `set_open`.
+        fn new(data: Vec<u8>) -> Self {
+            let (gate, _rx) = watch::channel(true);
+            Self {
+                data: Mutex::new(data),
+                counters: ProbeCounters::default(),
+                gate,
+            }
+        }
+
+        fn set_open(&self, open: bool) {
+            self.gate.send_replace(open);
+        }
+
+        async fn wait_open(&self) {
+            let mut rx = self.gate.subscribe();
+            // Returns immediately once the gate holds `true`; no missed
+            // wakeups because `wait_for` re-checks the current value.
+            let _ = rx
+                .wait_for(|open| *open)
+                .await
+                .expect("gate sender alive while file alive");
+        }
+
+        /// Wait until `expected` reads are parked inside the gate.
+        async fn wait_for_in_flight(&self, expected: u64) {
+            for _ in 0..1000 {
+                if self.counters.in_flight() >= expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            panic!("timed out waiting for in_flight >= {expected}");
+        }
+
+        fn read_vec(&self, offset: u64, len: usize) -> Vec<u8> {
+            let data = self.data.lock().expect("data mutex poisoned");
+            if len == 0 || offset >= data.len() as u64 {
+                return Vec::new();
+            }
+            let end = offset.saturating_add(len as u64).min(data.len() as u64) as usize;
+            data[offset as usize..end].to_vec()
+        }
+
+        fn read_into(&self, offset: u64, dst: &mut [u8]) -> usize {
+            let bytes = self.read_vec(offset, dst.len());
+            dst[..bytes.len()].copy_from_slice(&bytes);
+            bytes.len()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl VirtualFile for CountingMemoryFile {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<Bytes> {
+            let _guard = InFlightGuard::enter(&self.counters, len as u64);
+            self.wait_open().await;
+            Ok(Bytes::from(self.read_vec(offset, len)))
+        }
+
+        async fn read_at_into(&self, offset: u64, dst: &mut [u8]) -> Result<usize> {
+            let _guard = InFlightGuard::enter(&self.counters, dst.len() as u64);
+            self.wait_open().await;
+            Ok(self.read_into(offset, dst))
+        }
+
+        async fn write_at(&self, offset: u64, data: &[u8]) -> Result<usize> {
+            let mut inner = self.data.lock().expect("data mutex poisoned");
+            let end = usize::try_from(offset)
+                .context("write offset overflow")?
+                .checked_add(data.len())
+                .context("write offset overflow")?;
+            if end > inner.len() {
+                inner.resize(end, 0);
+            }
+            inner[offset as usize..end].copy_from_slice(data);
+            Ok(data.len())
+        }
+
+        async fn size(&self) -> Result<u64> {
+            Ok(self.data.lock().expect("data mutex poisoned").len() as u64)
         }
     }
 
     #[tokio::test]
-    async fn test_zstd_compression() {
+    async fn concurrent_reads_reach_backing() {
+        // Two reads on different blocks through ONE shared zfile handle must
+        // be able to overlap in the backing file: while the first read is
+        // parked inside the gated backing read, the second read must still
+        // reach the backing (`in_flight == 2`). A whole-request lock around
+        // the reader serializes the two, so `wait_for_in_flight(2)` times
+        // out and the test fails.
+        let data = sample_data(16 * 1024);
+        let block = 4096usize;
+
+        let src: Arc<dyn VirtualFile> = Arc::new(CountingMemoryFile::new(data.clone()));
+        // The gate starts open, so the fixture compress/open reads complete;
+        // reads only park once the gate is closed.
+        let backing = Arc::new(CountingMemoryFile::new(Vec::new()));
+        let args = CompressArgs {
+            opt: CompressOptions::new(CompressOptions::LZ4, block as u32, 1),
+            overwrite_header: false,
+            workers: 1,
+        };
+        zfile_compress(src, backing.clone(), &args)
+            .await
+            .expect("compress fixture");
+        let vf = zfile_open_ro_vfile(backing.clone(), false)
+            .await
+            .expect("open shared zfile reader");
+
+        // Close the gate and reset the probe so only the reads below count.
+        backing.set_open(false);
+        backing.counters.reset();
+
+        let spawn_read = |offset: u64, expected: &[u8]| {
+            let vf = vf.clone();
+            let expected = expected.to_vec();
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; expected.len()];
+                let n = vf
+                    .read_at_into(offset, &mut buf)
+                    .await
+                    .expect("blocked read through shared handle");
+                assert_eq!(n, expected.len());
+                assert_eq!(buf, expected);
+            })
+        };
+
+        let first = spawn_read(0, &data[..block]);
+        // In both implementations the first read reaches the backing and
+        // parks inside the closed gate.
+        backing.wait_for_in_flight(1).await;
+
+        let second = spawn_read(block as u64, &data[block..2 * block]);
+        // The second read must reach the backing while the first is parked.
+        backing.wait_for_in_flight(2).await;
+
+        backing.set_open(true);
+        first.await.expect("join first read");
+        second.await.expect("join second read");
+    }
+
+    // -----------------------------------------------------------------------
+    // Coalesced-read fixtures and contract tests. Batch behavior is pinned
+    // through the fixture's own jump table: requested bytes must equal the
+    // exact encoded span of the touched blocks (no partial-next-block
+    // overread).
+    // -----------------------------------------------------------------------
+
+    /// Compress `data` into a fresh [`CountingMemoryFile`], returning the
+    /// backing file with its probe counters still running.
+    async fn build_counting_zfile(
+        data: &[u8],
+        algo: u8,
+        block_size: u32,
+        verify: u8,
+    ) -> Arc<CountingMemoryFile> {
+        let src: Arc<dyn VirtualFile> = Arc::new(CountingMemoryFile::new(data.to_vec()));
+        let backing = Arc::new(CountingMemoryFile::new(Vec::new()));
+        let args = CompressArgs {
+            opt: CompressOptions::new(algo, block_size, verify),
+            overwrite_header: false,
+            workers: 1,
+        };
+        zfile_compress(src, backing.clone(), &args)
+            .await
+            .expect("compress counting fixture");
+        backing
+    }
+
+    /// Compress `data` into a [`CountingMemoryFile`], open it read-only, and
+    /// reset the probe so only reads after this call are counted.
+    async fn open_counting_zfile(
+        data: &[u8],
+        algo: u8,
+        block_size: u32,
+        verify: u8,
+    ) -> (Arc<CountingMemoryFile>, ZFileRO) {
+        let backing = build_counting_zfile(data, algo, block_size, verify).await;
+        let ro = zfile_open_ro(backing.clone(), verify != 0)
+            .await
+            .expect("open counting zfile");
+        backing.counters.reset();
+        (backing, ro)
+    }
+
+    /// Read `len` bytes at `offset` and assert content (with EOF clamping)
+    /// plus exact encoded-span accounting straight from the jump table:
+    /// requested bytes must cover exactly the touched blocks.
+    async fn check_coalesced_read(
+        backing: &CountingMemoryFile,
+        ro: &ZFileRO,
+        data: &[u8],
+        block_size: usize,
+        offset: u64,
+        len: usize,
+    ) {
+        backing.counters.reset();
+        let mut buf = vec![0u8; len];
+        let expect_len = min(len as u64, data.len() as u64 - offset) as usize;
+        let n = ro.pread(&mut buf, offset).await.expect("check pread");
+        assert_eq!(n, expect_len, "offset={offset} len={len}");
+        assert_eq!(
+            &buf[..n],
+            &data[offset as usize..offset as usize + n],
+            "offset={offset} len={len}"
+        );
+        if n == 0 {
+            assert_eq!(
+                backing.counters.read_calls(),
+                0,
+                "offset={offset} len={len}: empty read must not touch the backing"
+            );
+            return;
+        }
+        let begin_idx = (offset / block_size as u64) as usize;
+        let end_idx = ((offset + n as u64 - 1) / block_size as u64) as usize + 1;
+        let span = ro.jump_table.offset_at(end_idx).expect("end offset")
+            - ro.jump_table.offset_at(begin_idx).expect("begin offset");
+        assert_eq!(
+            backing.counters.requested_bytes(),
+            span,
+            "offset={offset} len={len}: exact encoded span, no overread"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Coalesced-read error and boundary regression tests.
+    // -----------------------------------------------------------------------
+
+    /// Read wrapper that corrupts the `len` bytes starting at absolute
+    /// offset `offset` (XOR 0xFF) on the first read intersecting that
+    /// window after being armed, then serves clean bytes. Drives the
+    /// evict-and-retry path: the merged batch read sees bad data, the
+    /// single-block retry sees good data. Reads land on the inner
+    /// [`CountingMemoryFile`] probe.
+    struct CorruptOnceFile {
+        inner: Arc<CountingMemoryFile>,
+        offset: u64,
+        len: usize,
+        armed: AtomicBool,
+        fired: AtomicBool,
+    }
+
+    impl CorruptOnceFile {
+        fn maybe_corrupt(&self, offset: u64, dst: &mut [u8]) {
+            if !self.armed.load(Ordering::SeqCst) || self.fired.load(Ordering::SeqCst) {
+                return;
+            }
+            let req_end = offset + dst.len() as u64;
+            let win_end = self.offset + self.len as u64;
+            let begin = self.offset.max(offset);
+            let end = win_end.min(req_end);
+            if begin >= end {
+                return;
+            }
+            self.fired.store(true, Ordering::SeqCst);
+            let lo = (begin - offset) as usize;
+            let hi = (end - offset) as usize;
+            for b in &mut dst[lo..hi] {
+                *b ^= 0xFF;
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl VirtualFile for CorruptOnceFile {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<Bytes> {
+            let mut bytes = self.inner.read_at(offset, len).await?.to_vec();
+            self.maybe_corrupt(offset, &mut bytes);
+            Ok(Bytes::from(bytes))
+        }
+
+        async fn read_at_into(&self, offset: u64, dst: &mut [u8]) -> Result<usize> {
+            let n = self.inner.read_at_into(offset, dst).await?;
+            self.maybe_corrupt(offset, &mut dst[..n]);
+            Ok(n)
+        }
+
+        async fn write_at(&self, offset: u64, data: &[u8]) -> Result<usize> {
+            self.inner.write_at(offset, data).await
+        }
+
+        async fn size(&self) -> Result<u64> {
+            self.inner.size().await
+        }
+    }
+
+    /// Compressor wrapper injecting one soft decode failure: the first
+    /// decode of the victim block's compressed bytes reports a short
+    /// output length (`Ok(n - 1)`) instead of the real result, driving
+    /// zfile's size-mismatch retry path. All other calls delegate.
+    struct FailOnceCompressor {
+        inner: Box<dyn Compressor>,
+        fail_src: Vec<u8>,
+        fired: AtomicBool,
+    }
+
+    impl Compressor for FailOnceCompressor {
+        fn max_dst_size(&self) -> usize {
+            self.inner.max_dst_size()
+        }
+
+        fn src_block_size(&self) -> usize {
+            self.inner.src_block_size()
+        }
+
+        fn compress(&mut self, src: &[u8], dst: &mut [u8]) -> Result<usize> {
+            self.inner.compress(src, dst)
+        }
+
+        fn decompress(&self, src: &[u8], dst: &mut [u8]) -> Result<usize> {
+            let n = self.inner.decompress(src, dst)?;
+            if !self.fired.load(Ordering::SeqCst) && src == self.fail_src.as_slice() {
+                self.fired.store(true, Ordering::SeqCst);
+                return Ok(n - 1);
+            }
+            Ok(n)
+        }
+    }
+
+    /// EOF boundary cases: a read running past the end clamps to the
+    /// partial last block, and a read exactly at EOF returns zero bytes
+    /// without touching the backing. Content, geometry, and coalescing
+    /// coverage live in the compression matrix and observation tests.
+    #[tokio::test]
+    async fn coalesced_read_eof_boundaries() {
+        // Non-block-multiple size so the last block is partial.
+        let data = sample_data(96 * 1024 + 1234);
+        let (backing, ro) = open_counting_zfile(&data, CompressOptions::LZ4, 4096, 1).await;
+
+        // EOF clamp: the read runs past the end of the file.
+        check_coalesced_read(&backing, &ro, &data, 4096, (data.len() - 100) as u64, 4096).await;
+        // At EOF: zero bytes, no backing reads.
+        check_coalesced_read(&backing, &ro, &data, 4096, data.len() as u64, 4096).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Observation-layer tests: drive real pread flows through
+    // `pread_observed` and assert the aggregated counters/durations. No
+    // metrics recorder is installed anywhere here, so these stay pure.
+    // -----------------------------------------------------------------------
+
+    /// A single-block retry must replay exactly one block's encoded span on
+    /// top of the clean baseline, attributed to exactly one retry reason.
+    fn assert_retry_stats(
+        baseline: &ZFileReadStats,
+        retry: &ZFileReadStats,
+        victim_size: u64,
+        checksum_retries: u64,
+        decompress_retries: u64,
+    ) {
+        assert_eq!(retry.output_bytes, baseline.output_bytes);
+        assert_eq!(retry.blocks, baseline.blocks);
+        assert_eq!(retry.read_batches, baseline.read_batches + 1);
+        assert_eq!(
+            retry.encoded_bytes,
+            baseline.encoded_bytes + victim_size,
+            "retry re-reads exactly the failed block"
+        );
+        assert_eq!(retry.checksum_retries, checksum_retries);
+        assert_eq!(retry.decompress_retries, decompress_retries);
+    }
+
+    /// Clean read: counters match the request geometry, retries stay zero,
+    /// and only a sampled pread carries durations.
+    #[tokio::test]
+    async fn zfile_observation_success_flow_counts_exact_work() {
+        let data = sample_data(128 * 1024);
+        let block_size = 4096usize;
+        let read_len = 64 * 1024;
+
+        let (_backing, ro) =
+            open_counting_zfile(&data, CompressOptions::LZ4, block_size as u32, 1).await;
+        let span = ro
+            .jump_table
+            .offset_at(read_len / block_size)
+            .expect("end offset")
+            - ro.jump_table.offset_at(0).expect("begin offset");
+
+        // Sampled: durations are collected alongside the exact counters.
+        let mut buf = vec![0u8; read_len];
+        let (result, sampled) = ro.pread_observed(&DirectRead, &mut buf, 0, true).await;
+        assert_eq!(result.expect("sampled pread"), read_len);
+        assert_eq!(buf, &data[..read_len]);
+        assert_eq!(sampled.stats.output_bytes, read_len as u64);
+        assert_eq!(sampled.stats.encoded_bytes, span);
+        assert_eq!(sampled.stats.blocks, (read_len / block_size) as u64);
+        assert!(
+            sampled.stats.read_batches < sampled.stats.blocks,
+            "batched reads must coalesce: {} batches for {} blocks",
+            sampled.stats.read_batches,
+            sampled.stats.blocks
+        );
+        assert_eq!(sampled.stats.checksum_retries, 0);
+        assert_eq!(sampled.stats.decompress_retries, 0);
+        let pread_elapsed = sampled.pread_elapsed.expect("sampled pread is timed");
+        assert!(
+            sampled.decompress_elapsed <= pread_elapsed,
+            "decode time is a component of the pread wall time"
+        );
+
+        // Unsampled: identical counters, but no durations at all.
+        let (result, unsampled) = ro.pread_observed(&DirectRead, &mut buf, 0, false).await;
+        result.expect("unsampled pread");
+        assert_eq!(unsampled.stats, sampled.stats);
+        assert!(unsampled.pread_elapsed.is_none());
+        assert_eq!(unsampled.decompress_elapsed, Duration::ZERO);
+    }
+
+    /// One transient CRC failure mid-batch: exactly one checksum retry, one
+    /// extra single-block exact read, output still fully returned.
+    #[tokio::test]
+    async fn zfile_observation_crc_retry_flow_counts_one_retry() {
+        let data = sample_data(128 * 1024);
+        let block_size = 4096usize;
+        let read_len = 64 * 1024;
+        // Block 5 always sits mid-batch for a 64 KiB budget over 4 KiB
+        // blocks.
+        let victim = 5usize;
+
+        let inner = build_counting_zfile(&data, CompressOptions::LZ4, block_size as u32, 1).await;
+        let probe = zfile_open_ro(inner.clone(), true)
+            .await
+            .expect("probe open");
+        let victim_begin = probe
+            .jump_table
+            .offset_at(victim)
+            .expect("victim block offset");
+        let victim_end = probe
+            .jump_table
+            .offset_at(victim + 1)
+            .expect("victim block offset");
+        drop(probe);
+
+        let trap = Arc::new(CorruptOnceFile {
+            inner: inner.clone(),
+            offset: victim_begin + 8,
+            len: 16,
+            armed: AtomicBool::new(false),
+            fired: AtomicBool::new(false),
+        });
+        let ro = zfile_open_ro(trap.clone(), true)
+            .await
+            .expect("open trapped zfile");
+
+        // Clean baseline over the same range, trap still disarmed.
+        let mut buf = vec![0u8; read_len];
+        let (result, baseline) = ro.pread_observed(&DirectRead, &mut buf, 0, true).await;
+        result.expect("clean baseline pread");
+
+        trap.armed.store(true, Ordering::SeqCst);
+        let (result, retry) = ro.pread_observed(&DirectRead, &mut buf, 0, true).await;
+        assert_eq!(result.expect("pread with corrupt block retries"), read_len);
+        assert_eq!(buf, &data[..read_len]);
+        assert!(trap.fired.load(Ordering::SeqCst), "trap must have fired");
+
+        assert_retry_stats(
+            &baseline.stats,
+            &retry.stats,
+            victim_end - victim_begin,
+            1,
+            0,
+        );
+    }
+
+    /// One transient decode failure mid-batch: exactly one decompress
+    /// retry, checksum retries stay zero.
+    #[tokio::test]
+    async fn zfile_observation_decompress_retry_flow_counts_one_retry() {
+        let data = sample_data(128 * 1024);
+        let block_size = 4096usize;
+        let read_len = 64 * 1024;
+        let victim = 5usize;
+
+        let inner = build_counting_zfile(&data, CompressOptions::LZ4, block_size as u32, 1).await;
+        let mut ro = zfile_open_ro(inner.clone(), true).await.expect("open");
+        let victim_begin = ro
+            .jump_table
+            .offset_at(victim)
+            .expect("victim block offset");
+        let victim_end = ro
+            .jump_table
+            .offset_at(victim + 1)
+            .expect("victim block offset");
+        // verify=1: the codec only sees the payload, not the CRC trailer.
+        let compressed_size = (victim_end - victim_begin) as usize - std::mem::size_of::<u32>();
+        let fail_src = inner.read_vec(victim_begin, compressed_size);
+
+        // Clean baseline over the same range, with the real compressor.
+        let mut buf = vec![0u8; read_len];
+        let (result, baseline) = ro.pread_observed(&DirectRead, &mut buf, 0, true).await;
+        result.expect("clean baseline pread");
+
+        // Swap in the fault-injecting compressor around the real one.
+        let placeholder = create_compressor(&CompressArgs::new(CompressOptions::new(
+            CompressOptions::LZ4,
+            block_size as u32,
+            1,
+        )))
+        .expect("placeholder compressor");
+        let real = std::mem::replace(&mut ro.compressor, placeholder);
+        ro.compressor = Box::new(FailOnceCompressor {
+            inner: real,
+            fail_src,
+            fired: AtomicBool::new(false),
+        });
+
+        let (result, retry) = ro.pread_observed(&DirectRead, &mut buf, 0, true).await;
+        assert_eq!(
+            result.expect("pread with soft decode failure retries"),
+            read_len
+        );
+        assert_eq!(buf, &data[..read_len]);
+
+        assert_retry_stats(
+            &baseline.stats,
+            &retry.stats,
+            victim_end - victim_begin,
+            0,
+            1,
+        );
+    }
+
+    /// Persistent corruption: the pread fails after 3 retries. The error
+    /// exit records zero output bytes but all submitted work — the initial
+    /// merged read plus the three single-block re-reads.
+    #[tokio::test]
+    async fn zfile_observation_error_exit_flow_records_partial_work() {
         let data = sample_data(64 * 1024);
-        let src = new_local_vfile().await;
-        let dst = new_local_vfile().await;
-        write_all(&src, &data).await;
+        let block_size = 4096usize;
+        let victim = 1usize;
 
-        let args = CompressArgs {
-            opt: CompressOptions::new(CompressOptions::ZSTD, 4096, 1),
-            overwrite_header: false,
-            workers: 1,
-        };
-        zfile_compress(src, dst.clone(), &args).await.unwrap();
-        let mut ro = zfile_open_ro(dst, false).await.unwrap();
-        seqread_compare(&data, &mut ro).await;
-    }
+        let (backing, ro) =
+            open_counting_zfile(&data, CompressOptions::LZ4, block_size as u32, 1).await;
+        let victim_begin = ro
+            .jump_table
+            .offset_at(victim)
+            .expect("victim block offset");
+        let victim_end = ro
+            .jump_table
+            .offset_at(victim + 1)
+            .expect("victim block offset");
+        let victim_size = victim_end - victim_begin;
 
-    #[tokio::test]
-    async fn test_single_block() {
-        let data = sample_data(2048);
-        let src = new_local_vfile().await;
-        let dst = new_local_vfile().await;
-        write_all(&src, &data).await;
+        // Persistently corrupt payload bytes inside the victim block.
+        {
+            let mut guard = backing.data.lock().expect("data mutex poisoned");
+            for b in &mut guard[(victim_begin + 16) as usize..(victim_begin + 32) as usize] {
+                *b ^= 0xFF;
+            }
+        }
 
-        let args = CompressArgs {
-            opt: CompressOptions::new(CompressOptions::LZ4, 4096, 1),
-            overwrite_header: false,
-            workers: 1,
-        };
-        zfile_compress(src, dst.clone(), &args).await.unwrap();
-        let mut ro = zfile_open_ro(dst, false).await.unwrap();
-        seqread_compare(&data, &mut ro).await;
-    }
+        let mut buf = vec![0u8; block_size];
+        let (result, obs) = ro
+            .pread_observed(&DirectRead, &mut buf, (victim * block_size) as u64, true)
+            .await;
+        let err = result.expect_err("persistently corrupt block must fail");
+        assert!(
+            err.to_string().contains("checksum verification failed"),
+            "unexpected error: {err}"
+        );
 
-    #[tokio::test]
-    async fn test_is_zfile_detection() {
-        let vf = new_local_vfile().await;
-        let data = vec![0u8; 1024];
-        write_all(&vf, &data).await;
-        let result = is_zfile(vf).await.unwrap();
-        assert_eq!(result, 0);
-    }
-
-    #[tokio::test]
-    async fn test_zfile_open_ro_vfile() {
-        let data = sample_data(8192);
-        let src = new_local_vfile().await;
-        let dst = new_local_vfile().await;
-        write_all(&src, &data).await;
-        let args = CompressArgs {
-            opt: CompressOptions::new(CompressOptions::LZ4, 4096, 1),
-            overwrite_header: false,
-            workers: 1,
-        };
-        zfile_compress(src, dst.clone(), &args).await.unwrap();
-        let _ro = zfile_open_ro_vfile(dst, false).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_zfile_decompress() {
-        let data = sample_data(8192);
-        let src = new_local_vfile().await;
-        let compressed = new_local_vfile().await;
-        let decompressed = new_local_vfile().await;
-        write_all(&src, &data).await;
-        let args = CompressArgs {
-            opt: CompressOptions::new(CompressOptions::LZ4, 4096, 1),
-            overwrite_header: false,
-            workers: 1,
-        };
-        zfile_compress(src, compressed.clone(), &args)
-            .await
-            .unwrap();
-        zfile_decompress(compressed, decompressed.clone())
-            .await
-            .unwrap();
-        let size = decompressed.size().await.unwrap();
-        assert_eq!(size, 8192);
-    }
-
-    #[tokio::test]
-    async fn test_zfile_builder_write() {
-        let dst = new_local_vfile().await;
-        let args = CompressArgs {
-            opt: CompressOptions::new(CompressOptions::LZ4, 4096, 1),
-            overwrite_header: false,
-            workers: 1,
-        };
-        let mut builder = new_zfile_builder(dst.clone(), &args).await.unwrap();
-        let data = vec![0xAB; 2048];
-        builder.write(&data).await.unwrap();
-        builder.finish().await.unwrap();
-        let _file = builder.close().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_zfile_pread() {
-        let data = sample_data(8192);
-        let src = new_local_vfile().await;
-        let dst = new_local_vfile().await;
-        write_all(&src, &data).await;
-        let args = CompressArgs {
-            opt: CompressOptions::new(CompressOptions::LZ4, 4096, 1),
-            overwrite_header: false,
-            workers: 1,
-        };
-        zfile_compress(src, dst.clone(), &args).await.unwrap();
-        let mut ro = zfile_open_ro(dst, false).await.unwrap();
-        let mut buf = vec![0u8; 1024];
-        let n = ro.pread(&mut buf, 1024).await.unwrap();
-        assert_eq!(n, 1024);
-        assert_eq!(buf, &data[1024..2048]);
+        assert_eq!(obs.stats.output_bytes, 0, "error exit returns no bytes");
+        assert_eq!(obs.stats.blocks, 1);
+        assert_eq!(obs.stats.checksum_retries, 3);
+        assert_eq!(obs.stats.decompress_retries, 0);
+        assert_eq!(
+            obs.stats.read_batches, 4,
+            "initial merged read plus three single-block re-reads"
+        );
+        assert_eq!(obs.stats.encoded_bytes, 4 * victim_size);
+        assert!(
+            obs.pread_elapsed.is_some(),
+            "sampled error pread is still timed"
+        );
     }
 }

--- a/storage/overlaybd/src/metrics.rs
+++ b/storage/overlaybd/src/metrics.rs
@@ -1,5 +1,6 @@
-use std::{error::Error, time::Duration};
+use std::{error::Error, sync::OnceLock, time::Duration};
 
+use ::metrics::{Counter, Histogram};
 use anyhow::Result;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -209,9 +210,210 @@ fn classify_remote_read_error_from_dependencies(
     None
 }
 
+// ---------------------------------------------------------------------------
+// ZFile read-path metrics. Exact counters are aggregated by the caller
+// (`compression::zfile`) across one logical `pread` and recorded here once
+// per pread (never per block or per retry). Duration histograms cover only
+// the preads picked by the 1-in-1024 per-thread sampler, so their `_count`
+// is a SAMPLE COUNT, not an operation count — compute rates from the exact
+// counters instead. Metric handles are registered lazily on first use and
+// cached in `ZFileReadMetrics`, so the hot path never rebuilds a Key or
+// touches the recorder registry.
+// ---------------------------------------------------------------------------
+
+/// ZFile compression codec. This is the complete `codec` label value set
+/// for every ZFile metric: keep cardinality at exactly these two values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ZFileCodec {
+    Lz4,
+    Zstd,
+}
+
+impl ZFileCodec {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Lz4 => "lz4",
+            Self::Zstd => "zstd",
+        }
+    }
+}
+
+/// Outcome of one logical ZFile `pread`; the complete `status` label value
+/// set of `agentenv_overlaybd_zfile_pread_duration_seconds`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ZFileReadStatus {
+    Ok,
+    Error,
+}
+
+impl ZFileReadStatus {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// Exact counters accumulated in plain stack variables across one logical
+/// ZFile `pread` by the read loop, then handed to [`ZFileReadMetrics::record`]
+/// once. A field left at zero records nothing, so error exits and EOF
+/// reads never create empty series.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ZFileReadStats {
+    /// Bytes returned to the caller; set only on success.
+    pub output_bytes: u64,
+    /// Encoded bytes submitted to exact reads, including retry re-reads.
+    pub encoded_bytes: u64,
+    /// Logical zfile blocks touched by the initial request; retries do not
+    /// re-increment this.
+    pub blocks: u64,
+    /// Initial merged-range reads plus single-block retry exact reads. This
+    /// is a zfile-level read count, NOT a syscall/HTTP attempt count: one
+    /// merged read may be filled by several backing calls.
+    pub read_batches: u64,
+    /// Block re-reads after a CRC32C mismatch.
+    pub checksum_retries: u64,
+    /// Block re-reads after a decompress failure.
+    pub decompress_retries: u64,
+}
+
+/// Lazily register a per-codec counter slot and increment it: registration
+/// (Key construction plus recorder lookup) happens exactly once per reader,
+/// after which a logical `pread` only pays an atomic increment.
+macro_rules! zcounter {
+    ($slot:expr, $name:literal, $codec:expr, $value:expr) => {
+        $slot
+            .get_or_init(|| ::metrics::counter!($name, "codec" => $codec))
+            .increment($value)
+    };
+    ($slot:expr, $name:literal, $codec:expr, $value:expr, $lk:literal => $lv:literal) => {
+        $slot
+            .get_or_init(|| ::metrics::counter!($name, "codec" => $codec, $lk => $lv))
+            .increment($value)
+    };
+}
+
+/// Metric handles for one codec's ZFile read path. Registration is lazy
+/// (unused series stay absent), so constructing a reader is free; the pread
+/// hot path never rebuilds a Key or touches the recorder registry.
+pub(crate) struct ZFileReadMetrics {
+    codec: ZFileCodec,
+    output_bytes: OnceLock<Counter>,
+    encoded_bytes: OnceLock<Counter>,
+    blocks: OnceLock<Counter>,
+    read_batches: OnceLock<Counter>,
+    checksum_retries: OnceLock<Counter>,
+    decompress_retries: OnceLock<Counter>,
+    pread_duration_ok: OnceLock<Histogram>,
+    pread_duration_error: OnceLock<Histogram>,
+    decompress_duration: OnceLock<Histogram>,
+}
+
+impl ZFileReadMetrics {
+    pub(crate) fn new(codec: ZFileCodec) -> Self {
+        Self {
+            codec,
+            output_bytes: OnceLock::new(),
+            encoded_bytes: OnceLock::new(),
+            blocks: OnceLock::new(),
+            read_batches: OnceLock::new(),
+            checksum_retries: OnceLock::new(),
+            decompress_retries: OnceLock::new(),
+            pread_duration_ok: OnceLock::new(),
+            pread_duration_error: OnceLock::new(),
+            decompress_duration: OnceLock::new(),
+        }
+    }
+
+    /// Record the exact counters of one logical ZFile `pread`. Called
+    /// exactly once per pread by the read path's observation wrapper, on
+    /// success and on every error exit alike.
+    pub(crate) fn record(&self, stats: &ZFileReadStats) {
+        let codec = self.codec.as_label();
+        if stats.output_bytes > 0 {
+            zcounter!(
+                self.output_bytes,
+                "agentenv_overlaybd_zfile_output_bytes_total",
+                codec,
+                stats.output_bytes
+            );
+        }
+        if stats.encoded_bytes > 0 {
+            zcounter!(
+                self.encoded_bytes,
+                "agentenv_overlaybd_zfile_encoded_bytes_total",
+                codec,
+                stats.encoded_bytes
+            );
+        }
+        if stats.blocks > 0 {
+            zcounter!(
+                self.blocks,
+                "agentenv_overlaybd_zfile_blocks_total",
+                codec,
+                stats.blocks
+            );
+        }
+        if stats.read_batches > 0 {
+            zcounter!(
+                self.read_batches,
+                "agentenv_overlaybd_zfile_read_batches_total",
+                codec,
+                stats.read_batches
+            );
+        }
+        if stats.checksum_retries > 0 {
+            zcounter!(self.checksum_retries, "agentenv_overlaybd_zfile_retries_total", codec, stats.checksum_retries, "reason" => "checksum");
+        }
+        if stats.decompress_retries > 0 {
+            zcounter!(self.decompress_retries, "agentenv_overlaybd_zfile_retries_total", codec, stats.decompress_retries, "reason" => "decompress");
+        }
+    }
+
+    /// Record the sampled duration histograms of one logical ZFile `pread`.
+    /// Called only for preads selected by the 1-in-1024 per-thread sampler,
+    /// so both histograms' exported `_count` is a SAMPLE COUNT, not an
+    /// operation count. `decompress_elapsed` is the SUM of all per-block
+    /// decode times inside this single pread (retry decodes included),
+    /// never a per-block record.
+    pub(crate) fn record_durations(
+        &self,
+        status: ZFileReadStatus,
+        pread_elapsed: Duration,
+        decompress_elapsed: Duration,
+    ) {
+        let codec = self.codec.as_label();
+        let pread_duration = match status {
+            ZFileReadStatus::Ok => &self.pread_duration_ok,
+            ZFileReadStatus::Error => &self.pread_duration_error,
+        };
+        pread_duration
+            .get_or_init(|| {
+                ::metrics::histogram!(
+                    "agentenv_overlaybd_zfile_pread_duration_seconds",
+                    "codec" => codec,
+                    "status" => status.as_label(),
+                )
+            })
+            .record(pread_elapsed.as_secs_f64());
+        self.decompress_duration
+            .get_or_init(|| {
+                ::metrics::histogram!(
+                    "agentenv_overlaybd_zfile_decompress_duration_seconds",
+                    "codec" => codec,
+                )
+            })
+            .record(decompress_elapsed.as_secs_f64());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{normalize_host, registry_source, RemoteReadStatus, RemoteSource};
+    use super::{ZFileCodec, ZFileReadMetrics, ZFileReadStats, ZFileReadStatus};
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+    use std::time::Duration;
 
     #[test]
     fn remote_read_status_labels_http_statuses() {
@@ -262,5 +464,116 @@ mod tests {
         let oss = RemoteSource::OssObject;
         assert_eq!(oss.as_label(), "oss_object");
         assert_eq!(oss.registry_label(), "none");
+    }
+
+    /// Drive the ZFile metrics handle set through a thread-local
+    /// [`DebuggingRecorder`] — synchronously, never installing a global
+    /// recorder, so this stays safe alongside parallel async tests — and
+    /// assert the exact metric names, the fixed label sets, the recorded
+    /// counter values, and that all-zero stats record no series at all.
+    #[test]
+    fn zfile_metrics_use_fixed_low_cardinality_series() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        ::metrics::with_local_recorder(&recorder, || {
+            // Full success+retry stats for lz4, a blocks-only record for
+            // zstd, and an all-zero record that must create no series (error
+            // exits and EOF reads rely on this zero-skip).
+            let lz4 = ZFileReadMetrics::new(ZFileCodec::Lz4);
+            let zstd = ZFileReadMetrics::new(ZFileCodec::Zstd);
+            lz4.record(&ZFileReadStats {
+                output_bytes: 8192,
+                encoded_bytes: 9000,
+                blocks: 2,
+                read_batches: 2,
+                checksum_retries: 1,
+                decompress_retries: 3,
+            });
+            zstd.record(&ZFileReadStats {
+                blocks: 1,
+                ..ZFileReadStats::default()
+            });
+            zstd.record(&ZFileReadStats::default());
+
+            lz4.record_durations(
+                ZFileReadStatus::Ok,
+                Duration::from_micros(42),
+                Duration::from_micros(30),
+            );
+            lz4.record_durations(
+                ZFileReadStatus::Error,
+                Duration::from_micros(7),
+                Duration::ZERO,
+            );
+        });
+
+        let mut counters: Vec<(String, String, u64)> = Vec::new();
+        let mut histograms: Vec<(String, String, usize)> = Vec::new();
+        for (key, _unit, _description, value) in snapshotter.snapshot().into_vec() {
+            let mut labels: Vec<String> = key
+                .key()
+                .labels()
+                .map(|label| format!("{}={}", label.key(), label.value()))
+                .collect();
+            labels.sort_unstable();
+            let name = key.key().name().to_owned();
+            match value {
+                DebugValue::Counter(recorded) => counters.push((name, labels.join(","), recorded)),
+                DebugValue::Histogram(values) => {
+                    histograms.push((name, labels.join(","), values.len()))
+                }
+                DebugValue::Gauge(_) => panic!("zfile metrics must not use gauges: {name}"),
+            }
+        }
+        counters.sort();
+        histograms.sort();
+
+        // Aliases for the longest names, so each expected series fits on
+        // one line.
+        const RETRIES: &str = "agentenv_overlaybd_zfile_retries_total";
+        const PREAD_DUR: &str = "agentenv_overlaybd_zfile_pread_duration_seconds";
+        const DECOMP_DUR: &str = "agentenv_overlaybd_zfile_decompress_duration_seconds";
+
+        let counter =
+            |name: &str, labels: &str, value: u64| (name.to_owned(), labels.to_owned(), value);
+        assert_eq!(
+            counters,
+            vec![
+                counter("agentenv_overlaybd_zfile_blocks_total", "codec=lz4", 2),
+                counter("agentenv_overlaybd_zfile_blocks_total", "codec=zstd", 1),
+                counter(
+                    "agentenv_overlaybd_zfile_encoded_bytes_total",
+                    "codec=lz4",
+                    9000
+                ),
+                counter(
+                    "agentenv_overlaybd_zfile_output_bytes_total",
+                    "codec=lz4",
+                    8192
+                ),
+                counter(
+                    "agentenv_overlaybd_zfile_read_batches_total",
+                    "codec=lz4",
+                    2
+                ),
+                counter(RETRIES, "codec=lz4,reason=checksum", 1),
+                counter(RETRIES, "codec=lz4,reason=decompress", 3),
+            ],
+            "exact counter series with fixed names/labels; zero fields record nothing",
+        );
+
+        let histogram = |name: &str, labels: &str, samples: usize| {
+            (name.to_owned(), labels.to_owned(), samples)
+        };
+        assert_eq!(
+            histograms,
+            vec![
+                histogram(DECOMP_DUR, "codec=lz4", 2),
+                histogram(PREAD_DUR, "codec=lz4,status=error", 1),
+                histogram(PREAD_DUR, "codec=lz4,status=ok", 1),
+            ],
+            "sampled histogram series with fixed names/labels and sample counts",
+        );
     }
 }

--- a/storage/overlaybd/src/prefetch.rs
+++ b/storage/overlaybd/src/prefetch.rs
@@ -2,7 +2,6 @@ use crate::io::virtual_file::{IoCtx, LocalBoxFuture, VirtualFile};
 use anyhow::{bail, ensure, Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
-use crc::{Crc, CRC_32_ISCSI};
 use parking_lot::Mutex;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
@@ -18,7 +17,6 @@ const TRACE_MAGIC: u32 = 3_270_449_184;
 const TRACE_HEADER_SIZE: usize = 24;
 const TRACE_RECORD_SIZE: usize = 24;
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
-const CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PrefetchMode {
@@ -183,11 +181,11 @@ impl PrefetcherInner {
         let records = self.record_array.lock().clone();
         let data_size = u64::try_from(records.len().saturating_mul(TRACE_RECORD_SIZE))
             .context("trace data size overflow")?;
-        let mut digest = CRC32C.digest();
+        let mut checksum: u32 = 0;
         let mut encoded = Vec::with_capacity(records.len());
         for record in &records {
             let raw = record.encode();
-            digest.update(&raw);
+            checksum = crc32c::crc32c_append(checksum, &raw);
             encoded.push(raw);
         }
 
@@ -214,7 +212,7 @@ impl PrefetcherInner {
 
         let header = TraceHeader {
             data_size,
-            checksum: digest.finalize(),
+            checksum,
         };
         trace_file.seek(SeekFrom::Start(0))?;
         trace_file.write_all(&header.encode())?;
@@ -251,14 +249,14 @@ impl PrefetcherInner {
             "prefetch trace payload is not record-aligned",
         );
 
-        let mut digest = CRC32C.digest();
+        let mut checksum: u32 = 0;
         let mut queue = VecDeque::new();
         for chunk in raw[TRACE_HEADER_SIZE..].chunks_exact(TRACE_RECORD_SIZE) {
-            digest.update(chunk);
+            checksum = crc32c::crc32c_append(checksum, chunk);
             queue.push_back(TraceRecord::decode(chunk)?);
         }
         ensure!(
-            digest.finalize() == header.checksum,
+            checksum == header.checksum,
             "prefetch trace checksum mismatch",
         );
         Ok(queue)


### PR DESCRIPTION
## Summary

- `ZFileRO` reads no longer serialize on a whole-request mutex: `pread` takes `&self` with a `Sync` compressor, so reads on one shared handle overlap in the backing file.
- Encoded blocks are fetched in coalesced batches (up to 64 KiB) with one merged backing read per batch; a block failing CRC or decode is evicted and re-read on its own (at most 3 retries).
- The merged batch buffer is pooled per thread and no longer zero-filled before being fully overwritten.
- Per-pread exact counters (output/encoded bytes, blocks, batches, retries) plus 1-in-1024 sampled duration histograms, recorded through lazily pre-registered metric handles; the two duration histograms get fine-grained Prometheus buckets.
- CRC-32C moves from `crc` to `crc32c` (SSE4.2) in zfile, cache meta, and prefetch traces.
- New `zfile_read` criterion benchmark (read throughput, block size, compression throughput), using the rand 0.10 API (`RngExt`) to match this repo's dev-dependency.

## Benchmark

Xeon Platinum 8269CY, kernel 6.8, in-memory instrumented backing, criterion mean.

### Read throughput

| case | time | throughput |
|---|---:|---:|
| `lz4_random4k_qd1` | 1.254 µs | 3.04 GiB/s |
| `zstd_random4k_qd1` | 1.304 µs | 2.93 GiB/s |
| `lz4_compressible_random4k_qd1` | 494 ns | 7.75 GiB/s |
| `zstd_compressible_random4k_qd1` | 642 ns | 5.95 GiB/s |
| `lz4_seq128k_qd1` | 35.85 µs | 3.41 GiB/s |
| `zstd_seq128k_qd1` | 37.90 µs | 3.22 GiB/s |
| `lz4_random4k_qd16_shared` | 20.6 µs/op (1.29 µs per 4 KiB page) | 2.95 GiB/s |
| `zstd_random4k_qd16_shared` | 21.7 µs/op (1.36 µs per 4 KiB page) | 2.80 GiB/s |

QD16 on one shared handle costs the same per page as QD1 (1.29 vs 1.25 µs), i.e. 16 concurrent reads overlap in the backing file instead of serializing.

### Block size (4 KiB random read)

| case | time |
|---|---:|
| `lz4_random4k_qd1_bs4k` | 1.60 µs |
| `lz4_random4k_qd1_bs64k` | 20.1 µs (reads a whole 64 KiB block per 4 KiB request) |

### Memory compression ratio

Compressed memory image size relative to the original (lower is better):

| Memory state | LZ4 | ZSTD |
|---|---:|---:|
| Idle | 32.68% | 21.78% |
| Zero-page / random-page mix | 34.63% | 32.52% |

## Verification

- `cargo test -p overlaybd --lib`: 302 passed, 0 failed
- `cargo clippy -p overlaybd --all-targets -- -D warnings`: clean
