### PR TITLE
feat: expose snapshot rootfs image references

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -129,12 +129,17 @@ p2p_enabled = true
 #   - "oss": store committed snapshots in object storage.
 #     Requires [backend.oss] to be configured.
 #
-# Advanced: enable only when source images already live in an overlaybd-capable
-# registry and AENV has push credentials. When enabled, AENV publishes
-# each new snapshot delta as a new overlaybd image tag in the original source
-# registry, so the snapshot can also be addressed and reused as an image version
-# there. Unsupported source images fall back to the configured snapshot
-# repository.
+# Advanced: only takes effect with repository_backend = "oss". Enable only when
+# source images already live in an overlaybd-capable registry and AENV has push
+# credentials (from ~/.docker/config.json). When enabled, AENV publishes each
+# snapshot rootfs as a new overlaybd image tag "agentenv-snapshot-{snapshot_id}"
+# in the original source registry: existing remote layers are referenced by
+# digest and only new delta layers are uploaded, so the snapshot can also be
+# addressed and reused as an image version there. The published reference is
+# returned as `imageRef` in snapshot APIs. Memory and VM-state artifacts always
+# stay in the snapshot repository. Locally converted (non-overlaybd) source
+# images fall back to object storage; incompatible remote-backed layouts fail
+# the publish instead of mixing sources.
 # [snapshot.image_publish]
 # enabled = true
 

--- a/config/oss_default.toml
+++ b/config/oss_default.toml
@@ -87,12 +87,18 @@ auto_resume_min_sandbox_timeout_secs = 300
 repository_backend = "oss"
 p2p_enabled = true
 
-# Advanced: enable only when source images already live in an overlaybd-capable
-# registry and AgentENV has push credentials. When enabled, AgentENV publishes
-# each new snapshot delta as a new overlaybd image tag in the original source
-# registry, so the snapshot can also be addressed and reused as an image version
-# there. Unsupported source images fall back to the configured snapshot
-# repository.
+# Advanced: only takes effect with repository_backend = "oss". Enable only when
+# source images already live in an overlaybd-capable registry and AgentENV has
+# push credentials (from ~/.docker/config.json). When enabled, AgentENV
+# publishes each snapshot rootfs as a new overlaybd image tag
+# "agentenv-snapshot-{snapshot_id}" in the original source registry: existing
+# remote layers are referenced by digest and only new delta layers are
+# uploaded, so the snapshot can also be addressed and reused as an image
+# version there. The published reference is returned as `imageRef` in snapshot
+# APIs. Memory and VM-state artifacts always stay in the snapshot repository.
+# Locally converted (non-overlaybd) source images fall back to object storage;
+# incompatible remote-backed layouts fail the publish instead of mixing
+# sources.
 [snapshot.image_publish]
 enabled = true
 

--- a/crates/aenv/src/client/snapshots.rs
+++ b/crates/aenv/src/client/snapshots.rs
@@ -14,6 +14,8 @@ pub struct SnapshotInfo {
     pub snapshot_id: String,
     #[serde(default)]
     pub names: Vec<String>,
+    #[serde(rename = "imageRef", default, skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
 }
 
 impl Client {
@@ -59,7 +61,7 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use super::CreateSnapshot;
+    use super::{CreateSnapshot, SnapshotInfo};
 
     #[test]
     fn create_snapshot_serializes_optional_name() {
@@ -68,5 +70,30 @@ mod tests {
 
         let unnamed = serde_json::to_value(CreateSnapshot { name: None }).unwrap();
         assert_eq!(unnamed, serde_json::json!({}));
+    }
+
+    #[test]
+    fn snapshot_info_supports_optional_image_ref() {
+        let with_ref: SnapshotInfo = serde_json::from_value(serde_json::json!({
+            "snapshotID": "snap-1",
+            "names": [],
+            "imageRef": "registry.example/ns/app:agentenv-snapshot-snap-1"
+        }))
+        .unwrap();
+        assert_eq!(
+            with_ref.image_ref.as_deref(),
+            Some("registry.example/ns/app:agentenv-snapshot-snap-1")
+        );
+
+        let without_ref: SnapshotInfo = serde_json::from_value(serde_json::json!({
+            "snapshotID": "snap-2",
+            "names": []
+        }))
+        .unwrap();
+        assert_eq!(without_ref.image_ref, None);
+        assert!(serde_json::to_value(without_ref)
+            .unwrap()
+            .get("imageRef")
+            .is_none());
     }
 }

--- a/crates/aenv/src/commands/snapshot.rs
+++ b/crates/aenv/src/commands/snapshot.rs
@@ -53,11 +53,16 @@ struct Row {
     snapshot_id: String,
     #[tabled(rename = "NAMES")]
     names: String,
+    #[tabled(rename = "IMAGE REF")]
+    image_ref: String,
 }
 
 fn create(client: &Client, sandbox_id: &str, name: Option<&str>) -> Result<()> {
     let snapshot = client.create_snapshot(sandbox_id, name)?;
     println!("Created snapshot {}", snapshot.snapshot_id);
+    if let Some(image_ref) = &snapshot.image_ref {
+        println!("Image: {image_ref}");
+    }
     Ok(())
 }
 
@@ -70,5 +75,9 @@ fn list(client: &Client, sandbox_id: Option<&str>, format: Format) -> Result<()>
         } else {
             snapshot.names.join(",")
         },
