### PR TITLE
fix(orchestrator): resume sandboxes after recoverable pause failures

### DIFF
--- a/src/orchestrator/proxy.rs
+++ b/src/orchestrator/proxy.rs
@@ -21,6 +21,7 @@ pub enum ProxyLookupResult {
 pub(crate) struct ProxyRoute {
     target: ProxyTarget,
     version: u64,
+    ready: bool,
     updated_at: SystemTime,
 }
 
@@ -42,6 +43,16 @@ impl ProxyRoute {
         Self {
             target,
             version,
+            ready: true,
+            updated_at: SystemTime::now(),
+        }
+    }
+
+    pub fn pending_validation(target: ProxyTarget, version: u64) -> Self {
+        Self {
+            target,
+            version,
+            ready: false,
             updated_at: SystemTime::now(),
         }
     }
@@ -52,6 +63,14 @@ impl ProxyRoute {
 
     pub fn version(&self) -> u64 {
         self.version
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.ready
+    }
+
+    pub fn mark_ready(&mut self) {
+        self.ready = true;
     }
 
     pub fn updated_at(&self) -> SystemTime {
@@ -71,8 +90,32 @@ impl ProxyRouteTable {
         route
     }
 
+    pub fn upsert_pending_validation(
+        &mut self,
+        sandbox_id: SandboxId,
+        target: ProxyTarget,
+        version: u64,
+    ) -> ProxyRoute {
+        let route = ProxyRoute::pending_validation(target, version);
+        self.routes.insert(sandbox_id, route.clone());
+        route
+    }
+
     pub fn remove(&mut self, sandbox_id: &SandboxId) -> Option<ProxyRoute> {
         self.routes.remove(sandbox_id)
+    }
+
+    pub fn mark_ready_if_version(
+        &mut self,
+        sandbox_id: &SandboxId,
+        expected_version: u64,
+    ) -> Option<ProxyRoute> {
+        let route = self.routes.get_mut(sandbox_id)?;
+        if route.version() != expected_version {
+            return None;
+        }
+        route.mark_ready();
+        Some(route.clone())
     }
 
     #[cfg(test)]
@@ -115,5 +158,23 @@ mod tests {
 
         assert!(!table.routes.contains_key(&sandbox_id));
         assert!(table.proxy_target(&sandbox_id).is_none());
+    }
+
+    #[test]
+    fn pending_route_becomes_ready_only_for_matching_version() {
+        let sandbox_id = SandboxId::new();
+        let target = ProxyTarget::new(Ipv4Addr::LOCALHOST);
+        let mut table = ProxyRouteTable::default();
+
+        table.upsert_pending_validation(sandbox_id, target.clone(), 7);
+        assert!(!table.route(&sandbox_id).unwrap().is_ready());
+        assert!(table.mark_ready_if_version(&sandbox_id, 6).is_none());
+        assert!(!table.route(&sandbox_id).unwrap().is_ready());
+
+        let route = table
+            .mark_ready_if_version(&sandbox_id, 7)
+            .expect("matching pending route should become ready");
+        assert!(route.is_ready());
+        assert_eq!(route.target(), &target);
     }
 }

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -36,6 +36,12 @@ use super::{OrchestratorError, Result, SandboxForkOutcome, SandboxOperation};
 
 type SandboxHandle = Arc<Mutex<Box<dyn SandboxBackend>>>;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LifecycleOperationKind {
+    Delete,
+    Pause,
+}
+
 /// Maximum time to wait for a sandbox to leave a transitional state.
 /// Guards against indefinite blocking when a sandbox's in-progress operation
 /// never completes (e.g. the task holding the state panics without rolling back).
@@ -94,7 +100,7 @@ pub struct Orchestrator<
     store: S,
     factory: F,
     persister: P,
-    lifecycle_operations: Mutex<HashMap<SandboxId, Arc<Mutex<()>>>>,
+    lifecycle_operations: Mutex<HashMap<SandboxId, Arc<Mutex<LifecycleOperationKind>>>>,
     sandboxes: RwLock<HashMap<SandboxId, SandboxHandle>>,
     proxy_routes: RwLock<ProxyRouteTable>,
     next_proxy_route_version: AtomicU64,
@@ -248,13 +254,34 @@ where
         })?
     }
 
