### PR TITLE
fix(snapshot): isolate registry publications on delete

### DIFF
--- a/src/snapshot/repository/backends/common/acr/manifest.rs
+++ b/src/snapshot/repository/backends/common/acr/manifest.rs
@@ -10,6 +10,7 @@ pub(crate) const OCI_IMAGE_CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.image.
 pub(crate) const OCI_TAR_LAYER_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar";
 const OVERLAYBD_BLOB_DIGEST_ANNOTATION: &str = "containerd.io/snapshot/overlaybd/blob-digest";
 const OVERLAYBD_BLOB_SIZE_ANNOTATION: &str = "containerd.io/snapshot/overlaybd/blob-size";
+const SNAPSHOT_TAG_ANNOTATION: &str = "io.agentenv.snapshot.tag";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -51,6 +52,7 @@ struct OciManifest {
     media_type: String,
     config: OciDescriptor,
     layers: Vec<OciDescriptor>,
+    annotations: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -106,12 +108,19 @@ pub(crate) fn minimal_oci_config_blob(
 pub(crate) fn build_oci_image_manifest(
     config: OciDescriptor,
     layers: Vec<OciDescriptor>,
+    publication_tag: &str,
 ) -> RepositoryResult<Vec<u8>> {
+    let mut annotations = BTreeMap::new();
+    annotations.insert(
+        SNAPSHOT_TAG_ANNOTATION.to_string(),
+        publication_tag.to_string(),
+    );
     let manifest = OciManifest {
         schema_version: 2,
         media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string(),
         config,
         layers,
+        annotations,
     };
     serde_json::to_vec(&manifest)
         .map_err(|e| RepositoryError::backend("serialize OCI image manifest", e))
@@ -140,6 +149,7 @@ mod tests {
         let manifest = build_oci_image_manifest(
             OciDescriptor::config("sha256:config".to_string(), 2),
             vec![layer],
+            "agentenv-snapshot-test",
         )
         .unwrap();
         let value: serde_json::Value = serde_json::from_slice(&manifest).unwrap();
@@ -159,6 +169,27 @@ mod tests {
         assert_eq!(
             value["layers"][0]["annotations"]["containerd.io/snapshot/overlaybd/blob-size"],
             "123"
+        );
+        assert_eq!(
+            value["annotations"]["io.agentenv.snapshot.tag"],
+            "agentenv-snapshot-test"
+        );
+    }
+
+    #[test]
+    fn publication_tag_makes_manifest_digest_unique() {
+        let config = OciDescriptor::config("sha256:config".to_string(), 2);
+        let layers = vec![OciDescriptor::overlaybd_layer(
+            "sha256:layer".to_string(),
+            123,
+        )];
+        let first =
+            build_oci_image_manifest(config.clone(), layers.clone(), "snapshot-first").unwrap();
+        let second = build_oci_image_manifest(config, layers, "snapshot-second").unwrap();
+
+        assert_ne!(
+            crate::digest::sha256_digest(&first),
+            crate::digest::sha256_digest(&second)
         );
     }
 }

--- a/src/snapshot/repository/backends/common/acr/publisher.rs
+++ b/src/snapshot/repository/backends/common/acr/publisher.rs
@@ -3,15 +3,13 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use tempfile::NamedTempFile;
-use tracing::warn;
-
 use crate::digest;
 use crate::snapshot::repository::backends::common::write_dense_overlaybd_layer_to_file;
 use crate::snapshot::repository::{RepositoryError, RepositoryResult};
 use crate::snapshot::{
     ExternalLayer, OverlaybdLayerRef, PersistedDiskImagePublication, SnapshotId,
 };
+use tempfile::NamedTempFile;
 
 use super::client::{AcrClient, AcrClientError};
 use super::manifest::{build_oci_image_manifest, minimal_oci_config_blob, OciDescriptor};
@@ -158,6 +156,7 @@ impl AcrDiskImageExporter {
         let manifest = build_oci_image_manifest(
             OciDescriptor::config(config_digest, config_size),
             descriptors,
+            &tag,
         )?;
         let manifest_digest = client
             .put_manifest(&manifest_url, &target.repository, manifest)
@@ -181,12 +180,12 @@ impl AcrDiskImageExporter {
         let repository_ref = match SourceRegistryRepository::parse(&publication.repo_blob_url) {
             Ok(repository_ref) => repository_ref,
             Err(error) => {
-                warn!(
-                    repo_blob_url = %publication.repo_blob_url,
-                    error = %error,
-                    "cannot roll back ACR publication with invalid repoBlobUrl"
-                );
-                return Ok(());
+                return Err(RepositoryError::InvalidRequest {
+                    reason: format!(
+                        "cannot delete ACR publication with invalid repoBlobUrl '{}': {error}",
+                        publication.repo_blob_url
+                    ),
+                });
             }
         };
         let client = self.client_for_registry(&repository_ref.registry).await?;
@@ -477,5 +476,25 @@ mod tests {
             ]
         );
         assert!(outcome.publication.is_none());
+    }
+
+    #[tokio::test]
+    async fn rollback_rejects_invalid_persisted_repository_metadata() {
+        let publisher = AcrDiskImageExporter::new_with_client_builder(Arc::new(|registry| {
+            panic!("invalid metadata must fail before creating a client for {registry}")
+        }));
+        let publication = PersistedDiskImagePublication {
+            image_ref: "invalid".to_string(),
+            tag: "agentenv-snapshot-test".to_string(),
+            manifest_digest: "sha256:manifest".to_string(),
+            repo_blob_url: "not-a-repository-url".to_string(),
+        };
+
+        let error = publisher
+            .rollback_publication(&publication)
+            .await
+            .expect_err("invalid persisted metadata must not be treated as cleaned up");
+
+        assert!(matches!(error, RepositoryError::InvalidRequest { .. }));
     }
 }

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -340,22 +340,10 @@ impl SnapshotRepository for OssSnapshotRepository {
     }
 
     async fn get(&self, id_or_alias: &str) -> RepositoryResult<Option<SnapshotRecord>> {
-        // Try by id first.
-        if let Ok(direct_id) = crate::snapshot::SnapshotId::parse(id_or_alias) {
-            if let Some(record) = self.read_record(&direct_id).await? {
-                return Ok(Some(record));
-            }
-        }
-
-        // Try by alias.
-        let resolved_id = match self.resolve_alias(id_or_alias).await {
-            Ok(id) => id,
-            Err(error) => return Err(error),
-        };
-        let Some(resolved_id) = resolved_id else {
-            return Ok(None);
-        };
-        self.read_record(&resolved_id).await
+        Ok(self
+            .read_record_by_id_or_alias(id_or_alias)
+            .await?
+            .filter(Self::is_visible_record))
     }
 
     async fn list(&self, filter: SnapshotListFilter) -> RepositoryResult<Vec<SnapshotRecord>> {
@@ -378,7 +366,9 @@ impl SnapshotRepository for OssSnapshotRepository {
             .try_collect()
             .await?;
 
-        records.retain(|record| Self::matches_record_filter(record, &filter));
+        records.retain(|record| {
+            Self::is_visible_record(record) && Self::matches_record_filter(record, &filter)
+        });
         records.sort_by(|a, b| {
             b.created_at_unix_ms
                 .cmp(&a.created_at_unix_ms)
@@ -390,25 +380,39 @@ impl SnapshotRepository for OssSnapshotRepository {
 
     async fn delete(&self, id_or_alias: &str) -> RepositoryResult<()> {
         // Resolve the actual id + metadata.
-        let record = match self.get(id_or_alias).await? {
+        let mut record = match self.read_record_by_id_or_alias(id_or_alias).await? {
             Some(t) => t,
             None => return Ok(()), // Idempotent.
         };
-        let id = &record.id;
-        let layout = self.layout(id);
+        let id = record.id.clone();
+        let layout = self.layout(&id);
 
-        // 1. Delete external publications while the durable record still
-        // contains the metadata required to retry cleanup. Manifest deletion
-        // treats 404 as success, so a partially completed cleanup is safe to
-        // retry.
+        // 1. Hide the snapshot durably before removing anything external.
+        // The tombstoned record retains publication metadata for retries, while
+        // get/list no longer expose a snapshot that may be partially deleted.
+        if !record.deleting {
+            record.mark_deleting(now_unix_ms());
+            self.write_record(&record).await?;
+        }
+
+        // 2. Delete external publications. Manifest deletion treats 404 as
+        // success, so a partially completed cleanup is safe to retry by id or
+        // alias while the tombstone remains durable.
         if let Some(committed) = record.committed.as_ref() {
-            self.delete_disk_publications(id, &committed.disk_publications)
+            self.delete_disk_publications(&id, &committed.disk_publications)
                 .await?;
         }
 
-        // 2. Delete alias binding.
+        // 3. Delete the catalog record. Until this succeeds, the alias remains
+        // available as a retry handle but resolves to an invisible tombstone.
+        self.client
+            .delete(&OssSnapshotArtifactLayout::record_key(&id))
+            .await
+            .map_err(|e| RepositoryError::backend("delete snapshot record from oss", e))?;
+
+        // 4. Delete alias binding.
         if let Some(ref alias) = record.alias {
-            if self.load_alias_target(alias.as_ref()).await?.as_ref() == Some(id) {
+            if self.load_alias_target(alias.as_ref()).await?.as_ref() == Some(&id) {
                 if let Err(error) = self
                     .client
                     .delete(&OssSnapshotArtifactLayout::alias_key(alias.as_ref()))
@@ -419,13 +423,7 @@ impl SnapshotRepository for OssSnapshotRepository {
             }
         }
 
-        // 3. Delete the catalog record.
-        self.client
-            .delete(&OssSnapshotArtifactLayout::record_key(id))
-            .await
-            .map_err(|e| RepositoryError::backend("delete snapshot record from oss", e))?;
-
-        // 4. Delete artifacts.
+        // 5. Delete artifacts.
         if let Err(error) = self.client.delete_prefix(&layout.artifact_prefix()).await {
             warn!(snapshot_id = %id, error = %error, "failed to delete oss snapshot artifacts");
         }
@@ -447,14 +445,19 @@ impl SnapshotRepository for OssSnapshotRepository {
         let id: SnapshotId = serde_json::from_slice(&data)
             .map_err(|e| RepositoryError::backend(format!("parse alias '{alias}'"), e))?;
 
-        // Stale-alias cleanup: if the snapshot record doesn't exist, delete the alias
-        // and return None (mirrors PosixFs catalog.rs:236 behavior).
-        let snapshot_exists = self.snapshot_exists(&id).await?;
-        if !snapshot_exists {
+        // Stale-alias cleanup: if the snapshot record doesn't exist, delete the
+        // alias and return None (mirrors PosixFs catalog.rs:236 behavior).
+        // Tombstoned records remain durable for deletion retries but are not
+        // exposed through public alias resolution.
+        let record = self.read_record(&id).await?;
+        if record.is_none() {
             warn!(alias = %alias, snapshot_id = %id, "cleaning up stale alias pointing to missing snapshot");
             if let Err(error) = self.client.delete(&key).await {
                 warn!(alias = %alias, snapshot_id = %id, error = %error, "failed to delete stale oss alias");
             }
+            return Ok(None);
+        }
+        if record.is_some_and(|record| record.deleting) {
             return Ok(None);
         }
 
@@ -515,6 +518,26 @@ impl SnapshotRepository for OssSnapshotRepository {
 // ── private helpers ────────────────────────────────────────────────────
 
 impl OssSnapshotRepository {
+    fn is_visible_record(record: &SnapshotRecord) -> bool {
+        !record.deleting
+    }
+
+    async fn read_record_by_id_or_alias(
+        &self,
+        id_or_alias: &str,
+    ) -> RepositoryResult<Option<SnapshotRecord>> {
+        if let Ok(direct_id) = SnapshotId::parse(id_or_alias) {
+            if let Some(record) = self.read_record(&direct_id).await? {
+                return Ok(Some(record));
+            }
+        }
+
+        let Some(resolved_id) = self.load_alias_target(id_or_alias).await? else {
+            return Ok(None);
+        };
+        self.read_record(&resolved_id).await
+    }
+
     async fn read_record(&self, id: &SnapshotId) -> RepositoryResult<Option<SnapshotRecord>> {
         let key = OssSnapshotArtifactLayout::record_key(id);
         match self.client.get_bytes(&key).await {
@@ -571,6 +594,7 @@ impl OssSnapshotRepository {
                 resources,
                 created_at_unix_ms: now,
                 updated_at_unix_ms: now,
+                deleting: false,
                 committed: Some(committed),
             }
         };
@@ -1193,6 +1217,15 @@ mod tests {
         )
         .expect("oss client");
         OssSnapshotRepository::new(Arc::new(client), SnapshotImageStoragePolicy::ObjectStorage)
+    }
+
+    #[test]
+    fn deleting_records_are_hidden_from_readers() {
+        let mut record = SnapshotRecord::mock_ready(CommittedSnapshot::mock());
+        assert!(OssSnapshotRepository::is_visible_record(&record));
+
+        record.mark_deleting(1);
+        assert!(!OssSnapshotRepository::is_visible_record(&record));
     }
 
     #[test]

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -397,7 +397,16 @@ impl SnapshotRepository for OssSnapshotRepository {
         let id = &record.id;
         let layout = self.layout(id);
 
-        // 1. Delete alias binding.
+        // 1. Delete external publications while the durable record still
+        // contains the metadata required to retry cleanup. Manifest deletion
+        // treats 404 as success, so a partially completed cleanup is safe to
+        // retry.
+        if let Some(committed) = record.committed.as_ref() {
+            self.delete_disk_publications(id, &committed.disk_publications)
+                .await?;
+        }
+
+        // 2. Delete alias binding.
         if let Some(ref alias) = record.alias {
             if self.load_alias_target(alias.as_ref()).await?.as_ref() == Some(id) {
                 if let Err(error) = self
@@ -410,17 +419,11 @@ impl SnapshotRepository for OssSnapshotRepository {
             }
         }
 
-        // 2. Delete the catalog record.
+        // 3. Delete the catalog record.
         self.client
             .delete(&OssSnapshotArtifactLayout::record_key(id))
             .await
             .map_err(|e| RepositoryError::backend("delete snapshot record from oss", e))?;
-
-        // 3. Delete external disk publications on a best-effort basis.
-        if let Some(committed) = record.committed.as_ref() {
-            self.delete_disk_publications(id, &committed.disk_publications)
-                .await;
-        }
 
         // 4. Delete artifacts.
         if let Err(error) = self.client.delete_prefix(&layout.artifact_prefix()).await {
@@ -840,18 +843,20 @@ impl OssSnapshotRepository {
         &self,
         snapshot_id: &SnapshotId,
         publications: &[PersistedDiskImagePublication],
-    ) {
+    ) -> RepositoryResult<()> {
         for publication in publications.iter().rev() {
-            if let Err(error) = self.acr_exporter.rollback_publication(publication).await {
-                warn!(
-                    snapshot_id = %snapshot_id,
-                    image_ref = %publication.image_ref,
-                    manifest_digest = %publication.manifest_digest,
-                    error = %error,
-                    "failed to delete ACR publication during snapshot removal; continuing OSS cleanup"
-                );
-            }
+            self.acr_exporter
+                .rollback_publication(publication)
+                .await
+                .map_err(|error| RepositoryError::Backend {
+                    message: format!(
+                        "delete ACR publication '{}' for snapshot '{}'",
+                        publication.image_ref, snapshot_id
+                    ),
+                    source: Some(anyhow::Error::from(error)),
+                })?;
         }
+        Ok(())
     }
 
     /// Export attached-drive disk images and derive committed metadata.

--- a/src/snapshot/repository/backends/posixfs/catalog.rs
+++ b/src/snapshot/repository/backends/posixfs/catalog.rs
@@ -688,6 +688,7 @@ impl PosixFsCatalogStore {
             resources,
             created_at_unix_ms: now_unix_ms,
             updated_at_unix_ms: now_unix_ms,
+            deleting: false,
             committed: Some(committed),
         })
     }

--- a/src/snapshot/repository/interfaces.rs
+++ b/src/snapshot/repository/interfaces.rs
@@ -154,6 +154,10 @@ pub trait SnapshotRepository: Send + Sync {
     ///
     /// For committed records, implementations should also remove per-snapshot committed artifacts and
     /// any alias binding that still points at the deleted id.
+    ///
+    /// Backends that remove externally referenced publications before the
+    /// catalog record must first persist a reader-invisible tombstone while
+    /// retaining enough metadata to retry interrupted cleanup.
     async fn delete(&self, id_or_alias: &str) -> RepositoryResult<()>;
 
     /// Resolves a human-readable alias to the current snapshot id.

--- a/src/snapshot/types/snapshot.rs
+++ b/src/snapshot/types/snapshot.rs
@@ -328,6 +328,10 @@ pub struct SnapshotRecord {
     pub resources: SandboxResources,
     pub created_at_unix_ms: i64,
     pub updated_at_unix_ms: i64,
+    /// Durable tombstone set before external publication cleanup starts.
+    /// Tombstoned records retain retry metadata but are hidden from readers.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub deleting: bool,
     pub committed: Option<CommittedSnapshot>,
 }
 
@@ -347,6 +351,7 @@ impl SnapshotRecord {
             resources,
             created_at_unix_ms: now_unix_ms,
             updated_at_unix_ms: now_unix_ms,
+            deleting: false,
             committed: None,
         }
     }
@@ -373,6 +378,11 @@ impl SnapshotRecord {
         self.committed = Some(committed);
     }
 
+    pub fn mark_deleting(&mut self, now_unix_ms: i64) {
+        self.deleting = true;
+        self.updated_at_unix_ms = now_unix_ms;
+    }
+
     #[cfg(test)]
     pub fn mock_ready(committed: CommittedSnapshot) -> Self {
         Self {
@@ -389,9 +399,14 @@ impl SnapshotRecord {
             resources: SandboxResources::default(),
             created_at_unix_ms: 0,
             updated_at_unix_ms: 0,
+            deleting: false,
             committed: Some(committed),
         }
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 fn now_unix_ms() -> i64 {
@@ -572,6 +587,22 @@ mod tests {
             .runtime_versions
             .tools_drive_version
             .is_empty());
+    }
+
+    #[test]
+    fn snapshot_deleting_tombstone_is_backward_compatible_and_persisted() {
+        let record = SnapshotRecord::mock_ready(CommittedSnapshot::mock());
+        let legacy = serde_json::to_value(&record).expect("serialize snapshot record");
+        assert!(legacy.get("deleting").is_none());
+
+        let mut restored: SnapshotRecord =
+            serde_json::from_value(legacy).expect("deserialize legacy snapshot record");
+        assert!(!restored.deleting);
+
+        restored.mark_deleting(123);
+        let tombstone = serde_json::to_value(&restored).expect("serialize tombstone");
+        assert_eq!(tombstone["deleting"], true);
+        assert_eq!(tombstone["updated_at_unix_ms"], 123);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add the exact snapshot publication tag to the top-level OCI manifest annotations;
- make rootfs and attached-drive manifest digests publication-specific while preserving layer and config blob deduplication;
- delete external registry publications before removing the durable OSS catalog record;
- persist a reader-invisible deletion tombstone before external cleanup;
- keep publication metadata and alias retry handles available when cleanup fails;
- reject invalid persisted `repoBlobUrl` metadata instead of treating cleanup as successful.

## Motivation

OCI registries delete manifests by content digest. Previously, two snapshot
publications with the same config and OverlayBD layer descriptors produced the
same manifest bytes and digest. Deleting either publication by digest could
therefore invalidate tags owned by another snapshot.

The manifest now includes:

```json
{
  "annotations": {
    "io.agentenv.snapshot.tag": "agentenv-snapshot-<snapshot-id>"
  }
}
```

Attached drives use their complete generated publication tag. Only the small
manifest object becomes unique; config and layer blobs remain content-addressed
and shared.

## Deletion semantics

Before external cleanup begins, the OSS record is durably marked `deleting`.
Public `get`, `list`, and alias resolution hide this tombstone, while internal
deletion lookup retains access by ID or alias to the publication metadata
needed for retry. Manifest deletion already treats registry `404 Not Found` as
success, so retries after partially completed cleanup remain idempotent.

If external cleanup fails, the alias, tombstoned catalog record, and snapshot
artifacts are retained. The alias is removed only after external cleanup and
catalog deletion succeed.

## Verification

Validated on an Alibaba Cloud Linux 3 node with Rust 1.97.1:

```text
cargo fmt --all -- --check
cargo test -p agentenv snapshot::repository::backends::common::acr::manifest::tests
cargo test -p agentenv snapshot::repository::backends::common::acr::publisher::tests
cargo test -p agentenv deleting
cargo clippy -p agentenv --all-targets -- -D warnings
```

The new tests verify that identical layers with different publication tags
produce different manifest digests, invalid persisted repository metadata fails
cleanup, legacy records deserialize without a tombstone, and deleting records
are hidden from readers.

Fixes #16.
