### PR TITLE
Optimize Docker cache for GitHub-hosted runners

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,6 +74,39 @@ jobs:
       - name: Configure ublk test host
         if: ${{ matrix.e2e_name != 'single-node' }}
         run: sudo scripts/tests/setup-ublk-access.sh "$(id -un)" "$(id -gn)"
+      - name: Set up Docker Buildx
+        if: ${{ matrix.e2e_name == 'docker-compose' }}
+        uses: docker/setup-buildx-action@v4
+      - name: Build AgentENV runtime image
+        if: ${{ matrix.e2e_name == 'docker-compose' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.agentenv
+          load: true
+          tags: agentenv-runtime:latest
+          cache-from: type=gha,scope=agentenv-runtime
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,scope=agentenv-runtime,mode=max' || '' }}
+      - name: Build gateway image
+        if: ${{ matrix.e2e_name == 'docker-compose' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.gateway
+          load: true
+          tags: agentenv-gateway:latest
+          cache-from: type=gha,scope=agentenv-gateway
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,scope=agentenv-gateway,mode=max' || '' }}
+      - name: Build scheduler image
+        if: ${{ matrix.e2e_name == 'docker-compose' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.scheduler
+          load: true
+          tags: agentenv-scheduler:latest
+          cache-from: type=gha,scope=agentenv-scheduler
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,scope=agentenv-scheduler,mode=max' || '' }}
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
@@ -91,7 +124,7 @@ jobs:
           if [[ "${{ matrix.e2e_name }}" == "single-node" ]]; then
             sg kvm -c "make ${{ matrix.make_target }} PROFILE=debug"
           else
-            make ${{ matrix.make_target }} PROFILE=debug
+            SKIP_BUILD=1 make ${{ matrix.make_target }} PROFILE=debug
           fi
       - uses: ./.github/actions/sandbox-artifacts-cleanup
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,7 @@ jobs:
           context: .
           file: deploy/docker/Dockerfile.agentenv
           push: true
+          cache-from: type=gha,scope=agentenv-runtime
           tags: |
             ghcr.io/${{ env.OWNER }}/aenv-server:${{ github.ref_name }}
             ghcr.io/${{ env.OWNER }}/aenv-server:latest

--- a/deploy/docker/Dockerfile.agentenv
+++ b/deploy/docker/Dockerfile.agentenv
@@ -31,9 +31,12 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS build-deps
 
 COPY --from=planner /build/recipe.json recipe.json
+# Keep Cargo target artifacts in this image layer rather than a BuildKit cache
+# mount. Cache mounts are local to a builder and are not included in exported
+# external caches; persisting target here lets fresh CI runners reuse the
+# cargo-chef dependency layer.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/build/target,sharing=locked \
     cargo chef cook --release --recipe-path recipe.json
 
 FROM build-deps AS builder
@@ -41,7 +44,6 @@ FROM build-deps AS builder
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/build/target,sharing=locked \
     cargo build --release -p agentenv --bin server -p uvm-ublk-daemon --bin uvm-ublk-daemon \
     && cp /build/target/release/server /out-server \
     && cp /build/target/release/uvm-ublk-daemon /out-uvm-ublk-daemon


### PR DESCRIPTION
This pull request introduces improvements to the Docker image build and caching strategy for CI workflows, especially for the `docker-compose` integration tests and image builds. The main changes ensure that Docker images are built and cached efficiently during CI runs, and that unnecessary rebuilds are avoided. Additionally, the Dockerfiles are updated to better leverage persistent layers for Rust build artifacts, improving cache reuse in CI environments.

**CI workflow enhancements:**

* [`.github/workflows/integration-tests.yml`](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R77-R109): Added steps to set up Docker Buildx and build the `agentenv-runtime`, `gateway`, and `scheduler` images with caching when running the `docker-compose` integration tests. This ensures that images are always up-to-date and leverages GitHub Actions cache for faster builds.
* [`.github/workflows/integration-tests.yml`](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L94-R127): Updated the make command for non-`single-node` tests to set `SKIP_BUILD=1`, preventing redundant local builds since images are already built in previous steps.

**Docker build and cache improvements:**

* [`deploy/docker/Dockerfile.agentenv`](diffhunk://#diff-875797b82816dfcac450829b3b6c1c8024f834ac69440a56f0ec5d550ed3a9e1R34-L44): Removed the BuildKit cache mount for the Cargo `target` directory and instead persist the build artifacts in the image layer. This allows external caches (like those used in CI runners) to reuse the dependency layer, speeding up builds on fresh runners.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R193): Added `cache-from` for the `agentenv-runtime` image, so release builds can reuse previously built layers from the GitHub Actions cache, reducing build times.