-    async fn lifecycle_operation_lock(&self, sandbox_id: SandboxId) -> Arc<Mutex<()>> {
+    async fn lifecycle_operation_lock(
+        &self,
+        sandbox_id: SandboxId,
+        operation: LifecycleOperationKind,
+    ) -> (Arc<Mutex<LifecycleOperationKind>>, bool) {
         let mut operations = self.lifecycle_operations.lock().await;
-        Arc::clone(
+        let already_existed = operations.contains_key(&sandbox_id);
+        let operation_lock = Arc::clone(
             operations
                 .entry(sandbox_id)
-                .or_insert_with(|| Arc::new(Mutex::new(()))),
-        )
+                .or_insert_with(|| Arc::new(Mutex::new(operation))),
+        );
+        (operation_lock, already_existed)
+    }
+
+    async fn retire_lifecycle_operation_lock(
+        &self,
+        sandbox_id: SandboxId,
+        operation_lock: &Arc<Mutex<LifecycleOperationKind>>,
+    ) {
+        let mut operations = self.lifecycle_operations.lock().await;
+        if Arc::strong_count(operation_lock) == 2
+            && operations
+                .get(&sandbox_id)
+                .is_some_and(|current| Arc::ptr_eq(current, operation_lock))
+        {
+            operations.remove(&sandbox_id);
+        }
     }
 
     async fn protect_image_refs(
@@ -275,22 +302,43 @@ where
         self.image_refs.unpin_best_effort(owner).await;
     }
 
+    async fn retain_sandbox_handle_for_cleanup(
+        &self,
+        sandbox_id: SandboxId,
+        handle: SandboxHandle,
+    ) -> std::result::Result<(), StoreError> {
+        match self
+            .store
+            .update_state_if_state(&sandbox_id, SandboxState::Killing, &[SandboxState::Pausing])
+            .await
+        {
+            Ok(_)
+            | Err(StoreError::StateConflict {
+                actual_state: SandboxState::Killing,
+                ..
+            }) => {
+                self.sandboxes.write().await.insert(sandbox_id, handle);
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+
     async fn remove_stopped_sandbox_or_retain_handle(
         &self,
         sandbox_id: SandboxId,
         handle: SandboxHandle,
-    ) -> Option<StoreError> {
-        let cleanup_error = self.store.remove(&sandbox_id).await.err();
-        if cleanup_error.is_some() {
-            // Killing is a stable, explicitly retryable cleanup state. A later
-            // delete can claim the retained handle and retry metadata removal.
-            let _ = self
-                .store
-                .update_state_if_state(&sandbox_id, SandboxState::Killing, &[SandboxState::Pausing])
-                .await;
-            self.sandboxes.write().await.insert(sandbox_id, handle);
+    ) -> Option<anyhow::Error> {
+        let cleanup_error = self.store.remove(&sandbox_id).await.err()?;
+        match self
+            .retain_sandbox_handle_for_cleanup(sandbox_id, handle)
+            .await
+        {
+            Ok(()) => Some(cleanup_error.into()),
+            Err(state_error) => Some(anyhow::anyhow!(
+                "metadata cleanup error: {cleanup_error}; cleanup state error: {state_error}"
+            )),
         }
-        cleanup_error
     }
 
     /// Snapshot the running set's local runtime artifacts for maintenance.
@@ -855,11 +903,28 @@ where
     async fn delete_sandbox_inner(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         info!("deleting sandbox");
 
+        let (operation_lock, cleanup_already_in_flight) = self
+            .lifecycle_operation_lock(sandbox_id, LifecycleOperationKind::Delete)
+            .await;
+        let mut operation_guard = operation_lock.lock().await;
+        *operation_guard = LifecycleOperationKind::Delete;
+        let result = self
+            .delete_sandbox_owned_inner(sandbox_id, cleanup_already_in_flight)
+            .await;
+        drop(operation_guard);
+        self.retire_lifecycle_operation_lock(sandbox_id, &operation_lock)
+            .await;
+        result
+    }
+
+    async fn delete_sandbox_owned_inner(
+        self: &Arc<Self>,
+        sandbox_id: SandboxId,
+        cleanup_already_in_flight: bool,
+    ) -> Result<()> {
         // Attempt to transition to Killing, retrying after waiting whenever we
         // find the sandbox in a transitional state.
-        let operation_lock = self.lifecycle_operation_lock(sandbox_id).await;
-        let (previous_state, operation_guard) = loop {
-            let operation_guard = operation_lock.lock().await;
+        let previous_state = loop {
             match self
                 .store
                 .update_state_if_state(
@@ -873,14 +938,14 @@ where
                 )
                 .await
             {
-                Ok(previous_state) => break (previous_state, operation_guard),
+                Ok(previous_state) => break previous_state,
                 Err(StoreError::StateConflict { actual_state, .. }) => match actual_state {
                     SandboxState::Killing => {
                         // Cleanup ownership for this sandbox is serialized.
                         // Reaching Killing here means a previous cleanup attempt
                         // completed and left retryable work.
                         debug!("retrying sandbox cleanup from killing state");
-                        break (SandboxState::Killing, operation_guard);
+                        break SandboxState::Killing;
                     }
                     SandboxState::Creating
                     | SandboxState::Snapshotting
@@ -893,7 +958,6 @@ where
                             state = ?actual_state,
                             "sandbox in transitional state, waiting before deletion"
                         );
-                        drop(operation_guard);
                         match self.wait_for_transition(sandbox_id, actual_state).await {
                             Ok(_) => {
                                 // Transition finished; retry the Killing CAS.
@@ -909,7 +973,6 @@ where
                         }
                     }
                     _ => {
-                        drop(operation_guard);
                         return Err(OrchestratorError::from(StoreError::StateConflict {
                             sandbox_id,
                             expected_states: vec![
@@ -921,8 +984,11 @@ where
                         }));
                     }
                 },
+                Err(StoreError::SandboxNotFound { .. }) if cleanup_already_in_flight => {
+                    info!("sandbox was deleted by a concurrent cleanup");
+                    return Ok(());
+                }
                 Err(err) => {
-                    drop(operation_guard);
                     return Err(OrchestratorError::from(err));
                 }
             }
@@ -977,8 +1043,6 @@ where
         }
         self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
             .await;
-        drop(operation_guard);
-        self.lifecycle_operations.lock().await.remove(&sandbox_id);
         info!("sandbox deleted");
 
         Ok(())
@@ -1031,6 +1095,34 @@ where
         fields(sandbox_id = %sandbox_id)
     )]
     async fn pause_sandbox_inner(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
+        let (operation_lock, _) = self
+            .lifecycle_operation_lock(sandbox_id, LifecycleOperationKind::Pause)
+            .await;
+        let operation_guard = match operation_lock.try_lock() {
+            Ok(mut operation_guard) => {
+                *operation_guard = LifecycleOperationKind::Pause;
+                operation_guard
+            }
+            Err(_) => {
+                let mut operation_guard = operation_lock.lock().await;
+                if *operation_guard == LifecycleOperationKind::Pause {
+                    drop(operation_guard);
+                    self.retire_lifecycle_operation_lock(sandbox_id, &operation_lock)
+                        .await;
+                    return self.join_concurrent_pause(sandbox_id).await;
+                }
+                *operation_guard = LifecycleOperationKind::Pause;
+                operation_guard
+            }
+        };
+        let result = self.pause_sandbox_owned_inner(sandbox_id).await;
+        drop(operation_guard);
+        self.retire_lifecycle_operation_lock(sandbox_id, &operation_lock)
+            .await;
+        result
+    }
+
+    async fn pause_sandbox_owned_inner(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         info!("pausing sandbox");
         match self
             .store
@@ -1059,8 +1151,6 @@ where
             }
             Err(err) => return Err(OrchestratorError::from(err)),
         }
-        let operation_lock = self.lifecycle_operation_lock(sandbox_id).await;
-        let _operation_guard = operation_lock.lock().await;
 
         // Pin paused runtime artifacts before detaching from the running set.
         let runtime_artifacts = {
@@ -1137,34 +1227,54 @@ where
                             // Proxy lookup gates routes on Running metadata, and
                             // lifecycle operations for this sandbox are serialized,
                             // so the final CAS makes the restored runtime visible.
-                            let restore_result = {
+                            let restored_route_version = {
                                 let mut sandboxes = self.sandboxes.write().await;
-                                let mut proxy_routes = self.proxy_routes.write().await;
                                 sandboxes.insert(sandbox_id, Arc::clone(&handle));
+                                drop(sandboxes);
+
                                 if let Some(route) = removed_proxy_route.as_ref() {
                                     let version = self
                                         .next_proxy_route_version
                                         .fetch_add(1, Ordering::Relaxed);
-                                    proxy_routes.upsert(
+                                    self.proxy_routes.write().await.upsert(
                                         sandbox_id,
                                         route.target().clone(),
                                         version,
                                     );
+                                    Some(version)
+                                } else {
+                                    None
                                 }
-                                let result = self
-                                    .store
-                                    .update_state_if_state(
-                                        &sandbox_id,
-                                        SandboxState::Running,
-                                        &[SandboxState::Pausing],
-                                    )
-                                    .await;
-                                if result.is_err() {
-                                    sandboxes.remove(&sandbox_id);
-                                    proxy_routes.remove(&sandbox_id);
-                                }
-                                result.map(|_| ())
                             };
+                            let restore_result = self
+                                .store
+                                .update_state_if_state(
+                                    &sandbox_id,
+                                    SandboxState::Running,
+                                    &[SandboxState::Pausing],
+                                )
+                                .await
+                                .map(|_| ());
+                            if restore_result.is_err() {
+                                let mut sandboxes = self.sandboxes.write().await;
+                                if sandboxes
+                                    .get(&sandbox_id)
+                                    .is_some_and(|current| Arc::ptr_eq(current, &handle))
+                                {
+                                    sandboxes.remove(&sandbox_id);
+                                }
+                                drop(sandboxes);
+
+                                if let Some(version) = restored_route_version {
+                                    let mut proxy_routes = self.proxy_routes.write().await;
+                                    if proxy_routes
+                                        .route(&sandbox_id)
+                                        .is_some_and(|route| route.version() == version)
+                                    {
+                                        proxy_routes.remove(&sandbox_id);
+                                    }
+                                }
+                            }
 
                             match restore_result {
                                 Ok(()) => (err.into(), true),
@@ -1204,24 +1314,28 @@ where
                                                 error = ?stop_err,
                                                 "failed to stop sandbox after state recovery failure"
                                             );
-                                            self.sandboxes.write().await.insert(sandbox_id, handle);
-                                            let _ = self
-                                                .store
-                                                .update_state_if_state(
-                                                    &sandbox_id,
-                                                    SandboxState::Killing,
-                                                    &[SandboxState::Pausing],
+                                            let cleanup_state_error = self
+                                                .retain_sandbox_handle_for_cleanup(
+                                                    sandbox_id, handle,
                                                 )
                                                 .await;
-                                            (
-                                                anyhow::anyhow!(
+                                            let source = match cleanup_state_error {
+                                                Ok(()) => anyhow::anyhow!(
                                                     "pause failed, Running state could not be \
                                                      restored, and sandbox could not be stopped: \
                                                      pause error: {err}; state error: \
                                                      {restore_err}; stop error: {stop_err:#}"
                                                 ),
-                                                false,
-                                            )
+                                                Err(cleanup_state_err) => anyhow::anyhow!(
+                                                    "pause failed, Running state could not be \
+                                                     restored, sandbox could not be stopped, and \
+                                                     cleanup state could not be established: pause \
+                                                     error: {err}; state error: {restore_err}; stop \
+                                                     error: {stop_err}; cleanup state error: \
+                                                     {cleanup_state_err}"
+                                                ),
+                                            };
+                                            (source, false)
                                         }
                                     }
                                 }
@@ -1262,23 +1376,23 @@ where
                                     // The backend may still own live resources.
                                     // Keep its handle in a stable cleanup state so
                                     // a later delete can retry stopping it.
-                                    self.sandboxes.write().await.insert(sandbox_id, handle);
-                                    let _ = self
-                                        .store
-                                        .update_state_if_state(
-                                            &sandbox_id,
-                                            SandboxState::Killing,
-                                            &[SandboxState::Pausing],
-                                        )
+                                    let cleanup_state_error = self
+                                        .retain_sandbox_handle_for_cleanup(sandbox_id, handle)
                                         .await;
-                                    (
-                                        anyhow::anyhow!(
+                                    let source = match cleanup_state_error {
+                                        Ok(()) => anyhow::anyhow!(
                                             "pause failed, sandbox could not be resumed, and \
                                              sandbox could not be stopped: pause error: {err}; \
                                              resume error: {resume_err}; stop error: {stop_err:#}"
                                         ),
-                                        false,
-                                    )
+                                        Err(cleanup_state_err) => anyhow::anyhow!(
+                                            "pause failed, sandbox could not be resumed or stopped, \
+                                             and cleanup state could not be established: pause \
+                                             error: {err}; resume error: {resume_err}; stop error: \
+                                             {stop_err}; cleanup state error: {cleanup_state_err}"
+                                        ),
+                                    };
+                                    (source, false)
                                 }
                             }
                         }

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -94,6 +94,7 @@ pub struct Orchestrator<
     store: S,
     factory: F,
     persister: P,
+    lifecycle_operations: Mutex<HashMap<SandboxId, Arc<Mutex<()>>>>,
     sandboxes: RwLock<HashMap<SandboxId, SandboxHandle>>,
     proxy_routes: RwLock<ProxyRouteTable>,
     next_proxy_route_version: AtomicU64,
@@ -176,6 +177,7 @@ where
             store,
             factory,
             persister,
+            lifecycle_operations: Mutex::new(HashMap::new()),
             sandboxes: RwLock::new(HashMap::new()),
             proxy_routes: RwLock::new(ProxyRouteTable::default()),
             next_proxy_route_version: AtomicU64::new(1),
@@ -246,6 +248,15 @@ where
         })?
     }
 
+    async fn lifecycle_operation_lock(&self, sandbox_id: SandboxId) -> Arc<Mutex<()>> {
+        let mut operations = self.lifecycle_operations.lock().await;
+        Arc::clone(
+            operations
+                .entry(sandbox_id)
+                .or_insert_with(|| Arc::new(Mutex::new(()))),
+        )
+    }
+
     async fn protect_image_refs(
         &self,
         owner: RuntimeImageOwner,
@@ -262,6 +273,24 @@ where
 
     async fn release_image_refs(&self, owner: RuntimeImageOwner) {
         self.image_refs.unpin_best_effort(owner).await;
+    }
+
+    async fn remove_stopped_sandbox_or_retain_handle(
+        &self,
+        sandbox_id: SandboxId,
+        handle: SandboxHandle,
+    ) -> Option<StoreError> {
+        let cleanup_error = self.store.remove(&sandbox_id).await.err();
+        if cleanup_error.is_some() {
+            // Killing is a stable, explicitly retryable cleanup state. A later
+            // delete can claim the retained handle and retry metadata removal.
+            let _ = self
+                .store
+                .update_state_if_state(&sandbox_id, SandboxState::Killing, &[SandboxState::Pausing])
+                .await;
+            self.sandboxes.write().await.insert(sandbox_id, handle);
+        }
+        cleanup_error
     }
 
     /// Snapshot the running set's local runtime artifacts for maintenance.
@@ -681,14 +710,6 @@ where
     /// Resolves the current proxyability of a sandbox without touching the sandbox mutex.
     #[tracing::instrument(skip(self), fields(sandbox_id = %sandbox_id))]
     pub async fn proxy_lookup_for(&self, sandbox_id: &SandboxId) -> Result<ProxyLookupResult> {
-        if let Some(route) = self.proxy_routes.read().await.route(sandbox_id).cloned() {
-            trace!(
-                version = route.version(),
-                "resolved running proxy target from runtime table"
-            );
-            return Ok(ProxyLookupResult::Ready(route.target().clone()));
-        }
-
         let metadata = self.store.get(sandbox_id).await?;
         Ok(match metadata {
             None => {
@@ -696,8 +717,19 @@ where
                 ProxyLookupResult::NotFound
             }
             Some(metadata) if metadata.state == SandboxState::Running => {
-                warn!("running sandbox is missing a runtime proxy route");
-                ProxyLookupResult::RouteMissing
+                match self.proxy_routes.read().await.route(sandbox_id).cloned() {
+                    Some(route) => {
+                        trace!(
+                            version = route.version(),
+                            "resolved running proxy target from runtime table"
+                        );
+                        ProxyLookupResult::Ready(route.target().clone())
+                    }
+                    None => {
+                        warn!("running sandbox is missing a runtime proxy route");
+                        ProxyLookupResult::RouteMissing
+                    }
+                }
             }
             Some(metadata) if metadata.state == SandboxState::Paused => {
                 debug!(auto_resume = metadata.auto_resume, "sandbox is paused");
@@ -825,41 +857,34 @@ where
 
         // Attempt to transition to Killing, retrying after waiting whenever we
         // find the sandbox in a transitional state.
-        let previous_state = loop {
+        let operation_lock = self.lifecycle_operation_lock(sandbox_id).await;
+        let (previous_state, operation_guard) = loop {
+            let operation_guard = operation_lock.lock().await;
             match self
                 .store
                 .update_state_if_state(
                     &sandbox_id,
                     SandboxState::Killing,
-                    &[SandboxState::Running, SandboxState::Paused],
+                    &[
+                        SandboxState::Running,
+                        SandboxState::Paused,
+                        SandboxState::Pausing,
+                    ],
                 )
                 .await
             {
-                Ok(previous_state) => break previous_state,
+                Ok(previous_state) => break (previous_state, operation_guard),
                 Err(StoreError::StateConflict { actual_state, .. }) => match actual_state {
                     SandboxState::Killing => {
-                        debug!("sandbox already in killing state, waiting for delete to finish");
-                        match self
-                            .wait_for_transition(sandbox_id, SandboxState::Killing)
-                            .await
-                        {
-                            Ok(_) => {
-                                // The in-flight delete rolled back to a stable state.
-                                // Retry the Killing CAS rather than letting multiple
-                                // deleters run concurrently.
-                                continue;
-                            }
-                            Err(OrchestratorError::SandboxNotFound(_)) => {
-                                info!("sandbox was deleted by a concurrent delete");
-                                return Ok(());
-                            }
-                            Err(e) => return Err(e),
-                        }
+                        // Cleanup ownership for this sandbox is serialized.
+                        // Reaching Killing here means a previous cleanup attempt
+                        // completed and left retryable work.
+                        debug!("retrying sandbox cleanup from killing state");
+                        break (SandboxState::Killing, operation_guard);
                     }
                     SandboxState::Creating
                     | SandboxState::Snapshotting
                     | SandboxState::Forking
-                    | SandboxState::Pausing
                     | SandboxState::Resuming => {
                         // An in-progress operation is currently holding the sandbox in this
                         // transitional state.  Wait for it to finish so our Killing transition
@@ -868,6 +893,7 @@ where
                             state = ?actual_state,
                             "sandbox in transitional state, waiting before deletion"
                         );
+                        drop(operation_guard);
                         match self.wait_for_transition(sandbox_id, actual_state).await {
                             Ok(_) => {
                                 // Transition finished; retry the Killing CAS.
@@ -883,14 +909,22 @@ where
                         }
                     }
                     _ => {
+                        drop(operation_guard);
                         return Err(OrchestratorError::from(StoreError::StateConflict {
                             sandbox_id,
-                            expected_states: vec![SandboxState::Running, SandboxState::Paused],
+                            expected_states: vec![
+                                SandboxState::Running,
+                                SandboxState::Paused,
+                                SandboxState::Pausing,
+                            ],
                             actual_state,
                         }));
                     }
                 },
-                Err(err) => return Err(OrchestratorError::from(err)),
+                Err(err) => {
+                    drop(operation_guard);
+                    return Err(OrchestratorError::from(err));
+                }
             }
         };
 
@@ -906,10 +940,16 @@ where
             if let Err(err) = stop_result {
                 warn!(error = ?err, "failed to stop sandbox during delete");
                 self.sandboxes.write().await.insert(sandbox_id, handle);
-                self.restore_proxy_route(sandbox_id, removed_route).await;
-                self.store
-                    .update_state_if_state(&sandbox_id, previous_state, &[SandboxState::Killing])
-                    .await?;
+                if matches!(previous_state, SandboxState::Running | SandboxState::Paused) {
+                    self.restore_proxy_route(sandbox_id, removed_route).await;
+                    self.store
+                        .update_state_if_state(
+                            &sandbox_id,
+                            previous_state,
+                            &[SandboxState::Killing],
+                        )
+                        .await?;
+                }
 
                 return Err(OrchestratorError::SandboxOperationFailed {
                     sandbox_id,
@@ -937,6 +977,8 @@ where
         }
         self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
             .await;
+        drop(operation_guard);
+        self.lifecycle_operations.lock().await.remove(&sandbox_id);
         info!("sandbox deleted");
 
         Ok(())
@@ -1017,6 +1059,8 @@ where
             }
             Err(err) => return Err(OrchestratorError::from(err)),
         }
+        let operation_lock = self.lifecycle_operation_lock(sandbox_id).await;
+        let _operation_guard = operation_lock.lock().await;
 
         // Pin paused runtime artifacts before detaching from the running set.
         let runtime_artifacts = {
@@ -1068,7 +1112,7 @@ where
             Ok(s) => s,
             Err(err) => {
                 warn!(error = ?err, "failed to pause sandbox");
-                let source = if err.is_terminal() {
+                let (source, release_paused_refs) = if err.is_terminal() {
                     // The handle was already detached from `self.sandboxes`
                     // before `pause()`. Do not reinsert it here: the live
                     // runtime may have been mutated and is no longer safe to
@@ -1081,7 +1125,7 @@ where
                         warn!(error = ?stop_err, "failed to stop sandbox after terminal pause failure");
                     }
                     self.store.remove(&sandbox_id).await?;
-                    err.into()
+                    (err.into(), true)
                 } else {
                     let resume_result = {
                         let mut sandbox = handle.lock().await;
@@ -1089,18 +1133,99 @@ where
                     };
                     match resume_result {
                         Ok(()) => {
-                            self.sandboxes.write().await.insert(sandbox_id, handle);
-                            self.restore_proxy_route(sandbox_id, removed_proxy_route)
-                                .await;
-                            let _ = self
-                                .store
-                                .update_state_if_state(
-                                    &sandbox_id,
-                                    SandboxState::Running,
-                                    &[SandboxState::Pausing],
-                                )
-                                .await;
-                            err.into()
+                            // Publish the runtime while metadata is still Pausing.
+                            // Proxy lookup gates routes on Running metadata, and
+                            // lifecycle operations for this sandbox are serialized,
+                            // so the final CAS makes the restored runtime visible.
+                            let restore_result = {
+                                let mut sandboxes = self.sandboxes.write().await;
+                                let mut proxy_routes = self.proxy_routes.write().await;
+                                sandboxes.insert(sandbox_id, Arc::clone(&handle));
+                                if let Some(route) = removed_proxy_route.as_ref() {
+                                    let version = self
+                                        .next_proxy_route_version
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    proxy_routes.upsert(
+                                        sandbox_id,
+                                        route.target().clone(),
+                                        version,
+                                    );
+                                }
+                                let result = self
+                                    .store
+                                    .update_state_if_state(
+                                        &sandbox_id,
+                                        SandboxState::Running,
+                                        &[SandboxState::Pausing],
+                                    )
+                                    .await;
+                                if result.is_err() {
+                                    sandboxes.remove(&sandbox_id);
+                                    proxy_routes.remove(&sandbox_id);
+                                }
+                                result.map(|_| ())
+                            };
+
+                            match restore_result {
+                                Ok(()) => (err.into(), true),
+                                Err(restore_err) => {
+                                    warn!(
+                                        error = ?restore_err,
+                                        "failed to restore Running state after pause recovery"
+                                    );
+                                    let stop_result = {
+                                        let mut sandbox = handle.lock().await;
+                                        sandbox.stop().await
+                                    };
+                                    match stop_result {
+                                        Ok(()) => {
+                                            let cleanup_error = self
+                                                .remove_stopped_sandbox_or_retain_handle(
+                                                    sandbox_id, handle,
+                                                )
+                                                .await;
+                                            let source = match cleanup_error {
+                                                Some(cleanup_err) => anyhow::anyhow!(
+                                                    "pause failed and Running state could not be \
+                                                     restored: pause error: {err}; state error: \
+                                                     {restore_err}; metadata cleanup error: \
+                                                     {cleanup_err}"
+                                                ),
+                                                None => anyhow::anyhow!(
+                                                    "pause failed and Running state could not be \
+                                                     restored: pause error: {err}; state error: \
+                                                     {restore_err}"
+                                                ),
+                                            };
+                                            (source, true)
+                                        }
+                                        Err(stop_err) => {
+                                            warn!(
+                                                error = ?stop_err,
+                                                "failed to stop sandbox after state recovery failure"
+                                            );
+                                            self.sandboxes.write().await.insert(sandbox_id, handle);
+                                            let _ = self
+                                                .store
+                                                .update_state_if_state(
+                                                    &sandbox_id,
+                                                    SandboxState::Killing,
+                                                    &[SandboxState::Pausing],
+                                                )
+                                                .await;
+                                            (
+                                                anyhow::anyhow!(
+                                                    "pause failed, Running state could not be \
+                                                     restored, and sandbox could not be stopped: \
+                                                     pause error: {err}; state error: \
+                                                     {restore_err}; stop error: {stop_err:#}"
+                                                ),
+                                                false,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
                         Err(resume_err) => {
                             warn!(
@@ -1111,22 +1236,58 @@ where
                                 let mut sandbox = handle.lock().await;
                                 sandbox.stop().await
                             };
-                            if let Err(stop_err) = stop_result {
-                                warn!(
-                                    error = ?stop_err,
-                                    "failed to stop sandbox after pause recovery failure"
-                                );
+                            match stop_result {
+                                Ok(()) => {
+                                    let cleanup_error = self
+                                        .remove_stopped_sandbox_or_retain_handle(sandbox_id, handle)
+                                        .await;
+                                    let source = match cleanup_error {
+                                        Some(cleanup_err) => anyhow::anyhow!(
+                                            "pause failed and sandbox could not be resumed: pause \
+                                             error: {err}; resume error: {resume_err}; metadata \
+                                             cleanup error: {cleanup_err}"
+                                        ),
+                                        None => anyhow::anyhow!(
+                                            "pause failed and sandbox could not be resumed: pause \
+                                             error: {err}; resume error: {resume_err:#}"
+                                        ),
+                                    };
+                                    (source, true)
+                                }
+                                Err(stop_err) => {
+                                    warn!(
+                                        error = ?stop_err,
+                                        "failed to stop sandbox after pause recovery failure"
+                                    );
+                                    // The backend may still own live resources.
+                                    // Keep its handle in a stable cleanup state so
+                                    // a later delete can retry stopping it.
+                                    self.sandboxes.write().await.insert(sandbox_id, handle);
+                                    let _ = self
+                                        .store
+                                        .update_state_if_state(
+                                            &sandbox_id,
+                                            SandboxState::Killing,
+                                            &[SandboxState::Pausing],
+                                        )
+                                        .await;
+                                    (
+                                        anyhow::anyhow!(
+                                            "pause failed, sandbox could not be resumed, and \
+                                             sandbox could not be stopped: pause error: {err}; \
+                                             resume error: {resume_err}; stop error: {stop_err:#}"
+                                        ),
+                                        false,
+                                    )
+                                }
                             }
-                            self.store.remove(&sandbox_id).await?;
-                            anyhow::anyhow!(
-                                "pause failed and sandbox could not be resumed: pause error: \
-                                 {err}; resume error: {resume_err:#}"
-                            )
                         }
                     }
                 };
-                self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
-                    .await;
+                if release_paused_refs {
+                    self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
+                        .await;
+                }
                 return Err(OrchestratorError::SandboxOperationFailed {
                     sandbox_id,
                     operation: SandboxOperation::Pause,

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc, Mutex as StdMutex,
@@ -815,6 +815,14 @@ where
     #[tracing::instrument(skip(self), fields(sandbox_id = %sandbox_id))]
     pub async fn proxy_lookup_for(&self, sandbox_id: &SandboxId) -> Result<ProxyLookupResult> {
         let route = self.proxy_routes.read().await.route(sandbox_id).cloned();
+        if let Some(route) = route.as_ref().filter(|route| route.is_ready()) {
+            trace!(
+                version = route.version(),
+                "resolved running proxy target from runtime table"
+            );
+            return Ok(ProxyLookupResult::Ready(route.target().clone()));
+        }
+
         let metadata = self.store.get(sandbox_id).await?;
         Ok(match metadata {
             None => {
@@ -822,12 +830,14 @@ where
                 ProxyLookupResult::NotFound
             }
             Some(metadata) if metadata.state == SandboxState::Running => {
-                let routes = self.proxy_routes.read().await;
-                match (route, routes.route(sandbox_id)) {
-                    (Some(route), Some(current)) if route.version() == current.version() => {
+                let mut routes = self.proxy_routes.write().await;
+                match route
+                    .and_then(|route| routes.mark_ready_if_version(sandbox_id, route.version()))
+                {
+                    Some(route) => {
                         trace!(
                             version = route.version(),
-                            "resolved running proxy target from runtime table"
+                            "validated recovered proxy target against Running metadata"
                         );
                         ProxyLookupResult::Ready(route.target().clone())
                     }
@@ -1076,7 +1086,8 @@ where
                 warn!(error = ?err, "failed to stop sandbox during delete");
                 if matches!(previous_state, SandboxState::Running | SandboxState::Paused) {
                     self.sandboxes.write().await.insert(sandbox_id, handle);
-                    self.restore_proxy_route(sandbox_id, removed_route).await;
+                    let restored_route_version =
+                        self.restore_proxy_route(sandbox_id, removed_route).await;
                     self.store
                         .update_state_if_state(
                             &sandbox_id,
@@ -1084,6 +1095,10 @@ where
                             &[SandboxState::Killing],
                         )
                         .await?;
+                    if previous_state == SandboxState::Running {
+                        self.mark_proxy_route_ready(sandbox_id, restored_route_version)
+                            .await;
+                    }
                 } else {
                     self.cleanup_handles
                         .write()
@@ -1209,6 +1224,7 @@ where
                     sandbox_id,
                     pause_handle.as_ref(),
                     removed_proxy_route,
+                    false,
                 )
                 .await;
                 return match actual_state {
@@ -1234,6 +1250,7 @@ where
                     sandbox_id,
                     pause_handle.as_ref(),
                     removed_proxy_route,
+                    false,
                 )
                 .await;
                 return Err(OrchestratorError::from(err));
@@ -1264,14 +1281,13 @@ where
                 .store
                 .update_state_if_state(&sandbox_id, SandboxState::Running, &[SandboxState::Pausing])
                 .await;
-            if rollback_result.is_ok() {
-                self.restore_invalidated_proxy_route(
-                    sandbox_id,
-                    pause_handle.as_ref(),
-                    removed_proxy_route,
-                )
-                .await;
-            }
+            self.restore_invalidated_proxy_route(
+                sandbox_id,
+                pause_handle.as_ref(),
+                removed_proxy_route,
+                rollback_result.is_ok(),
+            )
+            .await;
             return Err(error);
         }
 
@@ -1332,7 +1348,7 @@ where
                                     let version = self
                                         .next_proxy_route_version
                                         .fetch_add(1, Ordering::Relaxed);
-                                    self.proxy_routes.write().await.upsert(
+                                    self.proxy_routes.write().await.upsert_pending_validation(
                                         sandbox_id,
                                         route.target().clone(),
                                         version,
@@ -1351,6 +1367,10 @@ where
                                 )
                                 .await
                                 .map(|_| ());
+                            if restore_result.is_ok() {
+                                self.mark_proxy_route_ready(sandbox_id, restored_route_version)
+                                    .await;
+                            }
                             if restore_result.is_err() {
                                 let mut sandboxes = self.sandboxes.write().await;
                                 if sandboxes
@@ -1544,9 +1564,10 @@ where
                 }
             } else {
                 self.sandboxes.write().await.insert(sandbox_id, handle);
-                self.restore_proxy_route(sandbox_id, removed_proxy_route)
+                let restored_route_version = self
+                    .restore_proxy_route(sandbox_id, removed_proxy_route)
                     .await;
-                let _ = self
+                let restore_result = self
                     .store
                     .update_state_if_state(
                         &sandbox_id,
@@ -1554,6 +1575,10 @@ where
                         &[SandboxState::Pausing],
                     )
                     .await;
+                if restore_result.is_ok() {
+                    self.mark_proxy_route_ready(sandbox_id, restored_route_version)
+                        .await;
+                }
             }
             self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
                 .await;
@@ -2594,12 +2619,31 @@ where
         true
     }
 
-    async fn restore_proxy_route(&self, sandbox_id: SandboxId, route: Option<ProxyRoute>) {
-        let Some(route) = route else {
+    async fn restore_proxy_route(
+        &self,
+        sandbox_id: SandboxId,
+        route: Option<ProxyRoute>,
+    ) -> Option<u64> {
+        let route = route?;
+        let version = self
+            .next_proxy_route_version
+            .fetch_add(1, Ordering::Relaxed);
+        self.proxy_routes.write().await.upsert_pending_validation(
+            sandbox_id,
+            route.target().clone(),
+            version,
+        );
+        Some(version)
+    }
+
+    async fn mark_proxy_route_ready(&self, sandbox_id: SandboxId, version: Option<u64>) {
+        let Some(version) = version else {
             return;
         };
-        self.upsert_proxy_route(sandbox_id, route.target().clone())
-            .await;
+        self.proxy_routes
+            .write()
+            .await
+            .mark_ready_if_version(&sandbox_id, version);
     }
 
     async fn remove_proxy_route(&self, sandbox_id: &SandboxId) -> Option<ProxyRoute> {
@@ -2615,6 +2659,7 @@ where
         sandbox_id: SandboxId,
         expected_handle: Option<&SandboxHandle>,
         route: Option<ProxyRoute>,
+        ready: bool,
     ) {
         let (Some(expected_handle), Some(route)) = (expected_handle, route) else {
             return;
@@ -2640,7 +2685,11 @@ where
         let version = self
             .next_proxy_route_version
             .fetch_add(1, Ordering::Relaxed);
-        routes.upsert(sandbox_id, route.target().clone(), version);
+        if ready {
+            routes.upsert(sandbox_id, route.target().clone(), version);
+        } else {
+            routes.upsert_pending_validation(sandbox_id, route.target().clone(), version);
+        }
         debug!(
             version,
             "restored runtime proxy route after failed pause transition"
@@ -2675,7 +2724,7 @@ where
                 .await
                 .keys()
                 .copied()
-                .collect::<Vec<_>>();
+                .collect::<HashSet<_>>();
             let sandboxes = self
                 .store
                 .list_filtered(SandboxListFilter {
@@ -2845,6 +2894,17 @@ where
 
     pub(crate) async fn remove_proxy_route_for_test(&self, sandbox_id: &SandboxId) {
         let _ = self.proxy_routes.write().await.remove(sandbox_id);
+    }
+
+    pub(crate) async fn mark_proxy_route_pending_for_test(&self, sandbox_id: &SandboxId) {
+        let mut routes = self.proxy_routes.write().await;
+        let route = routes
+            .remove(sandbox_id)
+            .expect("proxy route should exist before marking it pending");
+        let version = self
+            .next_proxy_route_version
+            .fetch_add(1, Ordering::Relaxed);
+        routes.upsert_pending_validation(*sandbox_id, route.target().clone(), version);
     }
 }
 

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -1068,7 +1068,7 @@ where
             Ok(s) => s,
             Err(err) => {
                 warn!(error = ?err, "failed to pause sandbox");
-                if err.is_terminal() {
+                let source = if err.is_terminal() {
                     // The handle was already detached from `self.sandboxes`
                     // before `pause()`. Do not reinsert it here: the live
                     // runtime may have been mutated and is no longer safe to
@@ -1081,25 +1081,56 @@ where
                         warn!(error = ?stop_err, "failed to stop sandbox after terminal pause failure");
                     }
                     self.store.remove(&sandbox_id).await?;
+                    err.into()
                 } else {
-                    self.sandboxes.write().await.insert(sandbox_id, handle);
-                    self.restore_proxy_route(sandbox_id, removed_proxy_route)
-                        .await;
-                    let _ = self
-                        .store
-                        .update_state_if_state(
-                            &sandbox_id,
-                            SandboxState::Running,
-                            &[SandboxState::Pausing],
-                        )
-                        .await;
-                }
+                    let resume_result = {
+                        let mut sandbox = handle.lock().await;
+                        sandbox.resume().await
+                    };
+                    match resume_result {
+                        Ok(()) => {
+                            self.sandboxes.write().await.insert(sandbox_id, handle);
+                            self.restore_proxy_route(sandbox_id, removed_proxy_route)
+                                .await;
+                            let _ = self
+                                .store
+                                .update_state_if_state(
+                                    &sandbox_id,
+                                    SandboxState::Running,
+                                    &[SandboxState::Pausing],
+                                )
+                                .await;
+                            err.into()
+                        }
+                        Err(resume_err) => {
+                            warn!(
+                                error = ?resume_err,
+                                "failed to resume sandbox after recoverable pause failure"
+                            );
+                            let stop_result = {
+                                let mut sandbox = handle.lock().await;
+                                sandbox.stop().await
+                            };
+                            if let Err(stop_err) = stop_result {
+                                warn!(
+                                    error = ?stop_err,
+                                    "failed to stop sandbox after pause recovery failure"
+                                );
+                            }
+                            self.store.remove(&sandbox_id).await?;
+                            anyhow::anyhow!(
+                                "pause failed and sandbox could not be resumed: pause error: \
+                                 {err}; resume error: {resume_err:#}"
+                            )
+                        }
+                    }
+                };
                 self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
                     .await;
                 return Err(OrchestratorError::SandboxOperationFailed {
                     sandbox_id,
                     operation: SandboxOperation::Pause,
-                    source: err.into(),
+                    source,
                 });
             }
         };

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -788,6 +788,7 @@ where
     /// Resolves the current proxyability of a sandbox without touching the sandbox mutex.
     #[tracing::instrument(skip(self), fields(sandbox_id = %sandbox_id))]
     pub async fn proxy_lookup_for(&self, sandbox_id: &SandboxId) -> Result<ProxyLookupResult> {
+        let route = self.proxy_routes.read().await.route(sandbox_id).cloned();
         let metadata = self.store.get(sandbox_id).await?;
         Ok(match metadata {
             None => {
@@ -795,28 +796,19 @@ where
                 ProxyLookupResult::NotFound
             }
             Some(metadata) if metadata.state == SandboxState::Running => {
-                let route = self.proxy_routes.read().await.route(sandbox_id).cloned();
-                match self.store.get(sandbox_id).await? {
-                    None => ProxyLookupResult::NotFound,
-                    Some(current) if current.state == SandboxState::Running => match route {
-                        Some(route) => {
-                            trace!(
-                                version = route.version(),
-                                "resolved running proxy target from runtime table"
-                            );
-                            ProxyLookupResult::Ready(route.target().clone())
-                        }
-                        None => {
-                            warn!("running sandbox is missing a runtime proxy route");
-                            ProxyLookupResult::RouteMissing
-                        }
-                    },
-                    Some(current) if current.state == SandboxState::Paused => {
-                        ProxyLookupResult::Paused {
-                            auto_resume: current.auto_resume,
-                        }
+                let routes = self.proxy_routes.read().await;
+                match (route, routes.route(sandbox_id)) {
+                    (Some(route), Some(current)) if route.version() == current.version() => {
+                        trace!(
+                            version = route.version(),
+                            "resolved running proxy target from runtime table"
+                        );
+                        ProxyLookupResult::Ready(route.target().clone())
                     }
-                    Some(current) => ProxyLookupResult::Unavailable(current.state),
+                    _ => {
+                        warn!("running sandbox proxy route changed during state validation");
+                        ProxyLookupResult::RouteMissing
+                    }
                 }
             }
             Some(metadata) if metadata.state == SandboxState::Paused => {

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
-    Arc,
+    Arc, Mutex as StdMutex,
 };
 use std::time::{Duration, SystemTime};
 
@@ -35,11 +35,41 @@ use super::types::{
 use super::{OrchestratorError, Result, SandboxForkOutcome, SandboxOperation};
 
 type SandboxHandle = Arc<Mutex<Box<dyn SandboxBackend>>>;
+type LifecycleOperationLock = Arc<Mutex<LifecycleOperationState>>;
+type LifecycleOperationMap = Arc<StdMutex<HashMap<SandboxId, LifecycleOperationLock>>>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum LifecycleOperationKind {
     Delete,
     Pause,
+}
+
+#[derive(Debug)]
+struct LifecycleOperationState {
+    kind: LifecycleOperationKind,
+    delete_succeeded: bool,
+}
+
+struct LifecycleOperationLease {
+    sandbox_id: SandboxId,
+    operation_lock: LifecycleOperationLock,
+    operations: LifecycleOperationMap,
+}
+
+impl Drop for LifecycleOperationLease {
+    fn drop(&mut self) {
+        let mut operations = self
+            .operations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if Arc::strong_count(&self.operation_lock) == 2
+            && operations
+                .get(&self.sandbox_id)
+                .is_some_and(|current| Arc::ptr_eq(current, &self.operation_lock))
+        {
+            operations.remove(&self.sandbox_id);
+        }
+    }
 }
 
 /// Maximum time to wait for a sandbox to leave a transitional state.
@@ -100,7 +130,7 @@ pub struct Orchestrator<
     store: S,
     factory: F,
     persister: P,
-    lifecycle_operations: Mutex<HashMap<SandboxId, Arc<Mutex<LifecycleOperationKind>>>>,
+    lifecycle_operations: LifecycleOperationMap,
     sandboxes: RwLock<HashMap<SandboxId, SandboxHandle>>,
     proxy_routes: RwLock<ProxyRouteTable>,
     next_proxy_route_version: AtomicU64,
@@ -183,7 +213,7 @@ where
             store,
             factory,
             persister,
-            lifecycle_operations: Mutex::new(HashMap::new()),
+            lifecycle_operations: Arc::new(StdMutex::new(HashMap::new())),
             sandboxes: RwLock::new(HashMap::new()),
             proxy_routes: RwLock::new(ProxyRouteTable::default()),
             next_proxy_route_version: AtomicU64::new(1),
@@ -254,34 +284,31 @@ where
         })?
     }
 
-    async fn lifecycle_operation_lock(
+    fn lifecycle_operation_lock(
         &self,
         sandbox_id: SandboxId,
         operation: LifecycleOperationKind,
-    ) -> (Arc<Mutex<LifecycleOperationKind>>, bool) {
-        let mut operations = self.lifecycle_operations.lock().await;
+    ) -> (LifecycleOperationLease, bool) {
+        let mut operations = self
+            .lifecycle_operations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let already_existed = operations.contains_key(&sandbox_id);
-        let operation_lock = Arc::clone(
-            operations
-                .entry(sandbox_id)
-                .or_insert_with(|| Arc::new(Mutex::new(operation))),
-        );
-        (operation_lock, already_existed)
-    }
-
-    async fn retire_lifecycle_operation_lock(
-        &self,
-        sandbox_id: SandboxId,
-        operation_lock: &Arc<Mutex<LifecycleOperationKind>>,
-    ) {
-        let mut operations = self.lifecycle_operations.lock().await;
-        if Arc::strong_count(operation_lock) == 2
-            && operations
-                .get(&sandbox_id)
-                .is_some_and(|current| Arc::ptr_eq(current, operation_lock))
-        {
-            operations.remove(&sandbox_id);
-        }
+        let operation_lock = Arc::clone(operations.entry(sandbox_id).or_insert_with(|| {
+            Arc::new(Mutex::new(LifecycleOperationState {
+                kind: operation,
+                delete_succeeded: false,
+            }))
+        }));
+        drop(operations);
+        (
+            LifecycleOperationLease {
+                sandbox_id,
+                operation_lock,
+                operations: Arc::clone(&self.lifecycle_operations),
+            },
+            already_existed,
+        )
     }
 
     async fn protect_image_refs(
@@ -903,24 +930,24 @@ where
     async fn delete_sandbox_inner(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         info!("deleting sandbox");
 
-        let (operation_lock, cleanup_already_in_flight) = self
-            .lifecycle_operation_lock(sandbox_id, LifecycleOperationKind::Delete)
-            .await;
-        let mut operation_guard = operation_lock.lock().await;
-        *operation_guard = LifecycleOperationKind::Delete;
+        let (operation_lease, already_existed) =
+            self.lifecycle_operation_lock(sandbox_id, LifecycleOperationKind::Delete);
+        let mut operation_guard = operation_lease.operation_lock.lock().await;
+        let prior_delete_succeeded = already_existed && operation_guard.delete_succeeded;
+        operation_guard.kind = LifecycleOperationKind::Delete;
         let result = self
-            .delete_sandbox_owned_inner(sandbox_id, cleanup_already_in_flight)
+            .delete_sandbox_owned_inner(sandbox_id, prior_delete_succeeded)
             .await;
+        operation_guard.delete_succeeded |= result.is_ok();
         drop(operation_guard);
-        self.retire_lifecycle_operation_lock(sandbox_id, &operation_lock)
-            .await;
+        drop(operation_lease);
         result
     }
 
     async fn delete_sandbox_owned_inner(
         self: &Arc<Self>,
         sandbox_id: SandboxId,
-        cleanup_already_in_flight: bool,
+        prior_delete_succeeded: bool,
     ) -> Result<()> {
         // Attempt to transition to Killing, retrying after waiting whenever we
         // find the sandbox in a transitional state.
@@ -984,7 +1011,7 @@ where
                         }));
                     }
                 },
-                Err(StoreError::SandboxNotFound { .. }) if cleanup_already_in_flight => {
+                Err(StoreError::SandboxNotFound { .. }) if prior_delete_succeeded => {
                     info!("sandbox was deleted by a concurrent cleanup");
                     return Ok(());
                 }
@@ -1095,30 +1122,26 @@ where
         fields(sandbox_id = %sandbox_id)
     )]
     async fn pause_sandbox_inner(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
-        let (operation_lock, _) = self
-            .lifecycle_operation_lock(sandbox_id, LifecycleOperationKind::Pause)
-            .await;
-        let operation_guard = match operation_lock.try_lock() {
+        let (operation_lease, _) =
+            self.lifecycle_operation_lock(sandbox_id, LifecycleOperationKind::Pause);
+        let operation_guard = match operation_lease.operation_lock.try_lock() {
             Ok(mut operation_guard) => {
-                *operation_guard = LifecycleOperationKind::Pause;
+                operation_guard.kind = LifecycleOperationKind::Pause;
                 operation_guard
             }
             Err(_) => {
-                let mut operation_guard = operation_lock.lock().await;
-                if *operation_guard == LifecycleOperationKind::Pause {
+                let mut operation_guard = operation_lease.operation_lock.lock().await;
+                if operation_guard.kind == LifecycleOperationKind::Pause {
                     drop(operation_guard);
-                    self.retire_lifecycle_operation_lock(sandbox_id, &operation_lock)
-                        .await;
                     return self.join_concurrent_pause(sandbox_id).await;
                 }
-                *operation_guard = LifecycleOperationKind::Pause;
+                operation_guard.kind = LifecycleOperationKind::Pause;
                 operation_guard
             }
         };
         let result = self.pause_sandbox_owned_inner(sandbox_id).await;
         drop(operation_guard);
-        self.retire_lifecycle_operation_lock(sandbox_id, &operation_lock)
-            .await;
+        drop(operation_lease);
         result
     }
 
@@ -2038,8 +2061,8 @@ where
                 continue;
             }
             if let Err(err) = match metadata.timeout_action {
-                SandboxTimeoutAction::Pause => self.pause_sandbox_inner(metadata.id).await,
-                SandboxTimeoutAction::Delete => self.delete_sandbox_inner(metadata.id).await,
+                SandboxTimeoutAction::Pause => self.pause_sandbox(metadata.id).await,
+                SandboxTimeoutAction::Delete => self.delete_sandbox(metadata.id).await,
             } {
                 warn!(
                     sandbox_id = %metadata.id,
@@ -2556,7 +2579,7 @@ where
                         unreachable!("paused sandboxes should have been filtered out")
                     }
                     SandboxState::Running => {
-                        if let Err(err) = self.pause_sandbox_inner(sandbox_id).await {
+                        if let Err(err) = self.pause_sandbox(sandbox_id).await {
                             last_failures.push(format!("{sandbox_id}: {err}"));
                         }
                     }

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -131,6 +131,8 @@ pub struct Orchestrator<
     factory: F,
     persister: P,
     lifecycle_operations: LifecycleOperationMap,
+    #[cfg(test)]
+    lifecycle_join_started: StdMutex<Option<Arc<tokio::sync::Notify>>>,
     sandboxes: RwLock<HashMap<SandboxId, SandboxHandle>>,
     proxy_routes: RwLock<ProxyRouteTable>,
     next_proxy_route_version: AtomicU64,
@@ -214,6 +216,8 @@ where
             factory,
             persister,
             lifecycle_operations: Arc::new(StdMutex::new(HashMap::new())),
+            #[cfg(test)]
+            lifecycle_join_started: StdMutex::new(None),
             sandboxes: RwLock::new(HashMap::new()),
             proxy_routes: RwLock::new(ProxyRouteTable::default()),
             next_proxy_route_version: AtomicU64::new(1),
@@ -301,14 +305,31 @@ where
             }))
         }));
         drop(operations);
-        (
-            LifecycleOperationLease {
-                sandbox_id,
-                operation_lock,
-                operations: Arc::clone(&self.lifecycle_operations),
-            },
-            already_existed,
-        )
+        let lease = LifecycleOperationLease {
+            sandbox_id,
+            operation_lock,
+            operations: Arc::clone(&self.lifecycle_operations),
+        };
+        #[cfg(test)]
+        if already_existed {
+            if let Some(started) = self
+                .lifecycle_join_started
+                .lock()
+                .expect("lifecycle join hook mutex poisoned")
+                .take()
+            {
+                started.notify_one();
+            }
+        }
+        (lease, already_existed)
+    }
+
+    #[cfg(test)]
+    fn notify_on_next_lifecycle_join(&self, started: Arc<tokio::sync::Notify>) {
+        *self
+            .lifecycle_join_started
+            .lock()
+            .expect("lifecycle join hook mutex poisoned") = Some(started);
     }
 
     async fn protect_image_refs(
@@ -1137,8 +1158,9 @@ where
             Err(_) => {
                 let mut operation_guard = operation_lease.operation_lock.lock().await;
                 if operation_guard.kind == LifecycleOperationKind::Pause {
+                    let result = self.join_concurrent_pause(sandbox_id).await;
                     drop(operation_guard);
-                    return self.join_concurrent_pause(sandbox_id).await;
+                    return result;
                 }
                 operation_guard.kind = LifecycleOperationKind::Pause;
                 operation_guard

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -134,6 +134,7 @@ pub struct Orchestrator<
     #[cfg(test)]
     lifecycle_join_started: StdMutex<Option<Arc<tokio::sync::Notify>>>,
     sandboxes: RwLock<HashMap<SandboxId, SandboxHandle>>,
+    cleanup_handles: RwLock<HashMap<SandboxId, SandboxHandle>>,
     proxy_routes: RwLock<ProxyRouteTable>,
     next_proxy_route_version: AtomicU64,
     counters: OrchestratorCounters,
@@ -219,6 +220,7 @@ where
             #[cfg(test)]
             lifecycle_join_started: StdMutex::new(None),
             sandboxes: RwLock::new(HashMap::new()),
+            cleanup_handles: RwLock::new(HashMap::new()),
             proxy_routes: RwLock::new(ProxyRouteTable::default()),
             next_proxy_route_version: AtomicU64::new(1),
             counters: OrchestratorCounters::default(),
@@ -355,10 +357,13 @@ where
         sandbox_id: SandboxId,
         handle: SandboxHandle,
     ) -> std::result::Result<(), StoreError> {
-        // Publish cleanup ownership before exposing Killing. If the metadata
-        // write is cancelled or fails, a later delete can still find the
-        // detached backend and retry stop from its existing Pausing state.
-        self.sandboxes.write().await.insert(sandbox_id, handle);
+        // Publish cleanup ownership before exposing Killing. This registry is
+        // deliberately independent of metadata: an ambiguous or failed store
+        // write must not make a potentially live backend unreachable.
+        self.cleanup_handles
+            .write()
+            .await
+            .insert(sandbox_id, handle);
 
         let state_result = self
             .store
@@ -1037,6 +1042,12 @@ where
                         }));
                     }
                 },
+                Err(StoreError::SandboxNotFound { .. })
+                    if self.cleanup_handles.read().await.contains_key(&sandbox_id) =>
+                {
+                    debug!("retrying backend cleanup without sandbox metadata");
+                    break SandboxState::Killing;
+                }
                 Err(StoreError::SandboxNotFound { .. }) if prior_delete_succeeded => {
                     info!("sandbox was deleted by a concurrent cleanup");
                     return Ok(());
@@ -1047,7 +1058,12 @@ where
             }
         };
 
-        let (handle, removed_route) = self.detach_sandbox_handle_and_route(&sandbox_id).await;
+        let (active_handle, removed_route) =
+            self.detach_sandbox_handle_and_route(&sandbox_id).await;
+        let handle = match active_handle {
+            Some(handle) => Some(handle),
+            None => self.cleanup_handles.write().await.remove(&sandbox_id),
+        };
 
         // If the sandbox is still in memory, attempt to stop it.
         if let Some(handle) = handle {
@@ -1058,8 +1074,8 @@ where
 
             if let Err(err) = stop_result {
                 warn!(error = ?err, "failed to stop sandbox during delete");
-                self.sandboxes.write().await.insert(sandbox_id, handle);
                 if matches!(previous_state, SandboxState::Running | SandboxState::Paused) {
+                    self.sandboxes.write().await.insert(sandbox_id, handle);
                     self.restore_proxy_route(sandbox_id, removed_route).await;
                     self.store
                         .update_state_if_state(
@@ -1068,6 +1084,11 @@ where
                             &[SandboxState::Killing],
                         )
                         .await?;
+                } else {
+                    self.cleanup_handles
+                        .write()
+                        .await
+                        .insert(sandbox_id, handle);
                 }
 
                 return Err(OrchestratorError::SandboxOperationFailed {
@@ -1174,6 +1195,9 @@ where
 
     async fn pause_sandbox_owned_inner(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         info!("pausing sandbox");
+        let pause_handle = self.sandboxes.read().await.get(&sandbox_id).cloned();
+        let removed_proxy_route = self.remove_proxy_route(&sandbox_id).await;
+
         match self
             .store
             .update_state_if_state(&sandbox_id, SandboxState::Pausing, &[SandboxState::Running])
@@ -1181,6 +1205,12 @@ where
         {
             Ok(_) => {}
             Err(StoreError::StateConflict { actual_state, .. }) => {
+                self.restore_invalidated_proxy_route(
+                    sandbox_id,
+                    pause_handle.as_ref(),
+                    removed_proxy_route,
+                )
+                .await;
                 return match actual_state {
                     // Another task is already performing the pause.  Wait for
                     // it to finish and then report the final outcome.
@@ -1199,7 +1229,15 @@ where
                     }
                 };
             }
-            Err(err) => return Err(OrchestratorError::from(err)),
+            Err(err) => {
+                self.restore_invalidated_proxy_route(
+                    sandbox_id,
+                    pause_handle.as_ref(),
+                    removed_proxy_route,
+                )
+                .await;
+                return Err(OrchestratorError::from(err));
+            }
         }
 
         // Pin paused runtime artifacts before detaching from the running set.
@@ -1222,14 +1260,22 @@ where
             .await
         {
             warn!(error = %error, "failed to protect paused runtime artifacts; keeping sandbox Running");
-            let _ = self
+            let rollback_result = self
                 .store
                 .update_state_if_state(&sandbox_id, SandboxState::Running, &[SandboxState::Pausing])
                 .await;
+            if rollback_result.is_ok() {
+                self.restore_invalidated_proxy_route(
+                    sandbox_id,
+                    pause_handle.as_ref(),
+                    removed_proxy_route,
+                )
+                .await;
+            }
             return Err(error);
         }
 
-        let (handle, removed_proxy_route) = self.detach_sandbox_handle_and_route(&sandbox_id).await;
+        let handle = self.sandboxes.write().await.remove(&sandbox_id);
 
         let Some(handle) = handle else {
             warn!("sandbox handle not found while pausing, removing from store");
@@ -2556,6 +2602,51 @@ where
             .await;
     }
 
+    async fn remove_proxy_route(&self, sandbox_id: &SandboxId) -> Option<ProxyRoute> {
+        let removed_route = self.proxy_routes.write().await.remove(sandbox_id);
+        if let Some(route) = removed_route.as_ref() {
+            debug!(version = route.version(), "removed runtime proxy route");
+        }
+        removed_route
+    }
+
+    async fn restore_invalidated_proxy_route(
+        &self,
+        sandbox_id: SandboxId,
+        expected_handle: Option<&SandboxHandle>,
+        route: Option<ProxyRoute>,
+    ) {
+        let (Some(expected_handle), Some(route)) = (expected_handle, route) else {
+            return;
+        };
+
+        // A fresh route generation is safe even when the state write failed
+        // ambiguously: metadata still gates proxy visibility, while stale
+        // lookups that captured the removed generation will fail validation.
+        // Holding the handle table while publishing also prevents a stale
+        // backend from restoring a route after it has been replaced.
+        let sandboxes = self.sandboxes.read().await;
+        if !sandboxes
+            .get(&sandbox_id)
+            .is_some_and(|current| Arc::ptr_eq(current, expected_handle))
+        {
+            return;
+        }
+
+        let mut routes = self.proxy_routes.write().await;
+        if routes.route(&sandbox_id).is_some() {
+            return;
+        }
+        let version = self
+            .next_proxy_route_version
+            .fetch_add(1, Ordering::Relaxed);
+        routes.upsert(sandbox_id, route.target().clone(), version);
+        debug!(
+            version,
+            "restored runtime proxy route after failed pause transition"
+        );
+    }
+
     async fn detach_sandbox_handle_and_route(
         &self,
         sandbox_id: &SandboxId,
@@ -2565,10 +2656,7 @@ where
         let mut sandboxes = self.sandboxes.write().await;
         let handle = sandboxes.remove(sandbox_id);
 
-        let removed_route = self.proxy_routes.write().await.remove(sandbox_id);
-        if let Some(route) = removed_route.as_ref() {
-            debug!(version = route.version(), "removed runtime proxy route");
-        }
+        let removed_route = self.remove_proxy_route(sandbox_id).await;
 
         drop(sandboxes);
         (handle, removed_route)
@@ -2580,6 +2668,14 @@ where
 
         // Preserve recoverable sandboxes by pausing running VMs before process exit.
         for pass in 1..=MAX_SHUTDOWN_PASSES {
+            last_failures.clear();
+            let cleanup_ids = self
+                .cleanup_handles
+                .read()
+                .await
+                .keys()
+                .copied()
+                .collect::<Vec<_>>();
             let sandboxes = self
                 .store
                 .list_filtered(SandboxListFilter {
@@ -2588,19 +2684,27 @@ where
                     user_metadata: None,
                 })
                 .await?;
-            if sandboxes.is_empty() {
+            if cleanup_ids.is_empty() && sandboxes.is_empty() {
                 break;
             }
-            last_failures.clear();
 
             info!(
                 pass,
-                remaining = sandboxes.len(),
+                remaining = cleanup_ids.len() + sandboxes.len(),
                 "preserving sandboxes during shutdown"
             );
 
+            for sandbox_id in cleanup_ids.iter().copied() {
+                if let Err(err) = self.delete_sandbox(sandbox_id).await {
+                    last_failures.push(format!("{sandbox_id}: {err}"));
+                }
+            }
+
             for metadata in sandboxes {
                 let sandbox_id = metadata.id;
+                if cleanup_ids.contains(&sandbox_id) {
+                    continue;
+                }
                 match metadata.state {
                     SandboxState::Paused => {
                         unreachable!("paused sandboxes should have been filtered out")

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -792,18 +792,28 @@ where
                 ProxyLookupResult::NotFound
             }
             Some(metadata) if metadata.state == SandboxState::Running => {
-                match self.proxy_routes.read().await.route(sandbox_id).cloned() {
-                    Some(route) => {
-                        trace!(
-                            version = route.version(),
-                            "resolved running proxy target from runtime table"
-                        );
-                        ProxyLookupResult::Ready(route.target().clone())
+                let route = self.proxy_routes.read().await.route(sandbox_id).cloned();
+                match self.store.get(sandbox_id).await? {
+                    None => ProxyLookupResult::NotFound,
+                    Some(current) if current.state == SandboxState::Running => match route {
+                        Some(route) => {
+                            trace!(
+                                version = route.version(),
+                                "resolved running proxy target from runtime table"
+                            );
+                            ProxyLookupResult::Ready(route.target().clone())
+                        }
+                        None => {
+                            warn!("running sandbox is missing a runtime proxy route");
+                            ProxyLookupResult::RouteMissing
+                        }
+                    },
+                    Some(current) if current.state == SandboxState::Paused => {
+                        ProxyLookupResult::Paused {
+                            auto_resume: current.auto_resume,
+                        }
                     }
-                    None => {
-                        warn!("running sandbox is missing a runtime proxy route");
-                        ProxyLookupResult::RouteMissing
-                    }
+                    Some(current) => ProxyLookupResult::Unavailable(current.state),
                 }
             }
             Some(metadata) if metadata.state == SandboxState::Paused => {

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -334,19 +334,22 @@ where
         sandbox_id: SandboxId,
         handle: SandboxHandle,
     ) -> std::result::Result<(), StoreError> {
-        match self
+        // Publish cleanup ownership before exposing Killing. If the metadata
+        // write is cancelled or fails, a later delete can still find the
+        // detached backend and retry stop from its existing Pausing state.
+        self.sandboxes.write().await.insert(sandbox_id, handle);
+
+        let state_result = self
             .store
             .update_state_if_state(&sandbox_id, SandboxState::Killing, &[SandboxState::Pausing])
-            .await
-        {
+            .await;
+
+        match state_result {
             Ok(_)
             | Err(StoreError::StateConflict {
                 actual_state: SandboxState::Killing,
                 ..
-            }) => {
-                self.sandboxes.write().await.insert(sandbox_id, handle);
-                Ok(())
-            }
+            }) => Ok(()),
             Err(err) => Err(err),
         }
     }

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -136,7 +136,7 @@ fn make_orchestrator_without_background_with_factory_and_persister<
         store,
         factory,
         persister,
-        lifecycle_operations: Mutex::new(HashMap::new()),
+        lifecycle_operations: Arc::new(StdMutex::new(HashMap::new())),
         sandboxes: RwLock::new(HashMap::new()),
         proxy_routes: RwLock::new(ProxyRouteTable::default()),
         next_proxy_route_version: AtomicU64::new(1),
@@ -1665,7 +1665,7 @@ async fn pause_terminal_failure_removes_sandbox_and_metrics() -> Result<()> {
         !orchestrator
             .lifecycle_operations
             .lock()
-            .await
+            .expect("lifecycle operations mutex poisoned")
             .contains_key(&sandbox_id),
         "terminal pause cleanup should retire lifecycle ownership"
     );
@@ -2399,7 +2399,7 @@ async fn pause_waiting_for_failed_delete_retries_from_restored_running_state() -
         !orchestrator
             .lifecycle_operations
             .lock()
-            .await
+            .expect("lifecycle operations mutex poisoned")
             .contains_key(&sandbox_id),
         "completed pause and delete should retire lifecycle ownership"
     );
@@ -2614,7 +2614,7 @@ async fn orchestrator_unknown_sandbox_behaviors() -> Result<()> {
         !orchestrator
             .lifecycle_operations
             .lock()
-            .await
+            .expect("lifecycle operations mutex poisoned")
             .contains_key(&missing_id),
         "unknown pause should not leave lifecycle ownership behind"
     );
@@ -2635,7 +2635,7 @@ async fn orchestrator_unknown_sandbox_behaviors() -> Result<()> {
         !orchestrator
             .lifecycle_operations
             .lock()
-            .await
+            .expect("lifecycle operations mutex poisoned")
             .contains_key(&missing_id),
         "failed delete should retire lifecycle ownership"
     );
@@ -2647,6 +2647,97 @@ async fn orchestrator_unknown_sandbox_behaviors() -> Result<()> {
     assert!(matches!(retry_err, OrchestratorError::SandboxNotFound(_)));
 
     Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_unknown_deletes_both_report_not_found() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let first_delete_started = Arc::new(Notify::new());
+    let allow_first_delete = Arc::new(Notify::new());
+    store_control.push_update_if_state_action(StoreAction::Block {
+        started: Arc::clone(&first_delete_started),
+        release: Arc::clone(&allow_first_delete),
+    });
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(store_control),
+        MockBackendFactory::new(),
+    );
+    let missing_id = SandboxId::new();
+
+    let first_delete = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.delete_sandbox(missing_id).await })
+    };
+    timeout(Duration::from_secs(1), first_delete_started.notified())
+        .await
+        .expect("first delete should reach the blocked store operation");
+    let second_delete = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.delete_sandbox(missing_id).await })
+    };
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let second_delete_joined = orchestrator
+                .lifecycle_operations
+                .lock()
+                .expect("lifecycle operations mutex poisoned")
+                .get(&missing_id)
+                .is_some_and(|operation| Arc::strong_count(operation) >= 3);
+            if second_delete_joined {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("second delete should join the first lifecycle operation");
+
+    allow_first_delete.notify_one();
+    for result in [first_delete.await, second_delete.await] {
+        let error = result
+            .expect("delete task should not panic")
+            .expect_err("an unknown sandbox must not become idempotently deleted");
+        assert!(matches!(error, OrchestratorError::SandboxNotFound(_)));
+    }
+    assert!(
+        !orchestrator
+            .lifecycle_operations
+            .lock()
+            .expect("lifecycle operations mutex poisoned")
+            .contains_key(&missing_id),
+        "completed failed deletes should retire lifecycle ownership"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn lifecycle_operation_lease_retires_on_panic() {
+    setup();
+    let orchestrator = make_orchestrator().await;
+    let sandbox_id = SandboxId::new();
+    let operation_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move {
+            let (operation_lease, _) =
+                orchestrator.lifecycle_operation_lock(sandbox_id, LifecycleOperationKind::Pause);
+            let _operation_guard = operation_lease.operation_lock.lock().await;
+            panic!("forced lifecycle operation panic");
+        })
+    };
+
+    assert!(operation_task
+        .await
+        .expect_err("lifecycle task should panic")
+        .is_panic());
+    assert!(
+        !orchestrator
+            .lifecycle_operations
+            .lock()
+            .expect("lifecycle operations mutex poisoned")
+            .contains_key(&sandbox_id),
+        "a panicking operation must release its lifecycle-map membership"
+    );
 }
 
 #[tokio::test]
@@ -3252,7 +3343,7 @@ async fn pause_recovery_does_not_retain_handle_without_stable_cleanup_state() ->
         !orchestrator
             .lifecycle_operations
             .lock()
-            .await
+            .expect("lifecycle operations mutex poisoned")
             .contains_key(&sandbox_id),
         "failed recovery should retire lifecycle ownership"
     );
@@ -4052,6 +4143,94 @@ async fn auto_evict_task_does_not_keep_orchestrator_alive() -> anyhow::Result<()
     tokio::task::yield_now().await;
 
     assert!(weak.upgrade().is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn cancelled_shutdown_does_not_cancel_in_flight_pause_recovery() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let restore_started = Arc::new(Notify::new());
+    let allow_restore = Arc::new(Notify::new());
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Pause,
+        MockAction::Fail {
+            message: "forced pause failure".to_string(),
+        },
+    );
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::with_behavior(behavior),
+    );
+    let sandbox_id = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?
+        .id;
+    store_control.push_update_if_state_action(StoreAction::Delegate);
+    store_control.push_update_if_state_action(StoreAction::Block {
+        started: Arc::clone(&restore_started),
+        release: Arc::clone(&allow_restore),
+    });
+
+    let shutdown_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.shutdown().await })
+    };
+    timeout(Duration::from_secs(1), restore_started.notified())
+        .await
+        .expect("shutdown pause should reach the blocked metadata restore");
+    shutdown_task.abort();
+    assert!(shutdown_task
+        .await
+        .expect_err("shutdown task should be cancelled")
+        .is_cancelled());
+
+    allow_restore.notify_one();
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let metadata = orchestrator
+                .get_sandbox(&sandbox_id)
+                .await
+                .expect("metadata lookup should succeed");
+            let lookup = orchestrator
+                .proxy_lookup_for(&sandbox_id)
+                .await
+                .expect("proxy lookup should succeed");
+            let lifecycle_retired = !orchestrator
+                .lifecycle_operations
+                .lock()
+                .expect("lifecycle operations mutex poisoned")
+                .contains_key(&sandbox_id);
+            if metadata.is_some_and(|metadata| metadata.state == SandboxState::Running)
+                && matches!(lookup, ProxyLookupResult::Ready(_))
+                && lifecycle_retired
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("detached pause recovery should restore the running sandbox");
+    assert!(
+        !orchestrator
+            .lifecycle_operations
+            .lock()
+            .expect("lifecycle operations mutex poisoned")
+            .contains_key(&sandbox_id),
+        "detached pause recovery should retire lifecycle ownership"
+    );
+
+    orchestrator.shutdown().await?;
+    assert_eq!(
+        orchestrator
+            .get_sandbox(&sandbox_id)
+            .await?
+            .expect("shutdown should preserve paused metadata")
+            .state,
+        SandboxState::Paused
+    );
     Ok(())
 }
 

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -3703,11 +3703,6 @@ async fn pause_recovery_stop_failure_allows_delete_retry() -> Result<()> {
 async fn pause_running_state_restore_failure_stops_and_removes_sandbox() -> Result<()> {
     setup();
     let store_control = Arc::new(ScriptedStoreControl::default());
-    store_control.push_update_if_state_action(StoreAction::Delegate);
-    store_control.push_update_if_state_action(StoreAction::Delegate);
-    store_control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
-        source: anyhow::anyhow!("forced running state restore failure"),
-    }));
     let behavior = Arc::new(MockBehavior::new());
     behavior.push_action(
         MockOperation::Pause,
@@ -3716,7 +3711,7 @@ async fn pause_running_state_restore_failure_stops_and_removes_sandbox() -> Resu
         },
     );
     let orchestrator = make_orchestrator_without_background_with_factory(
-        ScriptedStore::new(store_control),
+        ScriptedStore::new(Arc::clone(&store_control)),
         MockBackendFactory::with_behavior(Arc::clone(&behavior)),
     );
 
@@ -3724,6 +3719,10 @@ async fn pause_running_state_restore_failure_stops_and_removes_sandbox() -> Resu
         .create_sandbox(create_request(Some(60), &[]))
         .await?;
     let sandbox_id = created.id;
+    store_control.push_update_if_state_action(StoreAction::Delegate);
+    store_control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("forced running state restore failure"),
+    }));
 
     let err = orchestrator
         .pause_sandbox(sandbox_id)

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -138,6 +138,7 @@ fn make_orchestrator_without_background_with_factory_and_persister<
         factory,
         persister,
         lifecycle_operations: Arc::new(StdMutex::new(HashMap::new())),
+        lifecycle_join_started: StdMutex::new(None),
         sandboxes: RwLock::new(HashMap::new()),
         proxy_routes: RwLock::new(ProxyRouteTable::default()),
         next_proxy_route_version: AtomicU64::new(1),
@@ -2476,28 +2477,52 @@ async fn orchestrator_concurrent_delete_calls_are_idempotent() -> Result<()> {
 #[tokio::test]
 async fn pause_waiting_for_failed_delete_retries_from_restored_running_state() -> Result<()> {
     setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
     let behavior = Arc::new(MockBehavior::new());
     behavior.push_action(
         MockOperation::Stop,
-        MockAction::FailAfter {
-            delay: Duration::from_millis(200),
+        MockAction::Fail {
             message: "forced delete stop failure".to_string(),
         },
     );
-    let orchestrator =
-        make_orchestrator_with_factory(MockBackendFactory::with_behavior(behavior)).await;
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::with_behavior(behavior),
+    );
     let created = orchestrator
         .create_sandbox(create_request(Some(60), &[]))
         .await?;
     let sandbox_id = created.id;
+    let delete_transition_started = Arc::new(Notify::new());
+    let allow_delete_transition = Arc::new(Notify::new());
+    store_control.push_update_if_state_action(StoreAction::BlockAfter {
+        started: Arc::clone(&delete_transition_started),
+        release: Arc::clone(&allow_delete_transition),
+    });
 
     let delete_task = {
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move { orchestrator.delete_sandbox(sandbox_id).await })
     };
-    wait_for_state(&orchestrator, &sandbox_id, SandboxState::Killing).await?;
+    timeout(Duration::from_secs(1), delete_transition_started.notified())
+        .await
+        .expect("delete should enter Killing before attempting stop");
 
-    orchestrator.pause_sandbox(sandbox_id).await?;
+    let pause_join_started = Arc::new(Notify::new());
+    orchestrator.notify_on_next_lifecycle_join(Arc::clone(&pause_join_started));
+    let pause_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.pause_sandbox(sandbox_id).await })
+    };
+    timeout(Duration::from_secs(1), pause_join_started.notified())
+        .await
+        .expect("pause should join the in-flight delete operation");
+
+    allow_delete_transition.notify_one();
+    pause_task
+        .await
+        .expect("pause task should not panic")
+        .expect("pause should retry after delete restores Running");
     let delete_error = delete_task
         .await
         .expect("delete task should not panic")
@@ -2793,25 +2818,18 @@ async fn concurrent_unknown_deletes_both_report_not_found() -> Result<()> {
         .await
         .expect("first delete should reach the blocked store operation");
     let second_delete = {
+        let second_delete_join_started = Arc::new(Notify::new());
+        orchestrator.notify_on_next_lifecycle_join(Arc::clone(&second_delete_join_started));
         let orchestrator = Arc::clone(&orchestrator);
-        tokio::spawn(async move { orchestrator.delete_sandbox(missing_id).await })
+        let task = tokio::spawn(async move { orchestrator.delete_sandbox(missing_id).await });
+        timeout(
+            Duration::from_secs(1),
+            second_delete_join_started.notified(),
+        )
+        .await
+        .expect("second delete should join the first lifecycle operation");
+        task
     };
-    timeout(Duration::from_secs(1), async {
-        loop {
-            let second_delete_joined = orchestrator
-                .lifecycle_operations
-                .lock()
-                .expect("lifecycle operations mutex poisoned")
-                .get(&missing_id)
-                .is_some_and(|operation| Arc::strong_count(operation) >= 3);
-            if second_delete_joined {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("second delete should join the first lifecycle operation");
 
     allow_first_delete.notify_one();
     for result in [first_delete.await, second_delete.await] {

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -3504,7 +3504,9 @@ async fn pause_recovery_store_wait_does_not_block_other_sandbox_tables() -> Resu
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move { orchestrator.pause_sandbox(recovering.id).await })
     };
-    restore_started.notified().await;
+    timeout(Duration::from_secs(1), restore_started.notified())
+        .await
+        .expect("pause recovery should reach the blocked metadata restore");
 
     let unaffected_lookup = timeout(
         Duration::from_secs(1),

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -2808,6 +2808,16 @@ async fn orchestrator_delete_paused_sandbox_removes_metadata() -> Result<()> {
 async fn pause_failure_rolls_back_to_running_and_preserves_handle() -> Result<()> {
     setup();
     let behavior = Arc::new(MockBehavior::new());
+    let resume_calls = Arc::new(StdMutex::new(0usize));
+    let resume_calls_for_hook = Arc::clone(&resume_calls);
+    behavior.set_on_operation(
+        MockOperation::Resume,
+        Arc::new(move || {
+            *resume_calls_for_hook
+                .lock()
+                .expect("resume call counter mutex poisoned") += 1;
+        }),
+    );
     behavior.push_action(
         MockOperation::Pause,
         MockAction::Fail {
@@ -2815,7 +2825,8 @@ async fn pause_failure_rolls_back_to_running_and_preserves_handle() -> Result<()
         },
     );
     let orchestrator =
-        make_orchestrator_with_factory(MockBackendFactory::with_behavior(behavior)).await;
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(Arc::clone(&behavior)))
+            .await;
 
     let created = orchestrator
         .create_sandbox(create_request(Some(60), &[("team", "pause-failure")]))
@@ -2859,8 +2870,66 @@ async fn pause_failure_rolls_back_to_running_and_preserves_handle() -> Result<()
         created.resources.memory_mib,
     )
     .await;
+    assert_eq!(
+        *resume_calls
+            .lock()
+            .expect("resume call counter mutex poisoned"),
+        1,
+        "recoverable pause failure should resume the backend before restoring Running state"
+    );
 
     orchestrator.delete_sandbox(sandbox_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_recovery_failure_stops_and_removes_sandbox() -> Result<()> {
+    setup();
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Pause,
+        MockAction::Fail {
+            message: "forced pause failure".to_string(),
+        },
+    );
+    behavior.push_action(
+        MockOperation::Resume,
+        MockAction::Fail {
+            message: "forced resume failure".to_string(),
+        },
+    );
+    let orchestrator =
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(Arc::clone(&behavior)))
+            .await;
+
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let sandbox_id = created.id;
+
+    let err = orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("pause should fail when the backend cannot be resumed");
+    assert!(matches!(
+        err,
+        OrchestratorError::SandboxOperationFailed {
+            operation: SandboxOperation::Pause,
+            ..
+        }
+    ));
+
+    assert!(
+        orchestrator.get_sandbox(&sandbox_id).await?.is_none(),
+        "sandbox should be removed when pause recovery fails"
+    );
+    assert_proxy_not_found(&orchestrator, &sandbox_id).await?;
+    assert_eq!(
+        behavior.stop_calls(),
+        1,
+        "pause recovery failure should stop the backend"
+    );
+    assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;
     Ok(())
 }
 

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -34,6 +34,51 @@ use crate::snapshot::RunnableSnapshot;
 use crate::types::{ImageConfigs, SandboxId, SandboxResources};
 
 const STATE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const TEST_SYNC_TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn wait_for_notification_or_abort<T>(
+    notification: &Notify,
+    task: &mut tokio::task::JoinHandle<T>,
+    context: &str,
+) {
+    tokio::select! {
+        _ = notification.notified() => {}
+        result = &mut *task => {
+            match result {
+                Ok(_) => panic!("{context}: task completed before the synchronization point"),
+                Err(error) => panic!("{context}: task ended before the synchronization point: {error}"),
+            }
+        }
+        _ = sleep(TEST_SYNC_TIMEOUT) => {
+            task.abort();
+            let _ = (&mut *task).await;
+            panic!("{context}: timed out after {TEST_SYNC_TIMEOUT:?}");
+        }
+    }
+}
+
+async fn join_task_or_abort<T>(
+    mut task: tokio::task::JoinHandle<T>,
+    context: &str,
+) -> std::result::Result<T, tokio::task::JoinError> {
+    tokio::select! {
+        result = &mut task => result,
+        _ = sleep(TEST_SYNC_TIMEOUT) => {
+            task.abort();
+            let _ = (&mut task).await;
+            panic!("{context}: timed out after {TEST_SYNC_TIMEOUT:?}");
+        }
+    }
+}
+
+async fn await_test_future<F>(future: F, context: &str) -> F::Output
+where
+    F: std::future::Future,
+{
+    timeout(TEST_SYNC_TIMEOUT, future)
+        .await
+        .unwrap_or_else(|_| panic!("{context}: timed out after {TEST_SYNC_TIMEOUT:?}"))
+}
 
 type TestOrchestrator<
     S = InMemoryMetadataStore,
@@ -140,6 +185,7 @@ fn make_orchestrator_without_background_with_factory_and_persister<
         lifecycle_operations: Arc::new(StdMutex::new(HashMap::new())),
         lifecycle_join_started: StdMutex::new(None),
         sandboxes: RwLock::new(HashMap::new()),
+        cleanup_handles: RwLock::new(HashMap::new()),
         proxy_routes: RwLock::new(ProxyRouteTable::default()),
         next_proxy_route_version: AtomicU64::new(1),
         counters: Default::default(),
@@ -1004,13 +1050,16 @@ async fn proxy_lookup_rejects_route_replaced_during_metadata_read() -> Result<()
         release: Arc::clone(&allow_first_read),
     });
 
-    let lookup_task = {
+    let mut lookup_task = {
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move { orchestrator.proxy_lookup_for(&created.id).await })
     };
-    timeout(Duration::from_secs(1), first_read_started.notified())
-        .await
-        .expect("proxy lookup should snapshot metadata after reading the route");
+    wait_for_notification_or_abort(
+        &first_read_started,
+        &mut lookup_task,
+        "proxy lookup should snapshot metadata after reading the route",
+    )
+    .await;
     assert_eq!(
         store_control.get_calls() - get_calls_before_lookup,
         1,
@@ -1024,10 +1073,12 @@ async fn proxy_lookup_rejects_route_replaced_during_metadata_read() -> Result<()
 
     let get_calls_before_release = store_control.get_calls();
     allow_first_read.notify_one();
-    let lookup = timeout(Duration::from_secs(1), lookup_task)
-        .await
-        .expect("proxy lookup should finish after its first read is released")
-        .expect("proxy lookup task should not panic")?;
+    let lookup = join_task_or_abort(
+        lookup_task,
+        "proxy lookup should finish after its first read is released",
+    )
+    .await
+    .expect("proxy lookup task should not panic")?;
     assert_eq!(
         lookup,
         ProxyLookupResult::RouteMissing,
@@ -1039,6 +1090,113 @@ async fn proxy_lookup_rejects_route_replaced_during_metadata_read() -> Result<()
         "the proxy lookup must not issue a second metadata read after validation"
     );
     orchestrator.delete_sandbox(created.id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn proxy_lookup_rejects_route_when_pause_state_is_published() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::new(),
+    );
+    let sandbox_id = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?
+        .id;
+
+    let lookup_read_started = Arc::new(Notify::new());
+    let allow_lookup_read = Arc::new(Notify::new());
+    store_control.push_get_action(StoreAction::BlockAfter {
+        started: Arc::clone(&lookup_read_started),
+        release: Arc::clone(&allow_lookup_read),
+    });
+    let mut lookup_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.proxy_lookup_for(&sandbox_id).await })
+    };
+    wait_for_notification_or_abort(
+        &lookup_read_started,
+        &mut lookup_task,
+        "proxy lookup should snapshot Running metadata",
+    )
+    .await;
+
+    let pause_transition_started = Arc::new(Notify::new());
+    let allow_pause_transition = Arc::new(Notify::new());
+    store_control.push_update_if_state_action(StoreAction::BlockAfter {
+        started: Arc::clone(&pause_transition_started),
+        release: Arc::clone(&allow_pause_transition),
+    });
+    let mut pause_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.pause_sandbox(sandbox_id).await })
+    };
+    wait_for_notification_or_abort(
+        &pause_transition_started,
+        &mut pause_task,
+        "pause should publish Pausing after invalidating the route",
+    )
+    .await;
+
+    allow_lookup_read.notify_one();
+    let lookup = join_task_or_abort(lookup_task, "proxy lookup should finish after release")
+        .await
+        .expect("proxy lookup task should not panic")?;
+    assert_eq!(
+        lookup,
+        ProxyLookupResult::RouteMissing,
+        "a lookup that observed the old Running state must not return a route after pause starts"
+    );
+
+    allow_pause_transition.notify_one();
+    join_task_or_abort(pause_task, "pause should finish after transition release")
+        .await
+        .expect("pause task should not panic")?;
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_transition_failure_restores_route_without_metadata_read() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::new(),
+    );
+    let sandbox_id = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?
+        .id;
+    let target = proxy_target_for(&orchestrator, &sandbox_id)
+        .await?
+        .expect("running sandbox should have a proxy route");
+    let get_calls_before_pause = store_control.get_calls();
+    store_control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("forced pause transition failure"),
+    }));
+
+    let error = orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("pause transition should fail");
+    assert!(
+        format!("{error:#}").contains("forced pause transition failure"),
+        "{error:#}"
+    );
+    assert_eq!(
+        store_control.get_calls(),
+        get_calls_before_pause,
+        "restoring the invalidated route must not depend on another store read"
+    );
+    assert_eq!(
+        proxy_target_for(&orchestrator, &sandbox_id).await?,
+        Some(target)
+    );
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
     Ok(())
 }
 
@@ -2500,23 +2658,29 @@ async fn pause_waiting_for_failed_delete_retries_from_restored_running_state() -
         release: Arc::clone(&allow_delete_transition),
     });
 