+        image_ref: snapshot
+            .image_ref
+            .clone()
+            .unwrap_or_else(|| "-".to_string()),
     })
 }

--- a/docs/src/concepts/snapshots.md
+++ b/docs/src/concepts/snapshots.md
@@ -27,6 +27,38 @@ Recoverable failures leave the sandbox running and surface the error to the
 caller. Terminal failures — where the runtime was mutated past safe resume —
 tear down the sandbox.
 
+## OverlayBD Image Publication
+
+When the snapshot repository backend is `oss` and `[snapshot.image_publish]` is
+enabled, publishing a snapshot also writes its rootfs back to the original
+OverlayBD-native OCI registry as an image tag:
+
+```text
+Created snapshot 018f0d93-aaaa-bbbb-cccc-0123456789ab
+Image: registry.example.com/team/app:agentenv-snapshot-018f0d93-aaaa-bbbb-cccc-0123456789ab
+```
+
+The tag lives in the same registry and repository as the source image.
+Publication is incremental: layers already present in that repository (the
+base image and previously published snapshot deltas) are referenced by digest
+and never re-uploaded; only new runtime delta layers are pushed. The result is
+an OverlayBD-native OCI image that can be used directly as a `userImage` to
+cold boot new sandboxes.
+
+Notes:
+
+- The image contains only the root filesystem. Memory state and `vm_state.bin`
+  remain in the snapshot repository, so resuming with full memory state still
+  requires starting from the snapshot itself.
+- The published reference is returned as `imageRef` in snapshot create/GET/list
+  API responses and shown by `aenv snapshot create` and `aenv snapshot list`.
+- Snapshots created from non-OverlayBD-native source images, or created while
+  publication is disabled, do not produce an `imageRef`.
+- AgentENV never overwrites an existing generated snapshot tag. Registry
+  administrators can still move or replace tags through external tooling.
+- Deleting a snapshot also attempts to delete its published manifest from the
+  registry.
+
 ## Manage Snapshots
 
 ### List Snapshots

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -349,6 +349,14 @@ Environment variable overrides:
 
 - `AENV_SNAPSHOT_LOCAL_CACHE_PATH`
 
+## `[snapshot.image_publish]`
+
+Source-registry image publication. Only takes effect when `snapshot.repository_backend = "oss"`.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | When enabled, publishing a snapshot also pushes its rootfs as an OverlayBD-native OCI image tag `agentenv-snapshot-{snapshot_id}` to the original source registry. Requires source images to be OverlayBD-native in that registry and push credentials in the Docker config (`~/.docker/config.json`). Existing remote layers are referenced by digest; only new delta layers are uploaded. The published reference is exposed as `imageRef` in snapshot APIs. Memory and VM-state artifacts always remain in the snapshot repository. |
+
 ## `[backend.posix_fs]`
 
 POSIX filesystem-backed snapshot repository configuration. This section is used when `snapshot.repository_backend = "posix_fs"`.

--- a/docs/src/getting-started/aenv-cli.md
+++ b/docs/src/getting-started/aenv-cli.md
@@ -199,6 +199,8 @@ aenv snapshot create <sandbox-id> --name my-base
 |------|-------------|
 | `--name <name>` | Snapshot name or alias |
 
+When source-registry image publication is enabled on the server, the command also prints the published OverlayBD-native image reference on an `Image:` line; that tag can be used directly as a `userImage`.
+
 ### `aenv snapshot list`
 
 List persistent snapshots. Alias: `aenv snapshot ls`, `aenv snap ls`.
@@ -212,5 +214,7 @@ aenv snapshot list --sandbox-id <sandbox-id>
 |------|-------------|
 | `--sandbox-id <id>` | Filter snapshots by source sandbox ID |
 | `--output <format>` | Output format: `table` (default on TTY) or `json` |
+
+The table output includes an `IMAGE REF` column (`-` when no image was published); JSON output includes the optional `imageRef` field.
 
 To delete a snapshot, use `aenv template delete <snapshot-id>` or `aenv template delete <name>` — snapshots share the same underlying store as templates and are deleted through the same command.

--- a/src/api/generated/src/models.rs
+++ b/src/api/generated/src/models.rs
@@ -6598,6 +6598,12 @@ pub struct SnapshotInfo {
     /// Time when the snapshot was last updated
     #[serde(rename = "updatedAt")]
     pub updated_at: chrono::DateTime<chrono::Utc>,
+
+    /// OverlayBD-native OCI image reference for the snapshot rootfs when source-registry image publication was enabled and succeeded. Omitted when no rootfs image was published.
+    #[serde(rename = "imageRef")]
+    #[validate(custom(function = "check_xss_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
 }
 
 impl SnapshotInfo {
@@ -6619,6 +6625,7 @@ impl SnapshotInfo {
             disk_size_mb,
             created_at,
             updated_at,
+            image_ref: None,
         }
     }
 }
