### PR TITLE
fix(ublk): stop blocking tokio workers while waiting for ublk device nodes

### DIFF
--- a/storage/ublk-daemon/src/main.rs
+++ b/storage/ublk-daemon/src/main.rs
@@ -262,8 +262,17 @@ fn main() -> Result<()> {
         tracing::warn!(?err, target, "failed to raise RLIMIT_NOFILE");
     }
 
+    // Device creation does short blocking work (open/ioctl on /dev) between
+    // awaits, so a small worker pool throttles concurrent sandbox creates.
+    // Default generously and allow tuning without a rebuild.
+    let worker_threads = std::env::var("AENV_UBLK_DAEMON_WORKER_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(32);
+    tracing::info!(worker_threads, "starting ublk daemon runtime");
     let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
+        .worker_threads(worker_threads)
         .enable_all()
         .build()
         .context("build tokio runtime")?;

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -19,8 +19,8 @@ use warm_pool::{PoolConfig, PoolMaintenanceAction, WarmPool};
 
 use storage_util::io_ring::IoRingHandle;
 use uvm_ublk::{
-    delete_dev, ublk_caps, wait_for_ublk_dev, BasicCowConfig, BasicCowTarget, OverlaybdTarget,
-    UVMUblkCtrlBuilder, UVMUblkDev, UVMUblkDevBuilder, UVMUblkTarget,
+    delete_dev, ublk_caps, wait_for_ublk_dev_async, BasicCowConfig, BasicCowTarget,
+    OverlaybdTarget, UVMUblkCtrlBuilder, UVMUblkDev, UVMUblkDevBuilder, UVMUblkTarget,
 };
 
 use crate::protocol::{
@@ -773,7 +773,10 @@ async fn create_overlaybd_device(
         return Err(err);
     }
 
-    if let Err(err) = wait_for_ublk_dev(dev_id).context("wait for ublk device") {
+    if let Err(err) = wait_for_ublk_dev_async(dev_id)
+        .await
+        .context("wait for ublk device")
+    {
         cleanup_failed_ublk_start(ctrl_ring.clone(), dev).await;
         return Err(err);
     }
@@ -828,7 +831,10 @@ async fn handle_create_cow(
         cleanup_failed_ublk_start(ctrl_ring.clone(), dev).await;
         return Err(err);
     }
-    if let Err(err) = wait_for_ublk_dev(dev_id).context("wait for ublk device") {
+    if let Err(err) = wait_for_ublk_dev_async(dev_id)
+        .await
+        .context("wait for ublk device")
+    {
         cleanup_failed_ublk_start(ctrl_ring.clone(), dev).await;
         return Err(err);
     }
@@ -1609,7 +1615,10 @@ async fn create_new_device(
         cleanup_failed_ublk_start(ctrl_ring.clone(), dev).await;
         return Err(err);
     }
-    if let Err(err) = wait_for_ublk_dev(dev_id).context("wait for ublk device") {
+    if let Err(err) = wait_for_ublk_dev_async(dev_id)
+        .await
+        .context("wait for ublk device")
+    {
         cleanup_failed_ublk_start(ctrl_ring.clone(), dev).await;
         return Err(err);
     }

--- a/storage/ublk/src/lib.rs
+++ b/storage/ublk/src/lib.rs
@@ -65,36 +65,76 @@ pub async fn delete_dev(
 /// The block node can appear before udev applies its group and mode rules. A
 /// mere existence check therefore races non-root consumers such as
 /// Firecracker's snapshot memory backend.
+/// Poll schedule as `(interval_ms, retries)`, totalling ~30s.
+///
+/// The block node normally appears within about a millisecond, so poll finely
+/// first and back off afterwards. The previous schedule started at 10ms, which
+/// charged nearly every device creation a full 10ms of dead wait.
+const WAIT_SCHEDULE: [(u64, u32); 5] = [(1, 20), (5, 16), (50, 18), (500, 10), (1000, 24)];
+
+/// One non-blocking readiness probe. `Ok(true)` means the node is open-able.
+fn probe_ublk_dev(path: &Path, warned_permission: &mut bool) -> Result<bool> {
+    match std::fs::File::open(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            if !*warned_permission {
+                tracing::warn!(
+                    path = %path.display(),
+                    "ublk device is not readable yet; udev rules may still be applying"
+                );
+                *warned_permission = true;
+            }
+            Ok(false)
+        }
+        Err(error) => Err(error).with_context(|| format!("open {}", path.display())),
+    }
+}
+
+fn wait_timed_out(dev_id: u32, path: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "ublk device {dev_id} did not become accessible at {}",
+        path.display()
+    )
+}
+
+/// Blocking variant, for synchronous callers (CLI, tests).
+///
+/// Do not call this from an async task: it parks the executor thread. Use
+/// [`wait_for_ublk_dev_async`] there instead.
 pub fn wait_for_ublk_dev(dev_id: u32) -> Result<()> {
     let p = format!("/dev/ublkb{}", dev_id);
     let p = Path::new(&p);
-    // Total around 30 seconds timeout
-    let interval_ms = [10, 100, 500, 1000];
-    let retry_times = [5, 10, 10, 24];
     let mut warned_permission = false;
-    for (interval, retry) in interval_ms.into_iter().zip(retry_times) {
+    for (interval, retry) in WAIT_SCHEDULE {
         for _ in 0..retry {
-            match std::fs::File::open(p) {
-                Ok(_) => return Ok(()),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
-                    if !warned_permission {
-                        tracing::warn!(
-                            path = %p.display(),
-                            "ublk device is not readable yet; udev rules may still be applying"
-                        );
-                        warned_permission = true;
-                    }
-                }
-                Err(error) => return Err(error).with_context(|| format!("open {}", p.display())),
+            if probe_ublk_dev(p, &mut warned_permission)? {
+                return Ok(());
             }
             std::thread::sleep(Duration::from_millis(interval));
         }
     }
-    bail!(
-        "ublk device {dev_id} did not become accessible at {}",
-        p.display()
-    );
+    Err(wait_timed_out(dev_id, p))
+}
+
+/// Async variant that yields instead of parking the worker thread.
+///
+/// Device creation runs on the daemon's shared multi-thread runtime; blocking a
+/// worker here caps concurrent creations at the worker-thread count, which was
+/// the dominant limit on per-node sandbox create throughput.
+pub async fn wait_for_ublk_dev_async(dev_id: u32) -> Result<()> {
+    let p = format!("/dev/ublkb{}", dev_id);
+    let p = Path::new(&p);
+    let mut warned_permission = false;
+    for (interval, retry) in WAIT_SCHEDULE {
+        for _ in 0..retry {
+            if probe_ublk_dev(p, &mut warned_permission)? {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(interval)).await;
+        }
+    }
+    Err(wait_timed_out(dev_id, p))
 }
 
 const LOG_FORMAT_ENV: &str = "AENV_LOG_FORMAT";


### PR DESCRIPTION
## Problem

`wait_for_ublk_dev` sleeps with `std::thread::sleep` and is called from the ublk daemon's async device-creation paths **without `.await`**, parking a tokio worker for the whole wait:

```rust
// storage/ublk-daemon/src/server.rs (3 call sites)
if let Err(err) = wait_for_ublk_dev(dev_id).context("wait for ublk device") { ... }
```

The daemon runs a hardcoded 4-worker runtime (`worker_threads(4)`), so concurrent cold device creations are capped at 4, each holding its worker for at least the 10 ms first retry interval.

## Note

This PR was opened in error against a repository we do not own, and has been closed. Retained only for the discussion thread.

Per review feedback, the correct fix is to remove the wait entirely rather than make it async: after `add_dev`/`start_dev` return, `ublk_ctrl_start_dev -> device_add_disk -> device_add` has already created the device node, so there is nothing to wait for.