-    let delete_task = {
+    let mut delete_task = {
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move { orchestrator.delete_sandbox(sandbox_id).await })
     };
-    timeout(Duration::from_secs(1), delete_transition_started.notified())
-        .await
-        .expect("delete should enter Killing before attempting stop");
+    wait_for_notification_or_abort(
+        &delete_transition_started,
+        &mut delete_task,
+        "delete should enter Killing before attempting stop",
+    )
+    .await;
 
     let pause_join_started = Arc::new(Notify::new());
     orchestrator.notify_on_next_lifecycle_join(Arc::clone(&pause_join_started));
-    let pause_task = {
+    let mut pause_task = {
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move { orchestrator.pause_sandbox(sandbox_id).await })
     };
-    timeout(Duration::from_secs(1), pause_join_started.notified())
-        .await
-        .expect("pause should join the in-flight delete operation");
+    wait_for_notification_or_abort(
+        &pause_join_started,
+        &mut pause_task,
+        "pause should join the in-flight delete operation",
+    )
+    .await;
 
     allow_delete_transition.notify_one();
     pause_task
@@ -2810,24 +2974,27 @@ async fn concurrent_unknown_deletes_both_report_not_found() -> Result<()> {
     );
     let missing_id = SandboxId::new();
 
-    let first_delete = {
+    let mut first_delete = {
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move { orchestrator.delete_sandbox(missing_id).await })
     };