@@ -6648,6 +6655,9 @@ impl std::fmt::Display for SnapshotInfo {
             // Skipping createdAt in query parameter serialization
 
             // Skipping updatedAt in query parameter serialization
+            self.image_ref
+                .as_ref()
+                .map(|image_ref| ["imageRef".to_string(), image_ref.to_string()].join(",")),
         ];
 
         write!(
@@ -6676,6 +6686,7 @@ impl std::str::FromStr for SnapshotInfo {
             pub disk_size_mb: Vec<u32>,
             pub created_at: Vec<chrono::DateTime<chrono::Utc>>,
             pub updated_at: Vec<chrono::DateTime<chrono::Utc>>,
+            pub image_ref: Vec<String>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -6729,6 +6740,10 @@ impl std::str::FromStr for SnapshotInfo {
                         <chrono::DateTime<chrono::Utc> as std::str::FromStr>::from_str(val)
                             .map_err(|x| x.to_string())?,
                     ),
+                    #[allow(clippy::redundant_clone)]
+                    "imageRef" => intermediate_rep.image_ref.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
                     _ => {
                         return std::result::Result::Err(
                             "Unexpected key while parsing SnapshotInfo".to_string(),
@@ -6778,6 +6793,7 @@ impl std::str::FromStr for SnapshotInfo {
                 .into_iter()
                 .next()
                 .ok_or_else(|| "updatedAt missing in SnapshotInfo".to_string())?,
+            image_ref: intermediate_rep.image_ref.into_iter().next(),
         })
     }
 }

--- a/src/api/impls/snapshots.rs
+++ b/src/api/impls/snapshots.rs
@@ -16,6 +16,7 @@ use super::ApiImpl;
 impl From<SnapshotRecord> for models::SnapshotInfo {
     fn from(record: SnapshotRecord) -> Self {
         let snapshot_id = record.id.to_string();
+        let image_ref = record.published_rootfs_image_ref().map(str::to_owned);
         let names = if let Some(alias) = record.alias {
             vec![alias.to_string()]
         } else {
@@ -33,6 +34,7 @@ impl From<SnapshotRecord> for models::SnapshotInfo {
             updated_at: chrono::DateTime::<chrono::Utc>::from(system_time_from_unix_ms(
                 record.updated_at_unix_ms,
             )),
+            image_ref,
         }
     }
 }
@@ -145,5 +147,42 @@ impl Snapshots<()> for ApiImpl {
                 Self::snapshot_manager_error(&err),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::snapshot::{
+        rootfs_snapshot_image_tag, CommittedSnapshot, PersistedDiskImagePublication,
+    };
+
+    #[test]
+    fn snapshot_info_includes_published_rootfs_image_ref() {
+        let mut record = SnapshotRecord::mock_ready(CommittedSnapshot::mock());
+        let tag = rootfs_snapshot_image_tag(&record.id);
+        let expected = format!("registry.example/ns/app:{tag}");
+        record.committed.as_mut().unwrap().disk_publications =
+            vec![PersistedDiskImagePublication {
+                image_ref: expected.clone(),
+                tag,
+                manifest_digest: "sha256:manifest".to_string(),
+                repo_blob_url: "https://registry.example/v2/ns/app/blobs".to_string(),
+            }];
+
+        let info = models::SnapshotInfo::from(record);
+
+        assert_eq!(info.image_ref.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn snapshot_info_omits_image_ref_without_publication() {
+        let record = SnapshotRecord::mock_ready(CommittedSnapshot::mock());
+
+        let info = models::SnapshotInfo::from(record);
+
+        assert_eq!(info.image_ref, None);
+        let serialized = serde_json::to_value(&info).expect("serialize SnapshotInfo");
+        assert!(serialized.get("imageRef").is_none());
     }
 }

--- a/src/api/openapi.yml
+++ b/src/api/openapi.yml
@@ -215,6 +215,12 @@ components:
           type: string
           format: date-time
           description: Time when the snapshot was last updated
+        imageRef:
+          type: string
+          description: >
+            OverlayBD-native OCI image reference for the snapshot rootfs when
+            source-registry image publication was enabled and succeeded.
+            Omitted when no rootfs image was published.
 
     EnvVars:
       additionalProperties:

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -9,6 +9,7 @@ mod types;
 
 pub use manager::SnapshotManager;
 pub use repository::{RepositoryError, RepositoryResult, SnapshotListFilter};
+pub(crate) use types::rootfs_snapshot_image_tag;
 pub use types::{
     CommandContext, CommittedAttachedDrive, CommittedSnapshot, ExternalLayer, ManagedLayer,
     OverlaybdLayerRef, PersistedDiskImagePublication, ResolvedAttachedDrive, RunnableSnapshot,

--- a/src/snapshot/repository/backends/common/acr/client.rs
+++ b/src/snapshot/repository/backends/common/acr/client.rs
@@ -149,6 +149,7 @@ impl AcrClient {
     ) -> Result<Self, AcrClientError> {
         let http = reqwest::Client::builder()
             .timeout(options.timeout)
+            .redirect(redirect_policy(&options))
             .build()
             .map_err(|e| AcrClientError::Registry {
                 message: format!("build ACR HTTP client: {e}"),
@@ -711,6 +712,47 @@ fn retry_after_delay(value: Option<&HeaderValue>) -> Option<Duration> {
         .map(Duration::from_secs)
 }
 
+fn redirect_policy(options: &AcrClientOptions) -> reqwest::redirect::Policy {
+    let allow_insecure_http = insecure_http_allowed(options);
+    reqwest::redirect::Policy::custom(move |attempt| {
+        if attempt.previous().len() >= 10 {
+            return attempt.error("too many ACR HTTP redirects");
+        }
+        let Some(origin) = attempt.previous().first() else {
+            return attempt.error("ACR HTTP redirect is missing its origin URL");
+        };
+        if !same_origin(origin, attempt.url()) {
+            return attempt.error("ACR HTTP redirect target must keep the original origin");
+        }
+        if attempt.url().scheme() != "https" && !allow_insecure_http {
+            return attempt.error("ACR HTTP redirect target must use https");
+        }
+        attempt.follow()
+    })
+}
+
+fn same_origin(left: &Url, right: &Url) -> bool {
+    left.scheme() == right.scheme()
+        && left.host_str() == right.host_str()
+        && left.port_or_known_default() == right.port_or_known_default()
+}
+
+fn redirect_target_allowed(url: &Url, options: &AcrClientOptions) -> bool {
+    url.scheme() == "https" || insecure_http_allowed(options)
+}
+
+fn insecure_http_allowed(options: &AcrClientOptions) -> bool {
+    #[cfg(not(test))]
+    {
+        let _ = options;
+        false
+    }
+    #[cfg(test)]
+    {
+        options.allow_insecure_http
+    }
+}
+
 fn validate_https_url_str(
     url: &str,
     description: &str,
@@ -727,18 +769,13 @@ fn validate_https_url(
     description: &str,
     options: &AcrClientOptions,
 ) -> Result<(), AcrClientError> {
-    if url.scheme() == "https" {
-        return Ok(());
+    if redirect_target_allowed(url, options) {
+        Ok(())
+    } else {
+        Err(AcrClientError::Registry {
+            message: format!("{description} must use https: {url}"),
+        })
     }
-    #[cfg(not(test))]
-    let _ = options;
-    #[cfg(test)]
-    if options.allow_insecure_http {
-        return Ok(());
-    }
-    Err(AcrClientError::Registry {
-        message: format!("{description} must use https: {url}"),
-    })
 }
 
 fn load_docker_credentials(
@@ -1032,14 +1069,15 @@ fn challenge_cache_key(url: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::net::SocketAddr;
+pub(super) mod tests {
+    use std::error::Error as _;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
 
     use axum::body::Bytes;
     use axum::extract::State;
     use axum::http::{HeaderMap as AxumHeaderMap, HeaderValue, StatusCode as AxumStatusCode};
-    use axum::response::IntoResponse;
+    use axum::response::{IntoResponse, Redirect};
     use axum::routing::{delete, get, head, patch, post, put};
     use axum::Router;
     use tempfile::TempDir;
@@ -1048,11 +1086,11 @@ mod tests {
     use super::*;
 
     #[derive(Default)]
-    struct FakeState {
+    pub(crate) struct FakeState {
         token_scopes: Vec<String>,
         uploads: Vec<Vec<u8>>,
         upload_completes: usize,
-        manifest_puts: Vec<Vec<u8>>,
+        pub(crate) manifest_puts: Vec<Vec<u8>>,
         deletes: Vec<String>,
         blob_exists: bool,
         blob_head_429s_remaining: usize,
@@ -1060,7 +1098,23 @@ mod tests {
         omit_manifest_digest: bool,
     }
 
-    async fn fake_server(state: Arc<Mutex<FakeState>>) -> String {
+    impl FakeState {
+        pub(crate) fn with_existing_blobs() -> Self {
+            Self {
+                blob_exists: true,
+                ..Default::default()
+            }
+        }
+    }
+
+    async fn serve(app: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        format!("http://{addr}")
+    }
+
+    pub(crate) async fn fake_server(state: Arc<Mutex<FakeState>>) -> String {
         let app = Router::new()
             .route("/token", get(token))
             .route("/v2/ns/repo/blobs/{digest}", head(blob_head))
@@ -1071,12 +1125,7 @@ mod tests {
             .route("/v2/ns/repo/manifests/{reference}", put(manifest_put))
             .route("/v2/ns/repo/manifests/{reference}", delete(manifest_delete))
             .with_state(state);
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr: SocketAddr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-        format!("http://{addr}")
+        serve(app).await
     }
 
     fn bearer_challenge(base: &str) -> String {
@@ -1095,7 +1144,7 @@ mod tests {
         format!("{base}/v2/ns/repo/blobs")
     }
 
-    fn client() -> AcrClient {
+    pub(crate) fn client() -> AcrClient {
         client_with_retry_count(0)
     }
 
@@ -1344,6 +1393,58 @@ printf '{"Username":"helper-user","Secret":"helper-secret"}'
             .await
             .unwrap());
         assert_eq!(state.lock().unwrap().blob_head_429s_remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn redirect_policy_rejects_cross_origin_body_replay() {
+        async fn receive_body(
+            State(reached): State<Arc<AtomicBool>>,
+            _body: Bytes,
+        ) -> AxumStatusCode {
+            reached.store(true, Ordering::SeqCst);
+            AxumStatusCode::OK
+        }
+
+        let reached = Arc::new(AtomicBool::new(false));
+        let target = Router::new()
+            .route("/upload", put(receive_body))
+            .with_state(Arc::clone(&reached));
+        let target_url = format!("{}/upload", serve(target).await);
+
+        let redirect = Router::new().route(
+            "/upload",
+            put(move || {
+                let target_url = target_url.clone();
+                async move { Redirect::temporary(&target_url) }
+            }),
+        );
+        let redirect_url = format!("{}/upload", serve(redirect).await);
+
+        client()
+            .http
+            .put(redirect_url)
+            .body("snapshot-data")
+            .send()
+            .await
+            .expect_err("cross-origin redirect must be rejected");
+        assert!(!reached.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn redirect_policy_limits_redirect_chain() {
+        async fn redirect_to_self(headers: AxumHeaderMap) -> Redirect {
+            let host = headers.get("host").unwrap().to_str().unwrap();
+            Redirect::temporary(&format!("http://{host}/loop"))
+        }
+
+        let app = Router::new().route("/loop", get(redirect_to_self));
+        let url = format!("{}/loop", serve(app).await);
+
+        let error = client().http.get(url).send().await.unwrap_err();
+        assert_eq!(
+            error.source().map(ToString::to_string).as_deref(),
+            Some("too many ACR HTTP redirects")
+        );
     }
 
     #[tokio::test]

--- a/src/snapshot/repository/backends/common/acr/manifest.rs
+++ b/src/snapshot/repository/backends/common/acr/manifest.rs
@@ -10,6 +10,7 @@ pub(crate) const OCI_IMAGE_CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.image.
 pub(crate) const OCI_TAR_LAYER_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar";
 const OVERLAYBD_BLOB_DIGEST_ANNOTATION: &str = "containerd.io/snapshot/overlaybd/blob-digest";
 const OVERLAYBD_BLOB_SIZE_ANNOTATION: &str = "containerd.io/snapshot/overlaybd/blob-size";
+const SNAPSHOT_TAG_ANNOTATION: &str = "io.agentenv.snapshot.tag";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -51,6 +52,7 @@ struct OciManifest {
     media_type: String,
     config: OciDescriptor,
     layers: Vec<OciDescriptor>,
+    annotations: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -106,12 +108,18 @@ pub(crate) fn minimal_oci_config_blob(
 pub(crate) fn build_oci_image_manifest(
     config: OciDescriptor,
     layers: Vec<OciDescriptor>,
+    publication_tag: &str,
 ) -> RepositoryResult<Vec<u8>> {
+    let annotations = BTreeMap::from([(
+        SNAPSHOT_TAG_ANNOTATION.to_string(),
+        publication_tag.to_string(),
+    )]);
     let manifest = OciManifest {
         schema_version: 2,
         media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string(),
         config,
         layers,
+        annotations,
     };
     serde_json::to_vec(&manifest)
         .map_err(|e| RepositoryError::backend("serialize OCI image manifest", e))
@@ -140,6 +148,7 @@ mod tests {
         let manifest = build_oci_image_manifest(
             OciDescriptor::config("sha256:config".to_string(), 2),
             vec![layer],
+            "agentenv-snapshot-s1",
         )
         .unwrap();
         let value: serde_json::Value = serde_json::from_slice(&manifest).unwrap();
@@ -159,6 +168,29 @@ mod tests {
         assert_eq!(
             value["layers"][0]["annotations"]["containerd.io/snapshot/overlaybd/blob-size"],
             "123"
+        );
+        assert_eq!(
+            value["annotations"]["io.agentenv.snapshot.tag"],
+            "agentenv-snapshot-s1"
+        );
+    }
+
+    #[test]
+    fn publication_tag_makes_manifest_digest_unique() {
+        let config = OciDescriptor::config("sha256:config".to_string(), 2);
+        let layers = vec![OciDescriptor::overlaybd_layer(
+            "sha256:abc".to_string(),
+            123,
+        )];
+
+        let first =
+            build_oci_image_manifest(config.clone(), layers.clone(), "agentenv-snapshot-s1")
+                .unwrap();
+        let second = build_oci_image_manifest(config, layers, "agentenv-snapshot-s2").unwrap();
+
+        assert_ne!(
+            crate::digest::sha256_digest(&first),
+            crate::digest::sha256_digest(&second)
         );
     }
 }

--- a/src/snapshot/repository/backends/common/acr/publisher.rs
+++ b/src/snapshot/repository/backends/common/acr/publisher.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 use crate::digest;
 use crate::snapshot::repository::backends::common::write_dense_overlaybd_layer_to_file;
 use crate::snapshot::repository::{RepositoryError, RepositoryResult};
+use crate::snapshot::rootfs_snapshot_image_tag;
 use crate::snapshot::{
     ExternalLayer, OverlaybdLayerRef, PersistedDiskImagePublication, SnapshotId,
 };
@@ -19,8 +20,6 @@ use super::source_image::{
     load_source_registry_image, LocalSnapshotDelta, LocalSnapshotDeltaDescriptor,
     SourceRegistryLayer, SourceRegistryRepository,
 };
-
-const SNAPSHOT_TAG_PREFIX: &str = "agentenv-snapshot-";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum DiskImageSubject {
@@ -76,30 +75,6 @@ impl AcrDiskImageExporter {
     ) -> RepositoryResult<DiskImageExportOutcome> {
         let image = load_source_registry_image(image_config_path)?;
         let target = &image.target;
-
-        let has_local_delta = image
-            .layers
-            .iter()
-            .any(|layer| matches!(layer, SourceRegistryLayer::LocalDelta(_)));
-        if !has_local_delta {
-            return Ok(DiskImageExportOutcome {
-                layers: image
-                    .layers
-                    .iter()
-                    .map(|layer| match layer {
-                        SourceRegistryLayer::Remote { digest, size } => {
-                            OverlaybdLayerRef::External(ExternalLayer {
-                                digest: digest.clone(),
-                                repo_blob_url: target.repo_blob_url.clone(),
-                                size: *size,
-                            })
-                        }
-                        SourceRegistryLayer::LocalDelta(_) => unreachable!("checked above"),
-                    })
-                    .collect(),
-                publication: None,
-            });
-        }
 
         let tag = snapshot_tag(snapshot_id, &subject);
         validate_snapshot_tag(&tag)?;
@@ -158,6 +133,7 @@ impl AcrDiskImageExporter {
         let manifest = build_oci_image_manifest(
             OciDescriptor::config(config_digest, config_size),
             descriptors,
+            &tag,
         )?;
         let manifest_digest = client
             .put_manifest(&manifest_url, &target.repository, manifest)
@@ -288,11 +264,12 @@ impl AcrDiskImageExporter {
 }
 
 fn snapshot_tag(snapshot_id: &crate::snapshot::SnapshotId, subject: &DiskImageSubject) -> String {
+    let rootfs_tag = rootfs_snapshot_image_tag(snapshot_id);
     match subject {
-        DiskImageSubject::Rootfs => format!("{SNAPSHOT_TAG_PREFIX}{snapshot_id}"),
+        DiskImageSubject::Rootfs => rootfs_tag,
         DiskImageSubject::AttachedDrive { drive_id } => {
             format!(
-                "{SNAPSHOT_TAG_PREFIX}{snapshot_id}-drive-{}",
+                "{rootfs_tag}-drive-{}",
                 sanitize_drive_tag_component(drive_id)
             )
         }
@@ -357,6 +334,7 @@ mod tests {
     use serde_json::json;
     use tempfile::TempDir;
 
+    use super::super::client::tests::{client as test_client, fake_server, FakeState};
     use super::*;
 
     #[test]
@@ -431,13 +409,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn all_remote_source_registry_image_publishes_without_registry_mutation() {
+    async fn all_remote_source_registry_image_publishes_manifest_without_layer_upload() {
+        let state = Arc::new(Mutex::new(FakeState::with_existing_blobs()));
+        let base = fake_server(Arc::clone(&state)).await;
         let dir = TempDir::new().unwrap();
         let image = dir.path().join("image.json");
         fs::write(
             &image,
             serde_json::to_vec_pretty(&json!({
-                "repoBlobUrl": "https://registry.example/v2/ns/repo/blobs",
+                "repoBlobUrl": format!("{base}/v2/ns/repo/blobs"),
                 "lowers": [
                     {"digest": "sha256:base", "size": 123},
                     {"digest": "sha256:delta", "size": 456}
@@ -448,34 +428,50 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
-        let publisher = AcrDiskImageExporter::new_with_client_builder(Arc::new(|registry| {
-            panic!("all-remote image should not create ACR client for {registry}")
-        }));
+        let client = test_client();
+        let publisher =
+            AcrDiskImageExporter::new_with_client_builder(Arc::new(move |_| Ok(client.clone())));
+        let snapshot_id = crate::snapshot::SnapshotId::generate();
 
         let outcome = publisher
-            .export(
-                &crate::snapshot::SnapshotId::generate(),
-                DiskImageSubject::Rootfs,
-                &image,
-            )
+            .export(&snapshot_id, DiskImageSubject::Rootfs, &image)
             .await
             .unwrap();
 
+        let expected_tag = format!("agentenv-snapshot-{snapshot_id}");
+        let publication = outcome.publication.unwrap();
+        assert_eq!(publication.tag, expected_tag);
+        assert_eq!(
+            publication.image_ref,
+            format!(
+                "{}/ns/repo:{}",
+                base.trim_start_matches("http://"),
+                expected_tag
+            )
+        );
         assert_eq!(
             outcome.layers,
             vec![
                 OverlaybdLayerRef::External(ExternalLayer {
                     digest: "sha256:base".to_string(),
-                    repo_blob_url: "https://registry.example/v2/ns/repo/blobs".to_string(),
+                    repo_blob_url: format!("{base}/v2/ns/repo/blobs"),
                     size: 123,
                 }),
                 OverlaybdLayerRef::External(ExternalLayer {
                     digest: "sha256:delta".to_string(),
-                    repo_blob_url: "https://registry.example/v2/ns/repo/blobs".to_string(),
+                    repo_blob_url: format!("{base}/v2/ns/repo/blobs"),
                     size: 456,
                 }),
             ]
         );
-        assert!(outcome.publication.is_none());
+        let state = state.lock().unwrap();
+        assert_eq!(state.manifest_puts.len(), 1);
+        let manifest: serde_json::Value = serde_json::from_slice(&state.manifest_puts[0]).unwrap();
+        assert_eq!(manifest["layers"][0]["digest"], "sha256:base");
+        assert_eq!(manifest["layers"][1]["digest"], "sha256:delta");
+        assert_eq!(
+            manifest["annotations"]["io.agentenv.snapshot.tag"],
+            expected_tag
+        );
     }
 }

--- a/src/snapshot/repository/backends/common/acr/source_image.rs
+++ b/src/snapshot/repository/backends/common/acr/source_image.rs
@@ -24,7 +24,10 @@ impl SourceRegistryRepository {
         let url = Url::parse(repo_blob_url).map_err(|e| RepositoryError::Unsupported {
             feature: format!("invalid ACR repoBlobUrl '{repo_blob_url}': {e}"),
         })?;
-        if url.scheme() != "https" {
+        let test_loopback_http = cfg!(test)
+            && url.scheme() == "http"
+            && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"));
+        if url.scheme() != "https" && !test_loopback_http {
             return Err(RepositoryError::Unsupported {
                 feature: format!("ACR repoBlobUrl must use https: {repo_blob_url}"),
             });
@@ -57,7 +60,12 @@ impl SourceRegistryRepository {
                 feature: format!("ACR repoBlobUrl repository is empty: {repo_blob_url}"),
             });
         }
-        let repo_blob_url = format!("https://{}{}", registry, url.path().trim_end_matches('/'));
+        let repo_blob_url = format!(
+            "{}://{}{}",
+            url.scheme(),
+            registry,
+            url.path().trim_end_matches('/')
+        );
 
         Ok(Self {
             registry,
@@ -70,17 +78,28 @@ impl SourceRegistryRepository {
         format!("{}/{}:{tag}", self.registry, self.repository)
     }
 
+    fn registry_api_url(&self) -> String {
+        let scheme = self
+            .repo_blob_url
+            .split_once("://")
+            .map(|(scheme, _)| scheme)
+            .unwrap_or("https");
+        format!("{scheme}://{}", self.registry)
+    }
+
     pub(crate) fn upload_url(&self) -> String {
         format!(
-            "https://{}/v2/{}/blobs/uploads/",
-            self.registry, self.repository
+            "{}/v2/{}/blobs/uploads/",
+            self.registry_api_url(),
+            self.repository
         )
     }
 
     pub(crate) fn manifest_url(&self, tag: &str) -> String {
         format!(
-            "https://{}/v2/{}/manifests/{tag}",
-            self.registry, self.repository
+            "{}/v2/{}/manifests/{tag}",
+            self.registry_api_url(),
+            self.repository
         )
     }
 }

--- a/src/snapshot/types/mod.rs
+++ b/src/snapshot/types/mod.rs
@@ -6,7 +6,7 @@ mod version;
 
 pub use artifacts::SNAPSHOT_ARTIFACT_LAYOUT;
 pub use drive::{CommittedAttachedDrive, ResolvedAttachedDrive};
-pub(crate) use snapshot::RuntimeArtifactLease;
+pub(crate) use snapshot::{rootfs_snapshot_image_tag, RuntimeArtifactLease};
 pub use snapshot::{
     CommandContext, CommittedSnapshot, ExternalLayer, ManagedLayer, OverlaybdLayerRef,
     PersistedDiskImagePublication, RunnableSnapshot, SnapshotPublishMetadata,

--- a/src/snapshot/types/snapshot.rs
+++ b/src/snapshot/types/snapshot.rs
@@ -373,6 +373,18 @@ impl SnapshotRecord {
         self.committed = Some(committed);
     }
 
+    /// Returns the published rootfs OCI image reference, if source-registry
+    /// image publication produced one for this snapshot.
+    pub(crate) fn published_rootfs_image_ref(&self) -> Option<&str> {
+        let committed = self.committed.as_ref()?;
+        let expected_tag = rootfs_snapshot_image_tag(&self.id);
+        committed
+            .disk_publications
+            .iter()
+            .find(|publication| publication.tag == expected_tag)
+            .map(|publication| publication.image_ref.as_str())
+    }
+
     #[cfg(test)]
     pub fn mock_ready(committed: CommittedSnapshot) -> Self {
         Self {
@@ -428,6 +440,13 @@ pub struct PersistedDiskImagePublication {
     pub tag: String,
     pub manifest_digest: String,
     pub repo_blob_url: String,
+}
+
+const SNAPSHOT_IMAGE_TAG_PREFIX: &str = "agentenv-snapshot-";
+
+/// OCI tag used when publishing a snapshot rootfs image to its source registry.
+pub(crate) fn rootfs_snapshot_image_tag(snapshot_id: &SnapshotId) -> String {
+    format!("{SNAPSHOT_IMAGE_TAG_PREFIX}{snapshot_id}")
 }
 
 pub(crate) trait RuntimeArtifactLease: Send + Sync {}
@@ -550,9 +569,22 @@ impl fmt::Debug for RunnableSnapshot {
 #[cfg(test)]
 mod tests {
     use super::{
-        CommandContext, CommittedSnapshot, ManagedLayer, SnapshotRecord, TemplateBuildErrorReason,
+        rootfs_snapshot_image_tag, CommandContext, CommittedSnapshot, ManagedLayer,
+        PersistedDiskImagePublication, SnapshotRecord, TemplateBuildErrorReason,
     };
     use std::collections::HashMap;
+
+    fn publication(
+        image_ref: impl Into<String>,
+        tag: impl Into<String>,
+    ) -> PersistedDiskImagePublication {
+        PersistedDiskImagePublication {
+            image_ref: image_ref.into(),
+            tag: tag.into(),
+            manifest_digest: "sha256:manifest".to_string(),
+            repo_blob_url: "https://registry.example/v2/ns/app/blobs".to_string(),
+        }
+    }
 
     #[test]
     fn snapshot_record_without_tools_drive_version_remains_readable() {
@@ -589,6 +621,34 @@ mod tests {
         );
         let value = serde_json::to_value(&layer).expect("serialize uuid layer");
         assert_eq!(value["uuid"], "11111111-2222-3333-4444-555555555555");
+    }
+
+    #[test]
+    fn returns_published_rootfs_image_ref_by_exact_tag() {
+        let mut record = SnapshotRecord::mock_ready(CommittedSnapshot::mock());
+        let rootfs_tag = rootfs_snapshot_image_tag(&record.id);
+        let expected = format!("registry.example/ns/app:{rootfs_tag}");
+        record.committed.as_mut().unwrap().disk_publications = vec![
+            publication(
+                "registry.example/ns/app:drive",
+                format!("{rootfs_tag}-drive-data-0123456789ab"),
+            ),
+            publication(expected.clone(), rootfs_tag),
+        ];
+
+        assert_eq!(record.published_rootfs_image_ref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn drive_only_publication_has_no_rootfs_image_ref() {
+        let mut record = SnapshotRecord::mock_ready(CommittedSnapshot::mock());
+        let rootfs_tag = rootfs_snapshot_image_tag(&record.id);
+        record.committed.as_mut().unwrap().disk_publications = vec![publication(
+            "registry.example/ns/app:drive",
+            format!("{rootfs_tag}-drive-data-0123456789ab"),
+        )];
+
+        assert_eq!(record.published_rootfs_image_ref(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Expose the existing source-registry snapshot rootfs publication as an optional `imageRef` in snapshot API and CLI responses.

Image publication remains part of snapshot creation and still requires the OSS snapshot backend with `[snapshot.image_publish].enabled = true`. This PR does not add a separate export endpoint or CLI command.

Fixes #16.

## Changes

- Add an optional `imageRef` to snapshot create, GET, and list responses.
- Print the published image after `aenv snapshot create`.
- Add an `IMAGE REF` column and optional JSON field to `aenv snapshot list`.
- Select rootfs publications by their exact deterministic tag so attached-drive publications cannot be exposed accidentally.
- Publish an OCI manifest and snapshot tag even when the rootfs contains only existing remote layers.
- Keep remote OverlayBD layers referenced by digest without downloading or uploading them again.
- Add the exact publication tag to OCI manifest annotations so otherwise identical snapshot publications receive distinct manifest digests.
- Delete registry publications before discarding their persisted snapshot metadata, allowing failed cleanup to be retried.
- Leave stale alias cleanup to the existing lookup/bind path to avoid races with concurrent alias rebinding.
- Reject invalid persisted registry publication metadata instead of silently discarding cleanup information.
- Reject HTTPS-to-HTTP registry redirects and limit redirect chains to 10 hops.
- Update snapshot image publication configuration, concepts, and CLI documentation.

## Compatibility

- `imageRef` is optional and omitted when no rootfs image was published.
- Existing snapshot records remain readable.
- Older clients can ignore the new response field.
- Standard OCI images converted to local OverlayBD layers retain the existing object-storage fallback.
- No new endpoint, background task, dependency, or persistent schema migration is introduced.

## Performance

- Existing remote layers are referenced by digest and are not re-uploaded.
- Local delta blobs retain digest-based existence checks and upload deduplication.
- All-remote publication performs only registry metadata requests and a manifest PUT.
- Snapshot GET/list performs only an in-memory publication lookup and does not access the registry.
- Layer and config blobs remain content-addressed and shared; only manifests are publication-specific.

## Testing

Validated on the remote Linux test host:

```text
cargo test -p agentenv --lib
640 passed, 0 failed, 2 ignored

cargo test -p aenv
23 passed, 0 failed
```

Additional checks:

```text
cargo clippy -p agentenv -p aenv --all-targets -- -D warnings
cargo fmt --all -- --check
git diff --check
```

The tests cover:

- all-remote publication through the existing fake registry;
- remote-only publication without layer uploads;
- publication-specific manifest digests;
- rootfs versus attached-drive publication selection;
- optional API and CLI `imageRef` serialization;
- invalid persisted publication metadata;
- HTTPS redirect enforcement;
- existing blob deduplication, chunked upload, and manifest deletion behavior.
