### PR TITLE
fix(sandbox): roll back resources after start failures

### DIFF
--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -894,6 +894,19 @@ impl FirecrackerSandbox {
         )
     }
 
+    fn configure_network_slot(
+        &mut self,
+        slot: Slot,
+        policy: Option<&SandboxNetworkPolicy>,
+    ) -> Result<()> {
+        self.network_slot = Some(slot);
+        self.network_slot
+            .as_ref()
+            .expect("network slot was just assigned")
+            .set_egress_policy(policy)
+            .context("Failed to configure sandbox egress policy")
+    }
+
     fn mmds_metadata(&self, common: &FirecrackerCommonConfig) -> MmdsMetadata {
         common
             .mmds_metadata
@@ -1216,9 +1229,7 @@ impl FirecrackerSandbox {
         // valid DNS server IP in the 8th field. See that method for format details.
         let ip_config = slot.build_ip_boot_arg();
         let netns = slot.namespace_path();
-        slot.set_egress_policy(config.common.network_policy.as_ref())
-            .context("Failed to configure sandbox egress policy")?;
-        self.network_slot = Some(slot);
+        self.configure_network_slot(slot, config.common.network_policy.as_ref())?;
         boot_args = Some(match boot_args.take() {
             Some(existing) => format!("{existing} {ip_config}"),
             None => ip_config,
@@ -1961,6 +1972,24 @@ mod tests {
             .take()
             .expect("network slot should still be present");
         manager.release(slot)?;
+        Ok(())
+    }
+
+    #[test]
+    fn egress_policy_failure_keeps_network_slot_owned_for_cleanup() -> Result<()> {
+        let mut sandbox = FirecrackerSandbox::new(fresh_config())?;
+        let manager = NetworkManager::new(false, 0, 0);
+        let slot = manager.allocate_test_slot()?;
+
+        sandbox
+            .configure_network_slot(slot, None)
+            .expect_err("test slot has no network namespace");
+
+        let slot = sandbox
+            .network_slot
+            .take()
+            .expect("failed policy setup must leave the slot owned by the sandbox");
+        manager.cleanup_allocated_slot(slot, true)?;
         Ok(())
     }
 

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -454,8 +454,23 @@ impl FirecrackerSandbox {
     #[tracing::instrument(skip(self))]
     pub async fn start(&mut self) -> Result<()> {
         debug!("starting firecracker sandbox");
-        self.start_nowait().await?;
-        self.wait_for_ready().await
+        let start_result = async {
+            self.start_nowait().await?;
+            self.wait_for_ready().await
+        }
+        .await;
+
+        if let Err(err) = start_result {
+            if let Err(stop_err) = self.stop().await {
+                warn!(
+                    error = %stop_err,
+                    "failed to stop sandbox after start failure"
+                );
+            }
+            return Err(err);
+        }
+
+        Ok(())
     }
 
     /// Start the sandbox WITHOUT waiting for envd's readiness.
@@ -1906,6 +1921,27 @@ mod tests {
         sandbox.stop().await?;
 
         assert!(sandbox.envd_instance.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn start_failure_rolls_back_initialized_runtime_state() -> Result<()> {
+        let mut sandbox = FirecrackerSandbox::new(fresh_config())?;
+        sandbox.envd_instance = Some(EnvdInstance::new(format!(
+            "http://127.0.0.1:{}",
+            ToolsConfig::default().control_plane_port
+        )));
+
+        let err = sandbox
+            .start()
+            .await
+            .expect_err("missing launch artifacts should fail validation");
+
+        assert!(err.to_string().contains("firecracker binary not found"));
+        assert!(
+            sandbox.envd_instance.is_none(),
+            "failed start must roll back initialized runtime state"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

Direct calls to `FirecrackerSandbox::start()` returned after startup or readiness errors without awaiting cleanup. Fresh startup also applied fallible egress-policy configuration before attaching the allocated network slot to the sandbox.

Together, these paths could retain daemon-managed ublk resources or leave a network slot unavailable after a failed start.

```text
A. Public start transaction

start_nowait
  +-- error --> stop --> return original error
  `-- ok ----> wait_for_ready
                 +-- error --> stop --> return original error
                 `-- ok ----> state: Running

B. Network slot ordering

before: allocate -> set policy -> store ownership
                       |
                       `-- error -> manager slot remains allocated

after:  allocate -> store ownership -> set policy
                                      +-- error -> stop/Drop releases slot
                                      `-- ok ---> continue boot
```

## Changes

- Treat `start_nowait()` and `wait_for_ready()` as one public-start transaction.
- Await `stop()` after either operation fails.
- Preserve the primary startup error and warn if cleanup also fails.
- Attach newly allocated network slots to the sandbox before applying fallible egress policy.

Existing orchestrator cleanup, `Drop`, and daemon shutdown behavior are unchanged.

## Commit structure

- `fix(sandbox): roll back failed direct starts`
- `fix(sandbox): retain network slot on policy failure`

The commits are separate because public-start transactionality and network-slot ownership are independently reviewable and revertible.

## Validation

- The direct-start regression test failed against the previous implementation at the runtime-state ownership assertion.
- `cargo test -p agentenv --lib sandbox::firecracker::sandbox::tests::` — 14 passed.
- `cargo clippy -p agentenv --lib -- -D warnings`
- `cargo fmt --all`

The network ownership test uses the existing deterministic test-slot seam. A full base-failing `start_fresh` integration test would require privileged networking, ublk setup, and an additional injection seam, so this PR does not add production-wide mocking for that path.

Closes #42.