-    timeout(Duration::from_secs(1), first_delete_started.notified())
-        .await
-        .expect("first delete should reach the blocked store operation");
+    wait_for_notification_or_abort(
+        &first_delete_started,
+        &mut first_delete,
+        "first delete should reach the blocked store operation",
+    )
+    .await;
     let second_delete = {
         let second_delete_join_started = Arc::new(Notify::new());
         orchestrator.notify_on_next_lifecycle_join(Arc::clone(&second_delete_join_started));
         let orchestrator = Arc::clone(&orchestrator);
-        let task = tokio::spawn(async move { orchestrator.delete_sandbox(missing_id).await });
-        timeout(
-            Duration::from_secs(1),
-            second_delete_join_started.notified(),
+        let mut task = tokio::spawn(async move { orchestrator.delete_sandbox(missing_id).await });
+        wait_for_notification_or_abort(
+            &second_delete_join_started,
+            &mut task,
+            "second delete should join the first lifecycle operation",
         )
-        .await
-        .expect("second delete should join the first lifecycle operation");
+        .await;
         task
     };
 
@@ -3388,7 +3555,7 @@ async fn pause_recovery_metadata_cleanup_failure_releases_paused_image_refs() ->
     assert_eq!(behavior.stop_calls(), 1);
     assert!(
         orchestrator
-            .sandboxes
+            .cleanup_handles
             .read()
             .await
             .contains_key(&sandbox_id),
@@ -3467,7 +3634,7 @@ async fn pause_recovery_retains_handle_when_cleanup_state_update_fails() -> Resu
     );
     assert!(
         orchestrator
-            .sandboxes
+            .cleanup_handles
             .read()
             .await
             .contains_key(&sandbox_id),
@@ -3516,7 +3683,7 @@ async fn cleanup_handle_is_reachable_before_cleanup_state_transition() -> Result
         started: Arc::clone(&transition_started),
         release: Arc::new(Notify::new()),
     });
-    let retain_task = {
+    let mut retain_task = {
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move {
             orchestrator
@@ -3524,12 +3691,15 @@ async fn cleanup_handle_is_reachable_before_cleanup_state_transition() -> Result
                 .await
         })
     };
-    timeout(Duration::from_secs(1), transition_started.notified())
-        .await
-        .expect("cleanup state transition should start");
+    wait_for_notification_or_abort(
+        &transition_started,
+        &mut retain_task,
+        "cleanup state transition should start",
+    )
+    .await;
     assert!(
         orchestrator
-            .sandboxes
+            .cleanup_handles
             .read()
             .await
             .contains_key(&sandbox_id),
@@ -3546,6 +3716,55 @@ async fn cleanup_handle_is_reachable_before_cleanup_state_transition() -> Result
     );
     orchestrator.delete_sandbox(sandbox_id).await?;
     assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_retries_cleanup_handle_after_metadata_disappears() -> Result<()> {
+    setup();
+    let behavior = Arc::new(MockBehavior::new());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+    let sandbox_id = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?
+        .id;
+    orchestrator
+        .store
+        .update_state_if_state(&sandbox_id, SandboxState::Pausing, &[SandboxState::Running])
+        .await?;
+    let (handle, _) = orchestrator
+        .detach_sandbox_handle_and_route(&sandbox_id)
+        .await;
+    let handle = handle.expect("created sandbox should have a backend handle");
+    orchestrator.store.remove(&sandbox_id).await?;
+
+    let retain_error = orchestrator
+        .retain_sandbox_handle_for_cleanup(sandbox_id, handle)
+        .await
+        .expect_err("missing metadata should prevent the Killing transition");
+    assert!(matches!(
+        retain_error,
+        StoreError::SandboxNotFound { sandbox_id: missing } if missing == sandbox_id
+    ));
+    assert!(
+        orchestrator
+            .cleanup_handles
+            .read()
+            .await
+            .contains_key(&sandbox_id),
+        "cleanup ownership must survive independently of metadata"
+    );
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    assert_eq!(behavior.stop_calls(), 1);
+    assert!(!orchestrator
+        .cleanup_handles
+        .read()
+        .await
+        .contains_key(&sandbox_id));
     Ok(())
 }
 
@@ -3581,20 +3800,22 @@ async fn pause_recovery_store_wait_does_not_block_other_sandbox_tables() -> Resu
         release: Arc::clone(&allow_restore),
     });
 
-    let pause_task = {
+    let mut pause_task = {
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move { orchestrator.pause_sandbox(recovering.id).await })
     };
-    timeout(Duration::from_secs(1), restore_started.notified())
-        .await
-        .expect("pause recovery should reach the blocked metadata restore");
-
-    let unaffected_lookup = timeout(
-        Duration::from_secs(1),
-        orchestrator.proxy_lookup_for(&unaffected.id),
+    wait_for_notification_or_abort(
+        &restore_started,
+        &mut pause_task,
+        "pause recovery should reach the blocked metadata restore",
     )
-    .await
-    .expect("blocked recovery store call must not hold global sandbox tables")?;
+    .await;
+
+    let unaffected_lookup = await_test_future(
+        orchestrator.proxy_lookup_for(&unaffected.id),
+        "blocked recovery store call must not hold global sandbox tables",
+    )
+    .await?;
     assert_eq!(
         unaffected_lookup,
         ProxyLookupResult::Ready(unaffected_target)
@@ -3658,7 +3879,7 @@ async fn pause_recovery_stop_failure_allows_delete_retry() -> Result<()> {
     assert_eq!(metadata.state, SandboxState::Killing);
     assert!(
         orchestrator
-            .sandboxes
+            .cleanup_handles
             .read()
             .await
             .contains_key(&sandbox_id),
@@ -4371,13 +4592,16 @@ async fn cancelled_shutdown_does_not_cancel_in_flight_pause_recovery() -> Result
         release: Arc::clone(&allow_restore),
     });
 
-    let shutdown_task = {
+    let mut shutdown_task = {
         let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move { orchestrator.shutdown().await })
     };
-    timeout(Duration::from_secs(1), restore_started.notified())
-        .await
-        .expect("shutdown pause should reach the blocked metadata restore");
+    wait_for_notification_or_abort(
+        &restore_started,
+        &mut shutdown_task,
+        "shutdown pause should reach the blocked metadata restore",
+    )
+    .await;
     shutdown_task.abort();
     assert!(shutdown_task
         .await
@@ -4385,32 +4609,34 @@ async fn cancelled_shutdown_does_not_cancel_in_flight_pause_recovery() -> Result
         .is_cancelled());
 
     allow_restore.notify_one();
-    timeout(Duration::from_secs(1), async {
-        loop {
-            let metadata = orchestrator
-                .get_sandbox(&sandbox_id)
-                .await
-                .expect("metadata lookup should succeed");
-            let lookup = orchestrator
-                .proxy_lookup_for(&sandbox_id)
-                .await
-                .expect("proxy lookup should succeed");
-            let lifecycle_retired = !orchestrator
-                .lifecycle_operations
-                .lock()
-                .expect("lifecycle operations mutex poisoned")
-                .contains_key(&sandbox_id);
-            if metadata.is_some_and(|metadata| metadata.state == SandboxState::Running)
-                && matches!(lookup, ProxyLookupResult::Ready(_))
-                && lifecycle_retired
-            {
-                break;
+    await_test_future(
+        async {
+            loop {
+                let metadata = orchestrator
+                    .get_sandbox(&sandbox_id)
+                    .await
+                    .expect("metadata lookup should succeed");
+                let lookup = orchestrator
+                    .proxy_lookup_for(&sandbox_id)
+                    .await
+                    .expect("proxy lookup should succeed");
+                let lifecycle_retired = !orchestrator
+                    .lifecycle_operations
+                    .lock()
+                    .expect("lifecycle operations mutex poisoned")
+                    .contains_key(&sandbox_id);
+                if metadata.is_some_and(|metadata| metadata.state == SandboxState::Running)
+                    && matches!(lookup, ProxyLookupResult::Ready(_))
+                    && lifecycle_retired
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
             }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("detached pause recovery should restore the running sandbox");
+        },
+        "detached pause recovery should restore the running sandbox",
+    )
+    .await;
     assert!(
         !orchestrator
             .lifecycle_operations

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -3397,7 +3397,7 @@ async fn pause_recovery_metadata_cleanup_failure_releases_paused_image_refs() ->
 }
 
 #[tokio::test]
-async fn pause_recovery_does_not_retain_handle_without_stable_cleanup_state() -> Result<()> {
+async fn pause_recovery_retains_handle_when_cleanup_state_update_fails() -> Result<()> {
     setup();
     let store_control = Arc::new(ScriptedStoreControl::default());
     store_control.push_remove_action(StoreAction::Fail(StoreError::Backend {
@@ -3444,12 +3444,12 @@ async fn pause_recovery_does_not_retain_handle_without_stable_cleanup_state() ->
         "{message}"
     );
     assert!(
-        !orchestrator
+        orchestrator
             .sandboxes
             .read()
             .await
             .contains_key(&sandbox_id),
-        "a handle must not be published without a stable cleanup state"
+        "an unresolved cleanup state must not make the backend handle unreachable"
     );
     assert_eq!(
         orchestrator.proxy_lookup_for(&sandbox_id).await?,
@@ -3465,6 +3465,65 @@ async fn pause_recovery_does_not_retain_handle_without_stable_cleanup_state() ->
     );
 
     orchestrator.delete_sandbox(sandbox_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cleanup_handle_is_reachable_before_cleanup_state_transition() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::new(),
+    );
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let sandbox_id = created.id;
+    orchestrator
+        .store
+        .update_state_if_state(&sandbox_id, SandboxState::Pausing, &[SandboxState::Running])
+        .await?;
+    let (handle, _) = orchestrator
+        .detach_sandbox_handle_and_route(&sandbox_id)
+        .await;
+    let handle = handle.expect("created sandbox should have a backend handle");
+
+    let transition_started = Arc::new(Notify::new());
+    store_control.push_update_if_state_action(StoreAction::Block {
+        started: Arc::clone(&transition_started),
+        release: Arc::new(Notify::new()),
+    });
+    let retain_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move {
+            orchestrator
+                .retain_sandbox_handle_for_cleanup(sandbox_id, handle)
+                .await
+        })
+    };
+    timeout(Duration::from_secs(1), transition_started.notified())
+        .await
+        .expect("cleanup state transition should start");
+    assert!(
+        orchestrator
+            .sandboxes
+            .read()
+            .await
+            .contains_key(&sandbox_id),
+        "backend ownership must be published before the cleanup state write"
+    );
+
+    retain_task.abort();
+    assert!(
+        retain_task
+            .await
+            .expect_err("retain task should be cancelled")
+            .is_cancelled(),
+        "retain task should stop at the blocked cleanup state transition"
+    );
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
     Ok(())
 }
 

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use async_trait::async_trait;
@@ -170,6 +171,7 @@ type StoreHookSlot = StdMutex<Option<StoreHook>>;
 struct ScriptedStoreControl {
     add_actions: StdMutex<VecDeque<StoreAction>>,
     get_actions: StdMutex<VecDeque<StoreAction>>,
+    get_calls: AtomicUsize,
     update_if_state_actions: StdMutex<VecDeque<StoreAction>>,
     remove_actions: StdMutex<VecDeque<StoreAction>>,
     on_add: StoreHookSlot,
@@ -195,6 +197,10 @@ impl ScriptedStoreControl {
             .lock()
             .expect("get actions mutex poisoned")
             .push_back(action);
+    }
+
+    fn get_calls(&self) -> usize {
+        self.get_calls.load(Ordering::Relaxed)
     }
 
     fn push_remove_action(&self, action: StoreAction) {
@@ -330,6 +336,7 @@ impl MetadataStore for ScriptedStore {
     }
 
     async fn get(&self, sandbox_id: &SandboxId) -> StdResult<Option<SandboxMetadata>, StoreError> {
+        self.control.get_calls.fetch_add(1, Ordering::Relaxed);
         match ScriptedStoreControl::take_action(&self.control.get_actions) {
             StoreAction::Delegate => self.inner.get(sandbox_id).await,
             StoreAction::Block { started, release } => {
@@ -978,7 +985,7 @@ async fn proxy_target_for_only_returns_running_routes() {
 }
 
 #[tokio::test]
-async fn proxy_lookup_revalidates_running_state_after_reading_route() -> Result<()> {
+async fn proxy_lookup_rejects_route_replaced_during_metadata_read() -> Result<()> {
     setup();
     let store_control = Arc::new(ScriptedStoreControl::default());
     let orchestrator = make_orchestrator_without_background_with_factory(
@@ -988,6 +995,7 @@ async fn proxy_lookup_revalidates_running_state_after_reading_route() -> Result<
     let created = orchestrator
         .create_sandbox(create_request(Some(60), &[]))
         .await?;
+    let get_calls_before_lookup = store_control.get_calls();
     let first_read_started = Arc::new(Notify::new());
     let allow_first_read = Arc::new(Notify::new());
     store_control.push_get_action(StoreAction::BlockAfter {
@@ -1001,22 +1009,19 @@ async fn proxy_lookup_revalidates_running_state_after_reading_route() -> Result<
     };
     timeout(Duration::from_secs(1), first_read_started.notified())
         .await
-        .expect("proxy lookup should complete its first metadata read");
+        .expect("proxy lookup should snapshot metadata after reading the route");
+    assert_eq!(
+        store_control.get_calls() - get_calls_before_lookup,
+        1,
+        "the suspended proxy lookup should have issued one metadata read"
+    );
 
-    let transition_started = Arc::new(Notify::new());
-    let allow_transition = Arc::new(Notify::new());
-    store_control.push_update_if_state_action(StoreAction::BlockAfter {
-        started: Arc::clone(&transition_started),
-        release: Arc::clone(&allow_transition),
-    });
-    let pause_task = {
-        let orchestrator = Arc::clone(&orchestrator);
-        tokio::spawn(async move { orchestrator.pause_sandbox(created.id).await })
-    };
-    timeout(Duration::from_secs(1), transition_started.notified())
-        .await
-        .expect("pause should persist Pausing before detaching the route");
+    orchestrator.pause_sandbox(created.id).await?;
+    orchestrator
+        .resume_sandbox(created.id, NewTimeout::UseExisting)
+        .await?;
 
+    let get_calls_before_release = store_control.get_calls();
     allow_first_read.notify_one();
     let lookup = timeout(Duration::from_secs(1), lookup_task)
         .await
@@ -1024,15 +1029,14 @@ async fn proxy_lookup_revalidates_running_state_after_reading_route() -> Result<
         .expect("proxy lookup task should not panic")?;
     assert_eq!(
         lookup,
-        ProxyLookupResult::Unavailable(SandboxState::Pausing),
-        "a route read against stale Running metadata must not remain proxyable"
+        ProxyLookupResult::RouteMissing,
+        "a replaced route generation must not be returned with stale Running metadata"
     );
-
-    allow_transition.notify_one();
-    pause_task
-        .await
-        .expect("pause task should not panic")
-        .expect("pause should succeed");
+    assert_eq!(
+        store_control.get_calls(),
+        get_calls_before_release,
+        "the proxy lookup must not issue a second metadata read after validation"
+    );
     orchestrator.delete_sandbox(created.id).await?;
     Ok(())
 }

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -48,6 +48,37 @@ fn test_runtime_image_refs() -> Arc<dyn RuntimeImageRefs> {
     local_image_services_from_global_config().runtime_refs
 }
 
+#[derive(Debug, Default)]
+struct RecordingRuntimeImageRefs {
+    unpinned: Mutex<Vec<RuntimeImageOwner>>,
+}
+
+#[async_trait]
+impl RuntimeImageRefs for RecordingRuntimeImageRefs {
+    async fn pin(
+        &self,
+        _owner: RuntimeImageOwner,
+        _artifacts: RuntimeArtifactSet,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn unpin_best_effort(&self, owner: RuntimeImageOwner) {
+        self.unpinned.lock().await.push(owner);
+    }
+
+    async fn reconcile_paused(&self, _live_paused: &[SandboxId]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn maintain_running(
+        &self,
+        _running: Vec<(SandboxId, RuntimeArtifactSet)>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
 async fn make_orchestrator() -> Arc<TestOrchestrator> {
     Orchestrator::new_inner(
         InMemoryMetadataStore::new(),
@@ -105,6 +136,7 @@ fn make_orchestrator_without_background_with_factory_and_persister<
         store,
         factory,
         persister,
+        lifecycle_operations: Mutex::new(HashMap::new()),
         sandboxes: RwLock::new(HashMap::new()),
         proxy_routes: RwLock::new(ProxyRouteTable::default()),
         next_proxy_route_version: AtomicU64::new(1),
@@ -130,6 +162,7 @@ type StoreHookSlot = StdMutex<Option<StoreHook>>;
 struct ScriptedStoreControl {
     add_actions: StdMutex<VecDeque<StoreAction>>,
     update_if_state_actions: StdMutex<VecDeque<StoreAction>>,
+    remove_actions: StdMutex<VecDeque<StoreAction>>,
     on_add: StoreHookSlot,
 }
 
@@ -145,6 +178,13 @@ impl ScriptedStoreControl {
         self.update_if_state_actions
             .lock()
             .expect("update_if_state actions mutex poisoned")
+            .push_back(action);
+    }
+
+    fn push_remove_action(&self, action: StoreAction) {
+        self.remove_actions
+            .lock()
+            .expect("remove actions mutex poisoned")
             .push_back(action);
     }
 
@@ -238,7 +278,10 @@ impl MetadataStore for ScriptedStore {
         &self,
         sandbox_id: &SandboxId,
     ) -> StdResult<Option<SandboxMetadata>, StoreError> {
-        self.inner.remove(sandbox_id).await
+        match ScriptedStoreControl::take_action(&self.control.remove_actions) {
+            StoreAction::Delegate => self.inner.remove(sandbox_id).await,
+            StoreAction::Fail(err) => Err(err),
+        }
     }
 
     async fn list(&self) -> StdResult<Vec<SandboxMetadata>, StoreError> {
@@ -828,8 +871,22 @@ async fn proxy_target_for_only_returns_running_routes() {
     let target = ProxyTarget::new(Ipv4Addr::new(10, 11, 0, 42));
 
     orchestrator
+        .set_metadata_state_for_test(sandbox_id, SandboxState::Pausing)
+        .await
+        .unwrap();
+    orchestrator
         .upsert_proxy_route(sandbox_id, target.clone())
         .await;
+    assert_eq!(
+        proxy_target_for(&orchestrator, &sandbox_id).await.unwrap(),
+        None,
+        "a pre-published route must remain unavailable until metadata is Running"
+    );
+    orchestrator
+        .store
+        .update_state_if_state(&sandbox_id, SandboxState::Running, &[SandboxState::Pausing])
+        .await
+        .unwrap();
     assert_eq!(
         proxy_target_for(&orchestrator, &sandbox_id).await.unwrap(),
         Some(target)
@@ -842,6 +899,10 @@ async fn restore_proxy_route_republishes_running_target() {
     let sandbox_id = SandboxId::new();
     let target = ProxyTarget::new(Ipv4Addr::new(10, 11, 0, 77));
 
+    orchestrator
+        .set_metadata_state_for_test(sandbox_id, SandboxState::Running)
+        .await
+        .unwrap();
     orchestrator
         .upsert_proxy_route(sandbox_id, target.clone())
         .await;
@@ -2911,6 +2972,7 @@ async fn pause_recovery_failure_stops_and_removes_sandbox() -> Result<()> {
         .pause_sandbox(sandbox_id)
         .await
         .expect_err("pause should fail when the backend cannot be resumed");
+    let message = format!("{err:#}");
     assert!(matches!(
         err,
         OrchestratorError::SandboxOperationFailed {
@@ -2918,6 +2980,8 @@ async fn pause_recovery_failure_stops_and_removes_sandbox() -> Result<()> {
             ..
         }
     ));
+    assert!(message.contains("forced pause failure"), "{message}");
+    assert!(message.contains("forced resume failure"), "{message}");
 
     assert!(
         orchestrator.get_sandbox(&sandbox_id).await?.is_none(),
@@ -2929,6 +2993,218 @@ async fn pause_recovery_failure_stops_and_removes_sandbox() -> Result<()> {
         1,
         "pause recovery failure should stop the backend"
     );
+    assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_recovery_metadata_cleanup_failure_releases_paused_image_refs() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    store_control.push_remove_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("forced metadata cleanup failure"),
+    }));
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Pause,
+        MockAction::Fail {
+            message: "forced pause failure".to_string(),
+        },
+    );
+    behavior.push_action(
+        MockOperation::Resume,
+        MockAction::Fail {
+            message: "forced resume failure".to_string(),
+        },
+    );
+    let image_refs = Arc::new(RecordingRuntimeImageRefs::default());
+    let mut orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(store_control),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+    Arc::get_mut(&mut orchestrator)
+        .expect("orchestrator should be uniquely owned")
+        .image_refs = image_refs.clone();
+
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let sandbox_id = created.id;
+    image_refs.unpinned.lock().await.clear();
+
+    let err = orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("pause recovery should report metadata cleanup failure");
+    let message = format!("{err:#}");
+    assert!(message.contains("forced pause failure"), "{message}");
+    assert!(message.contains("forced resume failure"), "{message}");
+    assert!(
+        message.contains("forced metadata cleanup failure"),
+        "{message}"
+    );
+    assert_eq!(behavior.stop_calls(), 1);
+    assert!(
+        orchestrator
+            .sandboxes
+            .read()
+            .await
+            .contains_key(&sandbox_id),
+        "stopped backend handle should remain owned while metadata cleanup is unresolved"
+    );
+    assert_eq!(
+        orchestrator.proxy_lookup_for(&sandbox_id).await?,
+        ProxyLookupResult::Unavailable(SandboxState::Killing)
+    );
+    assert!(
+        orchestrator
+            .proxy_routes
+            .read()
+            .await
+            .proxy_target(&sandbox_id)
+            .is_none(),
+        "proxy route should remain detached while metadata cleanup is unresolved"
+    );
+    assert_eq!(
+        image_refs.unpinned.lock().await.as_slice(),
+        &[RuntimeImageOwner::PausedSandbox(sandbox_id)]
+    );
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_recovery_stop_failure_allows_delete_retry() -> Result<()> {
+    setup();
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Pause,
+        MockAction::Fail {
+            message: "forced pause failure".to_string(),
+        },
+    );
+    behavior.push_action(
+        MockOperation::Resume,
+        MockAction::Fail {
+            message: "forced resume failure".to_string(),
+        },
+    );
+    behavior.push_action(
+        MockOperation::Stop,
+        MockAction::Fail {
+            message: "forced stop failure".to_string(),
+        },
+    );
+    let orchestrator =
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(Arc::clone(&behavior)))
+            .await;
+
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let sandbox_id = created.id;
+
+    let err = orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("pause should fail when recovery and cleanup fail");
+    let message = format!("{err:#}");
+    assert!(message.contains("forced pause failure"), "{message}");
+    assert!(message.contains("forced resume failure"), "{message}");
+    assert!(message.contains("forced stop failure"), "{message}");
+
+    let metadata = orchestrator
+        .get_sandbox(&sandbox_id)
+        .await?
+        .expect("sandbox metadata should remain while backend cleanup is unresolved");
+    assert_eq!(metadata.state, SandboxState::Killing);
+    assert!(
+        orchestrator
+            .sandboxes
+            .read()
+            .await
+            .contains_key(&sandbox_id),
+        "backend handle should remain available for cleanup retry"
+    );
+    assert_eq!(
+        orchestrator.proxy_lookup_for(&sandbox_id).await?,
+        ProxyLookupResult::Unavailable(SandboxState::Killing)
+    );
+    assert!(
+        orchestrator
+            .proxy_routes
+            .read()
+            .await
+            .proxy_target(&sandbox_id)
+            .is_none(),
+        "proxy route should remain detached while cleanup is unresolved"
+    );
+    assert_eq!(behavior.stop_calls(), 1);
+    assert_metrics_values(
+        &orchestrator,
+        1,
+        0,
+        1,
+        0,
+        created.resources.cpu_count,
+        created.resources.memory_mib,
+    )
+    .await;
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
+    assert_eq!(
+        behavior.stop_calls(),
+        2,
+        "delete should retry the failed stop"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_running_state_restore_failure_stops_and_removes_sandbox() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    store_control.push_update_if_state_action(StoreAction::Delegate);
+    store_control.push_update_if_state_action(StoreAction::Delegate);
+    store_control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("forced running state restore failure"),
+    }));
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Pause,
+        MockAction::Fail {
+            message: "forced pause failure".to_string(),
+        },
+    );
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(store_control),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let sandbox_id = created.id;
+
+    let err = orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("pause recovery should fail when Running state cannot be restored");
+    let message = format!("{err:#}");
+    assert!(message.contains("forced pause failure"), "{message}");
+    assert!(
+        message.contains("forced running state restore failure"),
+        "{message}"
+    );
+
+    assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
+    assert!(orchestrator.sandboxes.read().await.is_empty());
+    assert_proxy_not_found(&orchestrator, &sandbox_id).await?;
+    assert_eq!(behavior.stop_calls(), 1);
     assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;
     Ok(())
 }

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -156,6 +156,10 @@ enum StoreAction {
         started: Arc<Notify>,
         release: Arc<Notify>,
     },
+    BlockAfter {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    },
     Fail(StoreError),
 }
 
@@ -165,6 +169,7 @@ type StoreHookSlot = StdMutex<Option<StoreHook>>;
 #[derive(Default)]
 struct ScriptedStoreControl {
     add_actions: StdMutex<VecDeque<StoreAction>>,
+    get_actions: StdMutex<VecDeque<StoreAction>>,
     update_if_state_actions: StdMutex<VecDeque<StoreAction>>,
     remove_actions: StdMutex<VecDeque<StoreAction>>,
     on_add: StoreHookSlot,
@@ -182,6 +187,13 @@ impl ScriptedStoreControl {
         self.update_if_state_actions
             .lock()
             .expect("update_if_state actions mutex poisoned")
+            .push_back(action);
+    }
+
+    fn push_get_action(&self, action: StoreAction) {
+        self.get_actions
+            .lock()
+            .expect("get actions mutex poisoned")
             .push_back(action);
     }
 
@@ -236,6 +248,12 @@ impl MetadataStore for ScriptedStore {
                 release.notified().await;
                 self.inner.add(metadata).await
             }
+            StoreAction::BlockAfter { started, release } => {
+                let result = self.inner.add(metadata).await;
+                started.notify_one();
+                release.notified().await;
+                result
+            }
             StoreAction::Fail(err) => Err(err),
         }
     }
@@ -263,6 +281,15 @@ impl MetadataStore for ScriptedStore {
                     .update_state_if_state(sandbox_id, new_state, expected_states)
                     .await
             }
+            StoreAction::BlockAfter { started, release } => {
+                let result = self
+                    .inner
+                    .update_state_if_state(sandbox_id, new_state, expected_states)
+                    .await;
+                started.notify_one();
+                release.notified().await;
+                result
+            }
             StoreAction::Fail(err) => Err(err),
         }
     }
@@ -289,12 +316,35 @@ impl MetadataStore for ScriptedStore {
                     .update_if_state(sandbox_id, expected_states, update)
                     .await
             }
+            StoreAction::BlockAfter { started, release } => {
+                let result = self
+                    .inner
+                    .update_if_state(sandbox_id, expected_states, update)
+                    .await;
+                started.notify_one();
+                release.notified().await;
+                result
+            }
             StoreAction::Fail(err) => Err(err),
         }
     }
 
     async fn get(&self, sandbox_id: &SandboxId) -> StdResult<Option<SandboxMetadata>, StoreError> {
-        self.inner.get(sandbox_id).await
+        match ScriptedStoreControl::take_action(&self.control.get_actions) {
+            StoreAction::Delegate => self.inner.get(sandbox_id).await,
+            StoreAction::Block { started, release } => {
+                started.notify_one();
+                release.notified().await;
+                self.inner.get(sandbox_id).await
+            }
+            StoreAction::BlockAfter { started, release } => {
+                let result = self.inner.get(sandbox_id).await;
+                started.notify_one();
+                release.notified().await;
+                result
+            }
+            StoreAction::Fail(err) => Err(err),
+        }
     }
 
     async fn remove(
@@ -307,6 +357,12 @@ impl MetadataStore for ScriptedStore {
                 started.notify_one();
                 release.notified().await;
                 self.inner.remove(sandbox_id).await
+            }
+            StoreAction::BlockAfter { started, release } => {
+                let result = self.inner.remove(sandbox_id).await;
+                started.notify_one();
+                release.notified().await;
+                result
             }
             StoreAction::Fail(err) => Err(err),
         }
@@ -919,6 +975,66 @@ async fn proxy_target_for_only_returns_running_routes() {
         proxy_target_for(&orchestrator, &sandbox_id).await.unwrap(),
         Some(target)
     );
+}
+
+#[tokio::test]
+async fn proxy_lookup_revalidates_running_state_after_reading_route() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::new(),
+    );
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let first_read_started = Arc::new(Notify::new());
+    let allow_first_read = Arc::new(Notify::new());
+    store_control.push_get_action(StoreAction::BlockAfter {
+        started: Arc::clone(&first_read_started),
+        release: Arc::clone(&allow_first_read),
+    });
+
+    let lookup_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.proxy_lookup_for(&created.id).await })
+    };
+    timeout(Duration::from_secs(1), first_read_started.notified())
+        .await
+        .expect("proxy lookup should complete its first metadata read");
+
+    let transition_started = Arc::new(Notify::new());
+    let allow_transition = Arc::new(Notify::new());
+    store_control.push_update_if_state_action(StoreAction::BlockAfter {
+        started: Arc::clone(&transition_started),
+        release: Arc::clone(&allow_transition),
+    });
+    let pause_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.pause_sandbox(created.id).await })
+    };
+    timeout(Duration::from_secs(1), transition_started.notified())
+        .await
+        .expect("pause should persist Pausing before detaching the route");
+
+    allow_first_read.notify_one();
+    let lookup = timeout(Duration::from_secs(1), lookup_task)
+        .await
+        .expect("proxy lookup should finish after its first read is released")
+        .expect("proxy lookup task should not panic")?;
+    assert_eq!(
+        lookup,
+        ProxyLookupResult::Unavailable(SandboxState::Pausing),
+        "a route read against stale Running metadata must not remain proxyable"
+    );
+
+    allow_transition.notify_one();
+    pause_task
+        .await
+        .expect("pause task should not panic")
+        .expect("pause should succeed");
+    orchestrator.delete_sandbox(created.id).await?;
+    Ok(())
 }
 
 #[tokio::test]

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -125,6 +125,40 @@ impl RuntimeImageRefs for RecordingRuntimeImageRefs {
     }
 }
 
+#[derive(Debug)]
+struct FailOnPinCallRuntimeImageRefs {
+    fail_on_call: usize,
+    pin_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl RuntimeImageRefs for FailOnPinCallRuntimeImageRefs {
+    async fn pin(
+        &self,
+        _owner: RuntimeImageOwner,
+        _artifacts: RuntimeArtifactSet,
+    ) -> anyhow::Result<()> {
+        let call = self.pin_calls.fetch_add(1, Ordering::Relaxed) + 1;
+        if call == self.fail_on_call {
+            anyhow::bail!("forced image ref pin failure")
+        }
+        Ok(())
+    }
+
+    async fn unpin_best_effort(&self, _owner: RuntimeImageOwner) {}
+
+    async fn reconcile_paused(&self, _live_paused: &[SandboxId]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn maintain_running(
+        &self,
+        _running: Vec<(SandboxId, RuntimeArtifactSet)>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
 async fn make_orchestrator() -> Arc<TestOrchestrator> {
     Orchestrator::new_inner(
         InMemoryMetadataStore::new(),
@@ -176,6 +210,24 @@ fn make_orchestrator_without_background_with_factory_and_persister<
     factory: F,
     persister: P,
 ) -> Arc<TestOrchestrator<S, F, P>> {
+    make_orchestrator_without_background_with_factory_persister_and_image_refs(
+        store,
+        factory,
+        persister,
+        test_runtime_image_refs(),
+    )
+}
+
+fn make_orchestrator_without_background_with_factory_persister_and_image_refs<
+    S: MetadataStore + 'static,
+    F: SandboxBackendFactory,
+    P: SandboxPersister + 'static,
+>(
+    store: S,
+    factory: F,
+    persister: P,
+    image_refs: Arc<dyn RuntimeImageRefs>,
+) -> Arc<TestOrchestrator<S, F, P>> {
     let (sandbox_event_tx, _sandbox_event_rx) =
         tokio::sync::broadcast::channel(SANDBOX_EVENT_CHANNEL_CAPACITY);
     Arc::new(Orchestrator {
@@ -194,7 +246,7 @@ fn make_orchestrator_without_background_with_factory_and_persister<
         is_shutting_down: std::sync::atomic::AtomicBool::new(false),
         shutdown_tx: tokio::sync::watch::channel(false).0,
         shutdown_outcome: tokio::sync::OnceCell::new(),
-        image_refs: test_runtime_image_refs(),
+        image_refs,
     })
 }
 
@@ -209,6 +261,7 @@ enum StoreAction {
         release: Arc<Notify>,
     },
     Fail(StoreError),
+    DelegateThenFail(StoreError),
 }
 
 type StoreHook = Arc<dyn Fn(&SandboxMetadata) + Send + Sync>;
@@ -308,6 +361,10 @@ impl MetadataStore for ScriptedStore {
                 result
             }
             StoreAction::Fail(err) => Err(err),
+            StoreAction::DelegateThenFail(err) => {
+                self.inner.add(metadata).await?;
+                Err(err)
+            }
         }
     }
 
@@ -344,6 +401,12 @@ impl MetadataStore for ScriptedStore {
                 result
             }
             StoreAction::Fail(err) => Err(err),
+            StoreAction::DelegateThenFail(err) => {
+                self.inner
+                    .update_state_if_state(sandbox_id, new_state, expected_states)
+                    .await?;
+                Err(err)
+            }
         }
     }
 
@@ -379,6 +442,12 @@ impl MetadataStore for ScriptedStore {
                 result
             }
             StoreAction::Fail(err) => Err(err),
+            StoreAction::DelegateThenFail(err) => {
+                self.inner
+                    .update_if_state(sandbox_id, expected_states, update)
+                    .await?;
+                Err(err)
+            }
         }
     }
 
@@ -398,6 +467,10 @@ impl MetadataStore for ScriptedStore {
                 result
             }
             StoreAction::Fail(err) => Err(err),
+            StoreAction::DelegateThenFail(err) => {
+                self.inner.get(sandbox_id).await?;
+                Err(err)
+            }
         }
     }
 
@@ -419,6 +492,10 @@ impl MetadataStore for ScriptedStore {
                 result
             }
             StoreAction::Fail(err) => Err(err),
+            StoreAction::DelegateThenFail(err) => {
+                self.inner.remove(sandbox_id).await?;
+                Err(err)
+            }
         }
     }
 
@@ -1003,7 +1080,7 @@ async fn assert_metrics_snapshot<S, F, P>(
 }
 
 #[tokio::test]
-async fn proxy_target_for_only_returns_running_routes() {
+async fn proxy_target_for_only_returns_validated_routes() {
     let orchestrator = make_orchestrator().await;
     let sandbox_id = SandboxId::new();
     let target = ProxyTarget::new(Ipv4Addr::new(10, 11, 0, 42));
@@ -1014,6 +1091,9 @@ async fn proxy_target_for_only_returns_running_routes() {
         .unwrap();
     orchestrator
         .upsert_proxy_route(sandbox_id, target.clone())
+        .await;
+    orchestrator
+        .mark_proxy_route_pending_for_test(&sandbox_id)
         .await;
     assert_eq!(
         proxy_target_for(&orchestrator, &sandbox_id).await.unwrap(),
@@ -1042,6 +1122,9 @@ async fn proxy_lookup_rejects_route_replaced_during_metadata_read() -> Result<()
     let created = orchestrator
         .create_sandbox(create_request(Some(60), &[]))
         .await?;
+    orchestrator
+        .mark_proxy_route_pending_for_test(&created.id)
+        .await;
     let get_calls_before_lookup = store_control.get_calls();
     let first_read_started = Arc::new(Notify::new());
     let allow_first_read = Arc::new(Notify::new());
@@ -1094,6 +1177,34 @@ async fn proxy_lookup_rejects_route_replaced_during_metadata_read() -> Result<()
 }
 
 #[tokio::test]
+async fn proxy_lookup_ready_route_uses_in_memory_fast_path() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::new(),
+    );
+    let sandbox_id = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?
+        .id;
+    let get_calls_before_lookup = store_control.get_calls();
+
+    assert!(matches!(
+        orchestrator.proxy_lookup_for(&sandbox_id).await?,
+        ProxyLookupResult::Ready(_)
+    ));
+    assert_eq!(
+        store_control.get_calls(),
+        get_calls_before_lookup,
+        "ready proxy routes must not consult the metadata store"
+    );
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn proxy_lookup_rejects_route_when_pause_state_is_published() -> Result<()> {
     setup();
     let store_control = Arc::new(ScriptedStoreControl::default());
@@ -1105,6 +1216,9 @@ async fn proxy_lookup_rejects_route_when_pause_state_is_published() -> Result<()
         .create_sandbox(create_request(Some(60), &[]))
         .await?
         .id;
+    orchestrator
+        .mark_proxy_route_pending_for_test(&sandbox_id)
+        .await;
 
     let lookup_read_started = Arc::new(Notify::new());
     let allow_lookup_read = Arc::new(Notify::new());
@@ -1194,6 +1308,69 @@ async fn pause_transition_failure_restores_route_without_metadata_read() -> Resu
     assert_eq!(
         proxy_target_for(&orchestrator, &sandbox_id).await?,
         Some(target)
+    );
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn ambiguous_pause_rollback_restores_route_for_validation() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let orchestrator = make_orchestrator_without_background_with_factory_persister_and_image_refs(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::new(),
+        DisabledSandboxPersister,
+        Arc::new(FailOnPinCallRuntimeImageRefs {
+            fail_on_call: 2,
+            pin_calls: AtomicUsize::new(0),
+        }),
+    );
+    let sandbox_id = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?
+        .id;
+    store_control.push_update_if_state_action(StoreAction::Delegate);
+    store_control.push_update_if_state_action(StoreAction::DelegateThenFail(StoreError::Backend {
+        source: anyhow::anyhow!("forced ambiguous Running rollback failure"),
+    }));
+
+    orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("image ref protection should fail");
+    assert_eq!(
+        orchestrator
+            .get_sandbox(&sandbox_id)
+            .await?
+            .expect("ambiguous rollback applied the Running state")
+            .state,
+        SandboxState::Running
+    );
+    assert!(
+        !orchestrator
+            .proxy_routes
+            .read()
+            .await
+            .route(&sandbox_id)
+            .expect("rollback must restore the invalidated route")
+            .is_ready(),
+        "an ambiguously restored route must require metadata validation"
+    );
+    assert!(matches!(
+        orchestrator.proxy_lookup_for(&sandbox_id).await?,
+        ProxyLookupResult::Ready(_)
+    ));
+    assert!(
+        orchestrator
+            .proxy_routes
+            .read()
+            .await
+            .route(&sandbox_id)
+            .expect("validated route should remain published")
+            .is_ready(),
+        "Running metadata should promote the matching pending route"
     );
 
     orchestrator.delete_sandbox(sandbox_id).await?;
@@ -2683,14 +2860,20 @@ async fn pause_waiting_for_failed_delete_retries_from_restored_running_state() -
     .await;
 
     allow_delete_transition.notify_one();
-    pause_task
-        .await
-        .expect("pause task should not panic")
-        .expect("pause should retry after delete restores Running");
-    let delete_error = delete_task
-        .await
-        .expect("delete task should not panic")
-        .expect_err("the scripted stop should make delete fail");
+    join_task_or_abort(
+        pause_task,
+        "pause should finish after the delete transition is released",
+    )
+    .await
+    .expect("pause task should not panic")
+    .expect("pause should retry after delete restores Running");
+    let delete_error = join_task_or_abort(
+        delete_task,
+        "delete should finish after its transition is released",
+    )
+    .await
+    .expect("delete task should not panic")
+    .expect_err("the scripted stop should make delete fail");
     assert!(matches!(
         delete_error,
         OrchestratorError::SandboxOperationFailed {
@@ -2999,8 +3182,12 @@ async fn concurrent_unknown_deletes_both_report_not_found() -> Result<()> {
     };
 
     allow_first_delete.notify_one();
-    for result in [first_delete.await, second_delete.await] {
-        let error = result
+    for (task, context) in [
+        (first_delete, "first unknown delete should finish"),
+        (second_delete, "second unknown delete should finish"),
+    ] {
+        let error = join_task_or_abort(task, context)
+            .await
             .expect("delete task should not panic")
             .expect_err("an unknown sandbox must not become idempotently deleted");
         assert!(matches!(error, OrchestratorError::SandboxNotFound(_)));
@@ -3822,10 +4009,13 @@ async fn pause_recovery_store_wait_does_not_block_other_sandbox_tables() -> Resu
     );
 
     allow_restore.notify_one();
-    pause_task
-        .await
-        .expect("pause task should not panic")
-        .expect_err("the scripted backend pause should fail");
+    join_task_or_abort(
+        pause_task,
+        "pause recovery should finish after the metadata restore is released",
+    )
+    .await
+    .expect("pause task should not panic")
+    .expect_err("the scripted backend pause should fail");
 
     orchestrator.delete_sandbox(recovering.id).await?;
     orchestrator.delete_sandbox(unaffected.id).await?;

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use async_trait::async_trait;
 use serde_json::json;
 use tempfile::TempDir;
-use tokio::sync::Mutex;
-use tokio::time::{sleep, Duration};
+use tokio::sync::{Mutex, Notify};
+use tokio::time::{sleep, timeout, Duration};
 use uuid::Uuid;
 
 use super::super::launch_plan::LaunchPlan;
@@ -152,6 +152,10 @@ fn make_orchestrator_without_background_with_factory_and_persister<
 
 enum StoreAction {
     Delegate,
+    Block {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    },
     Fail(StoreError),
 }
 
@@ -227,6 +231,11 @@ impl MetadataStore for ScriptedStore {
         ScriptedStoreControl::run_hook(&self.control.on_add, &metadata);
         match ScriptedStoreControl::take_action(&self.control.add_actions) {
             StoreAction::Delegate => self.inner.add(metadata).await,
+            StoreAction::Block { started, release } => {
+                started.notify_one();
+                release.notified().await;
+                self.inner.add(metadata).await
+            }
             StoreAction::Fail(err) => Err(err),
         }
     }
@@ -243,6 +252,13 @@ impl MetadataStore for ScriptedStore {
     ) -> StdResult<SandboxState, StoreError> {
         match ScriptedStoreControl::take_action(&self.control.update_if_state_actions) {
             StoreAction::Delegate => {
+                self.inner
+                    .update_state_if_state(sandbox_id, new_state, expected_states)
+                    .await
+            }
+            StoreAction::Block { started, release } => {
+                started.notify_one();
+                release.notified().await;
                 self.inner
                     .update_state_if_state(sandbox_id, new_state, expected_states)
                     .await
@@ -266,6 +282,13 @@ impl MetadataStore for ScriptedStore {
                     .update_if_state(sandbox_id, expected_states, update)
                     .await
             }
+            StoreAction::Block { started, release } => {
+                started.notify_one();
+                release.notified().await;
+                self.inner
+                    .update_if_state(sandbox_id, expected_states, update)
+                    .await
+            }
             StoreAction::Fail(err) => Err(err),
         }
     }
@@ -280,6 +303,11 @@ impl MetadataStore for ScriptedStore {
     ) -> StdResult<Option<SandboxMetadata>, StoreError> {
         match ScriptedStoreControl::take_action(&self.control.remove_actions) {
             StoreAction::Delegate => self.inner.remove(sandbox_id).await,
+            StoreAction::Block { started, release } => {
+                started.notify_one();
+                release.notified().await;
+                self.inner.remove(sandbox_id).await
+            }
             StoreAction::Fail(err) => Err(err),
         }
     }
@@ -1633,6 +1661,14 @@ async fn pause_terminal_failure_removes_sandbox_and_metrics() -> Result<()> {
     );
     assert_proxy_not_found(&orchestrator, &sandbox_id).await?;
     assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;
+    assert!(
+        !orchestrator
+            .lifecycle_operations
+            .lock()
+            .await
+            .contains_key(&sandbox_id),
+        "terminal pause cleanup should retire lifecycle ownership"
+    );
     Ok(())
 }
 
@@ -2317,6 +2353,61 @@ async fn orchestrator_concurrent_delete_calls_are_idempotent() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn pause_waiting_for_failed_delete_retries_from_restored_running_state() -> Result<()> {
+    setup();
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Stop,
+        MockAction::FailAfter {
+            delay: Duration::from_millis(200),
+            message: "forced delete stop failure".to_string(),
+        },
+    );
+    let orchestrator =
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(behavior)).await;
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let sandbox_id = created.id;
+
+    let delete_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.delete_sandbox(sandbox_id).await })
+    };
+    wait_for_state(&orchestrator, &sandbox_id, SandboxState::Killing).await?;
+
+    orchestrator.pause_sandbox(sandbox_id).await?;
+    let delete_error = delete_task
+        .await
+        .expect("delete task should not panic")
+        .expect_err("the scripted stop should make delete fail");
+    assert!(matches!(
+        delete_error,
+        OrchestratorError::SandboxOperationFailed {
+            operation: SandboxOperation::Stop,
+            ..
+        }
+    ));
+
+    let metadata = orchestrator
+        .get_sandbox(&sandbox_id)
+        .await?
+        .expect("sandbox should remain after the successful pause");
+    assert_eq!(metadata.state, SandboxState::Paused);
+    assert!(
+        !orchestrator
+            .lifecycle_operations
+            .lock()
+            .await
+            .contains_key(&sandbox_id),
+        "completed pause and delete should retire lifecycle ownership"
+    );
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    Ok(())
+}
+
 /// `keep_alive_for` called concurrently with `resume_sandbox` must never
 /// surface transitional states to the caller.
 ///
@@ -2519,6 +2610,14 @@ async fn orchestrator_unknown_sandbox_behaviors() -> Result<()> {
         .await
         .expect_err("pause_sandbox should fail for unknown sandbox");
     assert!(matches!(pause_err, OrchestratorError::SandboxNotFound(_)));
+    assert!(
+        !orchestrator
+            .lifecycle_operations
+            .lock()
+            .await
+            .contains_key(&missing_id),
+        "unknown pause should not leave lifecycle ownership behind"
+    );
 
     let resume_err = orchestrator
         .resume_sandbox(missing_id, NewTimeout::None)
@@ -2532,6 +2631,20 @@ async fn orchestrator_unknown_sandbox_behaviors() -> Result<()> {
         .expect_err("deleting unknown sandbox should fail");
 
     assert!(matches!(err, OrchestratorError::SandboxNotFound(_)));
+    assert!(
+        !orchestrator
+            .lifecycle_operations
+            .lock()
+            .await
+            .contains_key(&missing_id),
+        "failed delete should retire lifecycle ownership"
+    );
+
+    let retry_err = orchestrator
+        .delete_sandbox(missing_id)
+        .await
+        .expect_err("repeated delete of unknown sandbox should still fail");
+    assert!(matches!(retry_err, OrchestratorError::SandboxNotFound(_)));
 
     Ok(())
 }
@@ -3073,6 +3186,138 @@ async fn pause_recovery_metadata_cleanup_failure_releases_paused_image_refs() ->
     orchestrator.delete_sandbox(sandbox_id).await?;
     assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_recovery_does_not_retain_handle_without_stable_cleanup_state() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    store_control.push_remove_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("forced metadata cleanup failure"),
+    }));
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Pause,
+        MockAction::Fail {
+            message: "forced pause failure".to_string(),
+        },
+    );
+    behavior.push_action(
+        MockOperation::Resume,
+        MockAction::Fail {
+            message: "forced resume failure".to_string(),
+        },
+    );
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let sandbox_id = created.id;
+    store_control.push_update_if_state_action(StoreAction::Delegate);
+    store_control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("forced cleanup state failure"),
+    }));
+
+    let err = orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("pause recovery should report both cleanup failures");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("forced metadata cleanup failure"),
+        "{message}"
+    );
+    assert!(
+        message.contains("forced cleanup state failure"),
+        "{message}"
+    );
+    assert!(
+        !orchestrator
+            .sandboxes
+            .read()
+            .await
+            .contains_key(&sandbox_id),
+        "a handle must not be published without a stable cleanup state"
+    );
+    assert_eq!(
+        orchestrator.proxy_lookup_for(&sandbox_id).await?,
+        ProxyLookupResult::Unavailable(SandboxState::Pausing)
+    );
+    assert!(
+        !orchestrator
+            .lifecycle_operations
+            .lock()
+            .await
+            .contains_key(&sandbox_id),
+        "failed recovery should retire lifecycle ownership"
+    );
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_recovery_store_wait_does_not_block_other_sandbox_tables() -> Result<()> {
+    setup();
+    let store_control = Arc::new(ScriptedStoreControl::default());
+    let restore_started = Arc::new(Notify::new());
+    let allow_restore = Arc::new(Notify::new());
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Pause,
+        MockAction::Fail {
+            message: "forced pause failure".to_string(),
+        },
+    );
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&store_control)),
+        MockBackendFactory::with_behavior(behavior),
+    );
+    let recovering = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let unaffected = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let unaffected_target = proxy_target_for(&orchestrator, &unaffected.id)
+        .await?
+        .expect("running sandbox should have a proxy target");
+    store_control.push_update_if_state_action(StoreAction::Delegate);
+    store_control.push_update_if_state_action(StoreAction::Block {
+        started: Arc::clone(&restore_started),
+        release: Arc::clone(&allow_restore),
+    });
+
+    let pause_task = {
+        let orchestrator = Arc::clone(&orchestrator);
+        tokio::spawn(async move { orchestrator.pause_sandbox(recovering.id).await })
+    };
+    restore_started.notified().await;
+
+    let unaffected_lookup = timeout(
+        Duration::from_secs(1),
+        orchestrator.proxy_lookup_for(&unaffected.id),
+    )
+    .await
+    .expect("blocked recovery store call must not hold global sandbox tables")?;
+    assert_eq!(
+        unaffected_lookup,
+        ProxyLookupResult::Ready(unaffected_target)
+    );
+
+    allow_restore.notify_one();
+    pause_task
+        .await
+        .expect("pause task should not panic")
+        .expect_err("the scripted backend pause should fail");
+
+    orchestrator.delete_sandbox(recovering.id).await?;
+    orchestrator.delete_sandbox(unaffected.id).await?;
     Ok(())
 }
 

--- a/src/sandbox/backend.rs
+++ b/src/sandbox/backend.rs
@@ -191,7 +191,8 @@ pub trait SandboxBackend: Send + 'static {
     ///
     /// [`SandboxCaptureError::Terminal`] indicates snapshot capture mutated the live
     /// runtime before failing, so callers must not keep treating the sandbox
-    /// as safely runnable.
+    /// as safely runnable. After a recoverable failure, callers must invoke
+    /// [`resume`][Self::resume] before treating the sandbox as running again.
     async fn pause(
         &mut self,
         artifact_root: Option<&Path>,


### PR DESCRIPTION
## Problem

A recoverable backend pause failure can happen after Firecracker has already been paused. The orchestrator restored the sandbox handle, proxy route, and `Running` state without first resuming the backend, so a frozen VM could be published as healthy.

```text
pause() returns recoverable error
                |
                v
             resume()
                |
                +-- success
                |      |
                |      v
                |   restore handle + route
                |      |
                |      v
                |   state: Running
                |      |
                |      v
                |   return pause error
                |
                `-- failure
                       |
                       v
                    stop + remove
                       |
                       v
                    state: Absent
                       |
                       v
                    return combined error
```

## Changes

- Call backend `resume()` before restoring the handle, route, and `Running` state after a recoverable pause failure.
- If resume fails, stop the backend, remove sandbox metadata, keep the route detached, and release protected image references.
- Include both the pause and recovery failures in the returned error.
- Document that callers must resume after a recoverable backend pause failure before treating the sandbox as running.

## Validation

- The regression test failed against the previous implementation because `resume()` was called 0 times instead of 1.
- `pause_failure_rolls_back_to_running_and_preserves_handle` passes after the fix.
- `pause_recovery_failure_stops_and_removes_sandbox` verifies one stop call, metadata and route removal, and zero running resource metrics.
- `cargo clippy -p agentenv --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Closes #41.
