### PR TITLE
feat(scheduler): add snapshot artifact locality preference

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -113,7 +113,10 @@ The strategy interface receives `RichNode` values that carry the node identity (
 ### Snapshot locality preference
 
 For `POST /sandboxes`, the Gateway derives advisory locality requirements from
-the requested `templateID` using the snapshot's stable P2P artifact keys:
+the requested `templateID` using the snapshot's stable P2P artifact keys. UUID
+template IDs are normalized to their canonical lowercase form. When the
+request uses a template alias, the Gateway resolves it through the discovered
+nodes' alias endpoint before building the keys:
 
 - `snapshot/v1/artifacts/{snapshot_id}/vm_state.bin`
 - `snapshot/v1/artifacts/{snapshot_id}/firecracker-manifest.json`
@@ -125,11 +128,12 @@ that preferred set. Artifact lookups use each candidate node's heartbeat
 reported cluster ID and P2P backend, so records do not cross cluster or backend
 boundaries.
 
-Locality is best-effort. If the request has no requirements, no eligible node
-has a matching record, or a node has not reported P2P context, the scheduler
-passes the full eligible candidate set to the configured strategy. Stale
-artifact records therefore affect placement only; the selected AgentENV node
-continues to use its normal local cache, P2P, repository, or registry fallback.
+Locality is best-effort. If alias resolution is unavailable, the request has no
+requirements, no eligible node has a matching record, or a node has not
+reported P2P context, the scheduler passes the full eligible candidate set to
+the configured strategy. Stale artifact records therefore affect placement
+only; the selected AgentENV node continues to use its normal local cache, P2P,
+repository, or registry fallback.
 
 This initial implementation does not resolve OCI image references into
 OverlayBD layer requirements and does not index non-P2P local caches.

--- a/services/README.md
+++ b/services/README.md
@@ -114,9 +114,8 @@ The strategy interface receives `RichNode` values that carry the node identity (
 
 For `POST /sandboxes`, the Gateway derives advisory locality requirements from
 the requested `templateID` using the snapshot's stable P2P artifact keys. UUID
-template IDs are normalized to their canonical lowercase form. When the
-request uses a template alias, the Gateway resolves it through the discovered
-nodes' alias endpoint before building the keys:
+template IDs must use the standard hyphenated form and are normalized to
+lowercase before building the keys:
 
 - `snapshot/v1/artifacts/{snapshot_id}/vm_state.bin`
 - `snapshot/v1/artifacts/{snapshot_id}/firecracker-manifest.json`
@@ -128,12 +127,14 @@ that preferred set. Artifact lookups use each candidate node's heartbeat
 reported cluster ID and P2P backend, so records do not cross cluster or backend
 boundaries.
 
-Locality is best-effort. If alias resolution is unavailable, the request has no
-requirements, no eligible node has a matching record, or a node has not
-reported P2P context, the scheduler passes the full eligible candidate set to
-the configured strategy. Stale artifact records therefore affect placement
-only; the selected AgentENV node continues to use its normal local cache, P2P,
-repository, or registry fallback.
+Locality is best-effort. Template aliases intentionally do not produce locality
+requirements because the Gateway has no authoritative pre-scheduling alias
+resolver; alias requests continue through normal scheduling. The scheduler also
+passes the full eligible candidate set to the configured strategy when no
+eligible node has a matching record or a node has not reported P2P context.
+Stale artifact records therefore affect placement only; the selected AgentENV
+node continues to use its normal local cache, P2P, repository, or registry
+fallback.
 
 This initial implementation does not resolve OCI image references into
 OverlayBD layer requirements and does not index non-P2P local caches.

--- a/services/README.md
+++ b/services/README.md
@@ -110,6 +110,30 @@ General config notes:
 
 The strategy interface receives `RichNode` values that carry the node identity (ID + endpoint) together with the latest heartbeat `NodeSnapshot` (sandbox counts, CPU, memory, disk metrics). Current built-in strategies ignore the snapshot, but custom strategy implementations can use it for load-aware decisions.
 
+### Snapshot locality preference
+
+For `POST /sandboxes`, the Gateway derives advisory locality requirements from
+the requested `templateID` using the snapshot's stable P2P artifact keys:
+
+- `snapshot/v1/artifacts/{snapshot_id}/vm_state.bin`
+- `snapshot/v1/artifacts/{snapshot_id}/firecracker-manifest.json`
+
+After applying node resource limits, the scheduler checks the existing P2P
+artifact index and keeps the eligible nodes tied for the highest positive
+requirement coverage. The configured scheduling strategy then selects from
+that preferred set. Artifact lookups use each candidate node's heartbeat
+reported cluster ID and P2P backend, so records do not cross cluster or backend
+boundaries.
+
+Locality is best-effort. If the request has no requirements, no eligible node
+has a matching record, or a node has not reported P2P context, the scheduler
+passes the full eligible candidate set to the configured strategy. Stale
+artifact records therefore affect placement only; the selected AgentENV node
+continues to use its normal local cache, P2P, repository, or registry fallback.
+
+This initial implementation does not resolve OCI image references into
+OverlayBD layer requirements and does not index non-P2P local caches.
+
 ### Node resource limit
 
 `scheduler.node_resource_limit` defines per-node resource thresholds that are evaluated **before** the strategy runs. Any node whose heartbeat snapshot exceeds a configured limit is removed from the candidate list, regardless of which strategy is in use. This is a generic guard-rail that sits above the strategy layer — strategies only see nodes that already passed the resource filter.

--- a/services/api/proto/scheduler.pb.go
+++ b/services/api/proto/scheduler.pb.go
@@ -24,12 +24,12 @@ const (
 // NodeStatus describes the effective state of a node as derived by the
 // scheduler from its discovery state and heartbeat history.
 //
-//   active  + heartbeat OK      → READY        — accepts new sandboxes
-//   active  + no heartbeat      → CONNECTING    — discovered but not yet confirmed
-//   active  + heartbeat timeout → UNHEALTHY     — heartbeat lost
-//   lingering + heartbeat OK    → LINGERING     — terminating, draining existing work
-//   lingering + no heartbeat    → CONNECTING    — terminating, never confirmed
-//   lingering + heartbeat timeout → UNHEALTHY   — terminating, heartbeat lost
+//	active  + heartbeat OK      → READY        — accepts new sandboxes
+//	active  + no heartbeat      → CONNECTING    — discovered but not yet confirmed
+//	active  + heartbeat timeout → UNHEALTHY     — heartbeat lost
+//	lingering + heartbeat OK    → LINGERING     — terminating, draining existing work
+//	lingering + no heartbeat    → CONNECTING    — terminating, never confirmed
+//	lingering + heartbeat timeout → UNHEALTHY   — terminating, heartbeat lost
 type NodeStatus int32
 
 const (

--- a/services/api/proto/scheduler.pb.go
+++ b/services/api/proto/scheduler.pb.go
@@ -24,12 +24,12 @@ const (
 // NodeStatus describes the effective state of a node as derived by the
 // scheduler from its discovery state and heartbeat history.
 //
-//	active  + heartbeat OK      → READY        — accepts new sandboxes
-//	active  + no heartbeat      → CONNECTING    — discovered but not yet confirmed
-//	active  + heartbeat timeout → UNHEALTHY     — heartbeat lost
-//	lingering + heartbeat OK    → LINGERING     — terminating, draining existing work
-//	lingering + no heartbeat    → CONNECTING    — terminating, never confirmed
-//	lingering + heartbeat timeout → UNHEALTHY   — terminating, heartbeat lost
+//   active  + heartbeat OK      → READY        — accepts new sandboxes
+//   active  + no heartbeat      → CONNECTING    — discovered but not yet confirmed
+//   active  + heartbeat timeout → UNHEALTHY     — heartbeat lost
+//   lingering + heartbeat OK    → LINGERING     — terminating, draining existing work
+//   lingering + no heartbeat    → CONNECTING    — terminating, never confirmed
+//   lingering + heartbeat timeout → UNHEALTHY   — terminating, heartbeat lost
 type NodeStatus int32
 
 const (
@@ -207,9 +207,12 @@ type ScheduleRequestHint struct {
 	//
 	//	*ScheduleRequestHint_NewColdSandbox
 	//	*ScheduleRequestHint_NewSandbox
-	Kind          isScheduleRequestHint_Kind `protobuf_oneof:"kind"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Kind isScheduleRequestHint_Kind `protobuf_oneof:"kind"`
+	// Stable artifact identities that can be used to prefer nodes which already
+	// provide content needed by this request. Requirements are advisory.
+	LocalityRequirements []*LocalityRequirement `protobuf:"bytes,3,rep,name=locality_requirements,json=localityRequirements,proto3" json:"locality_requirements,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ScheduleRequestHint) Reset() {
@@ -267,6 +270,13 @@ func (x *ScheduleRequestHint) GetNewSandbox() *NewSandboxHint {
 	return nil
 }
 
+func (x *ScheduleRequestHint) GetLocalityRequirements() []*LocalityRequirement {
+	if x != nil {
+		return x.LocalityRequirements
+	}
+	return nil
+}
+
 type isScheduleRequestHint_Kind interface {
 	isScheduleRequestHint_Kind()
 }
@@ -282,6 +292,50 @@ type ScheduleRequestHint_NewSandbox struct {
 func (*ScheduleRequestHint_NewColdSandbox) isScheduleRequestHint_Kind() {}
 
 func (*ScheduleRequestHint_NewSandbox) isScheduleRequestHint_Kind() {}
+
+type LocalityRequirement struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LocalityRequirement) Reset() {
+	*x = LocalityRequirement{}
+	mi := &file_api_proto_scheduler_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LocalityRequirement) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LocalityRequirement) ProtoMessage() {}
+
+func (x *LocalityRequirement) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_scheduler_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LocalityRequirement.ProtoReflect.Descriptor instead.
+func (*LocalityRequirement) Descriptor() ([]byte, []int) {
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *LocalityRequirement) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
 
 // NewColdSandboxHint describes a POST /sandboxes-cold request.
 type NewColdSandboxHint struct {
@@ -299,7 +353,7 @@ type NewColdSandboxHint struct {
 
 func (x *NewColdSandboxHint) Reset() {
 	*x = NewColdSandboxHint{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[2]
+	mi := &file_api_proto_scheduler_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -311,7 +365,7 @@ func (x *NewColdSandboxHint) String() string {
 func (*NewColdSandboxHint) ProtoMessage() {}
 
 func (x *NewColdSandboxHint) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[2]
+	mi := &file_api_proto_scheduler_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -324,7 +378,7 @@ func (x *NewColdSandboxHint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewColdSandboxHint.ProtoReflect.Descriptor instead.
 func (*NewColdSandboxHint) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{2}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *NewColdSandboxHint) GetCpuCount() uint32 {
@@ -359,14 +413,16 @@ func (x *NewColdSandboxHint) GetMetadata() map[string]string {
 type NewSandboxHint struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Sandbox metadata key/value pairs parsed from the request body.
-	Metadata      map[string]string `protobuf:"bytes,1,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata map[string]string `protobuf:"bytes,1,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Template identifier supplied by POST /sandboxes.
+	TemplateId    string `protobuf:"bytes,2,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *NewSandboxHint) Reset() {
 	*x = NewSandboxHint{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[3]
+	mi := &file_api_proto_scheduler_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -378,7 +434,7 @@ func (x *NewSandboxHint) String() string {
 func (*NewSandboxHint) ProtoMessage() {}
 
 func (x *NewSandboxHint) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[3]
+	mi := &file_api_proto_scheduler_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -391,7 +447,7 @@ func (x *NewSandboxHint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewSandboxHint.ProtoReflect.Descriptor instead.
 func (*NewSandboxHint) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{3}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *NewSandboxHint) GetMetadata() map[string]string {
@@ -399,6 +455,13 @@ func (x *NewSandboxHint) GetMetadata() map[string]string {
 		return x.Metadata
 	}
 	return nil
+}
+
+func (x *NewSandboxHint) GetTemplateId() string {
+	if x != nil {
+		return x.TemplateId
+	}
+	return ""
 }
 
 type ScheduleRequest struct {
@@ -410,7 +473,7 @@ type ScheduleRequest struct {
 
 func (x *ScheduleRequest) Reset() {
 	*x = ScheduleRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[4]
+	mi := &file_api_proto_scheduler_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -422,7 +485,7 @@ func (x *ScheduleRequest) String() string {
 func (*ScheduleRequest) ProtoMessage() {}
 
 func (x *ScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[4]
+	mi := &file_api_proto_scheduler_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -435,7 +498,7 @@ func (x *ScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleRequest.ProtoReflect.Descriptor instead.
 func (*ScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{4}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ScheduleRequest) GetHint() *ScheduleRequestHint {
@@ -454,7 +517,7 @@ type ScheduleResponse struct {
 
 func (x *ScheduleResponse) Reset() {
 	*x = ScheduleResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[5]
+	mi := &file_api_proto_scheduler_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -466,7 +529,7 @@ func (x *ScheduleResponse) String() string {
 func (*ScheduleResponse) ProtoMessage() {}
 
 func (x *ScheduleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[5]
+	mi := &file_api_proto_scheduler_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -479,7 +542,7 @@ func (x *ScheduleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleResponse.ProtoReflect.Descriptor instead.
 func (*ScheduleResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{5}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ScheduleResponse) GetNode() *Node {
@@ -497,7 +560,7 @@ type ListNodesRequest struct {
 
 func (x *ListNodesRequest) Reset() {
 	*x = ListNodesRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[6]
+	mi := &file_api_proto_scheduler_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -509,7 +572,7 @@ func (x *ListNodesRequest) String() string {
 func (*ListNodesRequest) ProtoMessage() {}
 
 func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[6]
+	mi := &file_api_proto_scheduler_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -522,7 +585,7 @@ func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodesRequest.ProtoReflect.Descriptor instead.
 func (*ListNodesRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{6}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{7}
 }
 
 type ListNodesResponse struct {
@@ -534,7 +597,7 @@ type ListNodesResponse struct {
 
 func (x *ListNodesResponse) Reset() {
 	*x = ListNodesResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[7]
+	mi := &file_api_proto_scheduler_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -546,7 +609,7 @@ func (x *ListNodesResponse) String() string {
 func (*ListNodesResponse) ProtoMessage() {}
 
 func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[7]
+	mi := &file_api_proto_scheduler_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -559,7 +622,7 @@ func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodesResponse.ProtoReflect.Descriptor instead.
 func (*ListNodesResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{7}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListNodesResponse) GetNodes() []*Node {
@@ -578,7 +641,7 @@ type LookupNodeRequest struct {
 
 func (x *LookupNodeRequest) Reset() {
 	*x = LookupNodeRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[8]
+	mi := &file_api_proto_scheduler_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -590,7 +653,7 @@ func (x *LookupNodeRequest) String() string {
 func (*LookupNodeRequest) ProtoMessage() {}
 
 func (x *LookupNodeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[8]
+	mi := &file_api_proto_scheduler_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -603,7 +666,7 @@ func (x *LookupNodeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupNodeRequest.ProtoReflect.Descriptor instead.
 func (*LookupNodeRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{8}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *LookupNodeRequest) GetSandboxId() string {
@@ -622,7 +685,7 @@ type LookupNodeResponse struct {
 
 func (x *LookupNodeResponse) Reset() {
 	*x = LookupNodeResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[9]
+	mi := &file_api_proto_scheduler_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -634,7 +697,7 @@ func (x *LookupNodeResponse) String() string {
 func (*LookupNodeResponse) ProtoMessage() {}
 
 func (x *LookupNodeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[9]
+	mi := &file_api_proto_scheduler_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -647,7 +710,7 @@ func (x *LookupNodeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupNodeResponse.ProtoReflect.Descriptor instead.
 func (*LookupNodeResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{9}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *LookupNodeResponse) GetNode() *Node {
@@ -667,7 +730,7 @@ type RecordAssignmentRequest struct {
 
 func (x *RecordAssignmentRequest) Reset() {
 	*x = RecordAssignmentRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[10]
+	mi := &file_api_proto_scheduler_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -679,7 +742,7 @@ func (x *RecordAssignmentRequest) String() string {
 func (*RecordAssignmentRequest) ProtoMessage() {}
 
 func (x *RecordAssignmentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[10]
+	mi := &file_api_proto_scheduler_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -692,7 +755,7 @@ func (x *RecordAssignmentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordAssignmentRequest.ProtoReflect.Descriptor instead.
 func (*RecordAssignmentRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{10}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RecordAssignmentRequest) GetSandboxId() string {
@@ -717,7 +780,7 @@ type RecordAssignmentResponse struct {
 
 func (x *RecordAssignmentResponse) Reset() {
 	*x = RecordAssignmentResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[11]
+	mi := &file_api_proto_scheduler_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -729,7 +792,7 @@ func (x *RecordAssignmentResponse) String() string {
 func (*RecordAssignmentResponse) ProtoMessage() {}
 
 func (x *RecordAssignmentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[11]
+	mi := &file_api_proto_scheduler_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -742,7 +805,7 @@ func (x *RecordAssignmentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordAssignmentResponse.ProtoReflect.Descriptor instead.
 func (*RecordAssignmentResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{11}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{12}
 }
 
 type MachineInfo struct {
@@ -758,7 +821,7 @@ type MachineInfo struct {
 
 func (x *MachineInfo) Reset() {
 	*x = MachineInfo{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[12]
+	mi := &file_api_proto_scheduler_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -770,7 +833,7 @@ func (x *MachineInfo) String() string {
 func (*MachineInfo) ProtoMessage() {}
 
 func (x *MachineInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[12]
+	mi := &file_api_proto_scheduler_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -783,7 +846,7 @@ func (x *MachineInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineInfo.ProtoReflect.Descriptor instead.
 func (*MachineInfo) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{12}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *MachineInfo) GetCpuFamily() string {
@@ -834,7 +897,7 @@ type DiskMetric struct {
 
 func (x *DiskMetric) Reset() {
 	*x = DiskMetric{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[13]
+	mi := &file_api_proto_scheduler_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -846,7 +909,7 @@ func (x *DiskMetric) String() string {
 func (*DiskMetric) ProtoMessage() {}
 
 func (x *DiskMetric) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[13]
+	mi := &file_api_proto_scheduler_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -859,7 +922,7 @@ func (x *DiskMetric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiskMetric.ProtoReflect.Descriptor instead.
 func (*DiskMetric) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{13}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DiskMetric) GetMountPoint() string {
@@ -927,7 +990,7 @@ type NodeSnapshot struct {
 
 func (x *NodeSnapshot) Reset() {
 	*x = NodeSnapshot{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[14]
+	mi := &file_api_proto_scheduler_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -939,7 +1002,7 @@ func (x *NodeSnapshot) String() string {
 func (*NodeSnapshot) ProtoMessage() {}
 
 func (x *NodeSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[14]
+	mi := &file_api_proto_scheduler_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -952,7 +1015,7 @@ func (x *NodeSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeSnapshot.ProtoReflect.Descriptor instead.
 func (*NodeSnapshot) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{14}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *NodeSnapshot) GetStatus() NodeStatus {
@@ -1077,7 +1140,7 @@ type P2PEndpoint struct {
 
 func (x *P2PEndpoint) Reset() {
 	*x = P2PEndpoint{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[15]
+	mi := &file_api_proto_scheduler_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1089,7 +1152,7 @@ func (x *P2PEndpoint) String() string {
 func (*P2PEndpoint) ProtoMessage() {}
 
 func (x *P2PEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[15]
+	mi := &file_api_proto_scheduler_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1102,7 +1165,7 @@ func (x *P2PEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use P2PEndpoint.ProtoReflect.Descriptor instead.
 func (*P2PEndpoint) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{15}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *P2PEndpoint) GetBackend() string {
@@ -1136,7 +1199,7 @@ type ObservedNode struct {
 
 func (x *ObservedNode) Reset() {
 	*x = ObservedNode{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[16]
+	mi := &file_api_proto_scheduler_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1148,7 +1211,7 @@ func (x *ObservedNode) String() string {
 func (*ObservedNode) ProtoMessage() {}
 
 func (x *ObservedNode) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[16]
+	mi := &file_api_proto_scheduler_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1161,7 +1224,7 @@ func (x *ObservedNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ObservedNode.ProtoReflect.Descriptor instead.
 func (*ObservedNode) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{16}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ObservedNode) GetNodeId() string {
@@ -1244,7 +1307,7 @@ type HeartbeatRequest struct {
 
 func (x *HeartbeatRequest) Reset() {
 	*x = HeartbeatRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[17]
+	mi := &file_api_proto_scheduler_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1256,7 +1319,7 @@ func (x *HeartbeatRequest) String() string {
 func (*HeartbeatRequest) ProtoMessage() {}
 
 func (x *HeartbeatRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[17]
+	mi := &file_api_proto_scheduler_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1269,7 +1332,7 @@ func (x *HeartbeatRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatRequest.ProtoReflect.Descriptor instead.
 func (*HeartbeatRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{17}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *HeartbeatRequest) GetNodeId() string {
@@ -1344,7 +1407,7 @@ type HeartbeatResponse struct {
 
 func (x *HeartbeatResponse) Reset() {
 	*x = HeartbeatResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[18]
+	mi := &file_api_proto_scheduler_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1356,7 +1419,7 @@ func (x *HeartbeatResponse) String() string {
 func (*HeartbeatResponse) ProtoMessage() {}
 
 func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[18]
+	mi := &file_api_proto_scheduler_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1369,7 +1432,7 @@ func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatResponse.ProtoReflect.Descriptor instead.
 func (*HeartbeatResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{18}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *HeartbeatResponse) GetCpuConfigJson() string {
@@ -1392,7 +1455,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[19]
+	mi := &file_api_proto_scheduler_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1404,7 +1467,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[19]
+	mi := &file_api_proto_scheduler_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1417,7 +1480,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{19}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -1467,7 +1530,7 @@ type ReportSandboxEventRequest struct {
 
 func (x *ReportSandboxEventRequest) Reset() {
 	*x = ReportSandboxEventRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[20]
+	mi := &file_api_proto_scheduler_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1479,7 +1542,7 @@ func (x *ReportSandboxEventRequest) String() string {
 func (*ReportSandboxEventRequest) ProtoMessage() {}
 
 func (x *ReportSandboxEventRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[20]
+	mi := &file_api_proto_scheduler_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1492,7 +1555,7 @@ func (x *ReportSandboxEventRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportSandboxEventRequest.ProtoReflect.Descriptor instead.
 func (*ReportSandboxEventRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{20}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ReportSandboxEventRequest) GetNodeId() string {
@@ -1531,7 +1594,7 @@ type ReportSandboxEventResponse struct {
 
 func (x *ReportSandboxEventResponse) Reset() {
 	*x = ReportSandboxEventResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[21]
+	mi := &file_api_proto_scheduler_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1543,7 +1606,7 @@ func (x *ReportSandboxEventResponse) String() string {
 func (*ReportSandboxEventResponse) ProtoMessage() {}
 
 func (x *ReportSandboxEventResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[21]
+	mi := &file_api_proto_scheduler_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1556,7 +1619,7 @@ func (x *ReportSandboxEventResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportSandboxEventResponse.ProtoReflect.Descriptor instead.
 func (*ReportSandboxEventResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{21}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{22}
 }
 
 type ListObservedNodesRequest struct {
@@ -1568,7 +1631,7 @@ type ListObservedNodesRequest struct {
 
 func (x *ListObservedNodesRequest) Reset() {
 	*x = ListObservedNodesRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[22]
+	mi := &file_api_proto_scheduler_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1580,7 +1643,7 @@ func (x *ListObservedNodesRequest) String() string {
 func (*ListObservedNodesRequest) ProtoMessage() {}
 
 func (x *ListObservedNodesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[22]
+	mi := &file_api_proto_scheduler_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1593,7 +1656,7 @@ func (x *ListObservedNodesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListObservedNodesRequest.ProtoReflect.Descriptor instead.
 func (*ListObservedNodesRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{22}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListObservedNodesRequest) GetClusterId() string {
@@ -1612,7 +1675,7 @@ type ListObservedNodesResponse struct {
 
 func (x *ListObservedNodesResponse) Reset() {
 	*x = ListObservedNodesResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[23]
+	mi := &file_api_proto_scheduler_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1624,7 +1687,7 @@ func (x *ListObservedNodesResponse) String() string {
 func (*ListObservedNodesResponse) ProtoMessage() {}
 
 func (x *ListObservedNodesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[23]
+	mi := &file_api_proto_scheduler_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1637,7 +1700,7 @@ func (x *ListObservedNodesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListObservedNodesResponse.ProtoReflect.Descriptor instead.
 func (*ListObservedNodesResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{23}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ListObservedNodesResponse) GetNodes() []*ObservedNode {
@@ -1657,7 +1720,7 @@ type P2PPeer struct {
 
 func (x *P2PPeer) Reset() {
 	*x = P2PPeer{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[24]
+	mi := &file_api_proto_scheduler_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1669,7 +1732,7 @@ func (x *P2PPeer) String() string {
 func (*P2PPeer) ProtoMessage() {}
 
 func (x *P2PPeer) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[24]
+	mi := &file_api_proto_scheduler_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1682,7 +1745,7 @@ func (x *P2PPeer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use P2PPeer.ProtoReflect.Descriptor instead.
 func (*P2PPeer) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{24}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *P2PPeer) GetNodeId() string {
@@ -1710,7 +1773,7 @@ type ListP2PPeersRequest struct {
 
 func (x *ListP2PPeersRequest) Reset() {
 	*x = ListP2PPeersRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[25]
+	mi := &file_api_proto_scheduler_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1722,7 +1785,7 @@ func (x *ListP2PPeersRequest) String() string {
 func (*ListP2PPeersRequest) ProtoMessage() {}
 
 func (x *ListP2PPeersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[25]
+	mi := &file_api_proto_scheduler_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1735,7 +1798,7 @@ func (x *ListP2PPeersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListP2PPeersRequest.ProtoReflect.Descriptor instead.
 func (*ListP2PPeersRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{25}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ListP2PPeersRequest) GetClusterId() string {
@@ -1768,7 +1831,7 @@ type ListP2PPeersResponse struct {
 
 func (x *ListP2PPeersResponse) Reset() {
 	*x = ListP2PPeersResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[26]
+	mi := &file_api_proto_scheduler_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1780,7 +1843,7 @@ func (x *ListP2PPeersResponse) String() string {
 func (*ListP2PPeersResponse) ProtoMessage() {}
 
 func (x *ListP2PPeersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[26]
+	mi := &file_api_proto_scheduler_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1793,7 +1856,7 @@ func (x *ListP2PPeersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListP2PPeersResponse.ProtoReflect.Descriptor instead.
 func (*ListP2PPeersResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{26}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListP2PPeersResponse) GetPeers() []*P2PPeer {
@@ -1815,7 +1878,7 @@ type RecordP2PArtifactRequest struct {
 
 func (x *RecordP2PArtifactRequest) Reset() {
 	*x = RecordP2PArtifactRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[27]
+	mi := &file_api_proto_scheduler_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1827,7 +1890,7 @@ func (x *RecordP2PArtifactRequest) String() string {
 func (*RecordP2PArtifactRequest) ProtoMessage() {}
 
 func (x *RecordP2PArtifactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[27]
+	mi := &file_api_proto_scheduler_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1840,7 +1903,7 @@ func (x *RecordP2PArtifactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordP2PArtifactRequest.ProtoReflect.Descriptor instead.
 func (*RecordP2PArtifactRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{27}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *RecordP2PArtifactRequest) GetClusterId() string {
@@ -1879,7 +1942,7 @@ type RecordP2PArtifactResponse struct {
 
 func (x *RecordP2PArtifactResponse) Reset() {
 	*x = RecordP2PArtifactResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[28]
+	mi := &file_api_proto_scheduler_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1891,7 +1954,7 @@ func (x *RecordP2PArtifactResponse) String() string {
 func (*RecordP2PArtifactResponse) ProtoMessage() {}
 
 func (x *RecordP2PArtifactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[28]
+	mi := &file_api_proto_scheduler_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1904,7 +1967,7 @@ func (x *RecordP2PArtifactResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordP2PArtifactResponse.ProtoReflect.Descriptor instead.
 func (*RecordP2PArtifactResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{28}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{29}
 }
 
 type ForgetP2PArtifactRequest struct {
@@ -1919,7 +1982,7 @@ type ForgetP2PArtifactRequest struct {
 
 func (x *ForgetP2PArtifactRequest) Reset() {
 	*x = ForgetP2PArtifactRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[29]
+	mi := &file_api_proto_scheduler_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1931,7 +1994,7 @@ func (x *ForgetP2PArtifactRequest) String() string {
 func (*ForgetP2PArtifactRequest) ProtoMessage() {}
 
 func (x *ForgetP2PArtifactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[29]
+	mi := &file_api_proto_scheduler_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1944,7 +2007,7 @@ func (x *ForgetP2PArtifactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForgetP2PArtifactRequest.ProtoReflect.Descriptor instead.
 func (*ForgetP2PArtifactRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{29}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ForgetP2PArtifactRequest) GetClusterId() string {
@@ -1983,7 +2046,7 @@ type ForgetP2PArtifactResponse struct {
 
 func (x *ForgetP2PArtifactResponse) Reset() {
 	*x = ForgetP2PArtifactResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[30]
+	mi := &file_api_proto_scheduler_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1995,7 +2058,7 @@ func (x *ForgetP2PArtifactResponse) String() string {
 func (*ForgetP2PArtifactResponse) ProtoMessage() {}
 
 func (x *ForgetP2PArtifactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[30]
+	mi := &file_api_proto_scheduler_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2008,7 +2071,7 @@ func (x *ForgetP2PArtifactResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForgetP2PArtifactResponse.ProtoReflect.Descriptor instead.
 func (*ForgetP2PArtifactResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{30}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{31}
 }
 
 type LookupP2PArtifactRequest struct {
@@ -2023,7 +2086,7 @@ type LookupP2PArtifactRequest struct {
 
 func (x *LookupP2PArtifactRequest) Reset() {
 	*x = LookupP2PArtifactRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[31]
+	mi := &file_api_proto_scheduler_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2035,7 +2098,7 @@ func (x *LookupP2PArtifactRequest) String() string {
 func (*LookupP2PArtifactRequest) ProtoMessage() {}
 
 func (x *LookupP2PArtifactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[31]
+	mi := &file_api_proto_scheduler_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2048,7 +2111,7 @@ func (x *LookupP2PArtifactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupP2PArtifactRequest.ProtoReflect.Descriptor instead.
 func (*LookupP2PArtifactRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{31}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LookupP2PArtifactRequest) GetClusterId() string {
@@ -2088,7 +2151,7 @@ type LookupP2PArtifactResponse struct {
 
 func (x *LookupP2PArtifactResponse) Reset() {
 	*x = LookupP2PArtifactResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[32]
+	mi := &file_api_proto_scheduler_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2100,7 +2163,7 @@ func (x *LookupP2PArtifactResponse) String() string {
 func (*LookupP2PArtifactResponse) ProtoMessage() {}
 
 func (x *LookupP2PArtifactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[32]
+	mi := &file_api_proto_scheduler_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2113,7 +2176,7 @@ func (x *LookupP2PArtifactResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupP2PArtifactResponse.ProtoReflect.Descriptor instead.
 func (*LookupP2PArtifactResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{32}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *LookupP2PArtifactResponse) GetPeers() []*P2PPeer {
@@ -2133,7 +2196,7 @@ type GetNodeRequest struct {
 
 func (x *GetNodeRequest) Reset() {
 	*x = GetNodeRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[33]
+	mi := &file_api_proto_scheduler_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2145,7 +2208,7 @@ func (x *GetNodeRequest) String() string {
 func (*GetNodeRequest) ProtoMessage() {}
 
 func (x *GetNodeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[33]
+	mi := &file_api_proto_scheduler_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2158,7 +2221,7 @@ func (x *GetNodeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNodeRequest.ProtoReflect.Descriptor instead.
 func (*GetNodeRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{33}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetNodeRequest) GetNodeId() string {
@@ -2184,7 +2247,7 @@ type GetNodeResponse struct {
 
 func (x *GetNodeResponse) Reset() {
 	*x = GetNodeResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[34]
+	mi := &file_api_proto_scheduler_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2196,7 +2259,7 @@ func (x *GetNodeResponse) String() string {
 func (*GetNodeResponse) ProtoMessage() {}
 
 func (x *GetNodeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[34]
+	mi := &file_api_proto_scheduler_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2209,7 +2272,7 @@ func (x *GetNodeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNodeResponse.ProtoReflect.Descriptor instead.
 func (*GetNodeResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{34}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetNodeResponse) GetNode() *ObservedNode {
@@ -2229,7 +2292,7 @@ type UnregisterNodeRequest struct {
 
 func (x *UnregisterNodeRequest) Reset() {
 	*x = UnregisterNodeRequest{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[35]
+	mi := &file_api_proto_scheduler_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2241,7 +2304,7 @@ func (x *UnregisterNodeRequest) String() string {
 func (*UnregisterNodeRequest) ProtoMessage() {}
 
 func (x *UnregisterNodeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[35]
+	mi := &file_api_proto_scheduler_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2254,7 +2317,7 @@ func (x *UnregisterNodeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnregisterNodeRequest.ProtoReflect.Descriptor instead.
 func (*UnregisterNodeRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{35}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *UnregisterNodeRequest) GetNodeId() string {
@@ -2279,7 +2342,7 @@ type UnregisterNodeResponse struct {
 
 func (x *UnregisterNodeResponse) Reset() {
 	*x = UnregisterNodeResponse{}
-	mi := &file_api_proto_scheduler_proto_msgTypes[36]
+	mi := &file_api_proto_scheduler_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2291,7 +2354,7 @@ func (x *UnregisterNodeResponse) String() string {
 func (*UnregisterNodeResponse) ProtoMessage() {}
 
 func (x *UnregisterNodeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_scheduler_proto_msgTypes[36]
+	mi := &file_api_proto_scheduler_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2304,7 +2367,7 @@ func (x *UnregisterNodeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnregisterNodeResponse.ProtoReflect.Descriptor instead.
 func (*UnregisterNodeResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{36}
+	return file_api_proto_scheduler_proto_rawDescGZIP(), []int{37}
 }
 
 var File_api_proto_scheduler_proto protoreflect.FileDescriptor
@@ -2314,12 +2377,15 @@ const file_api_proto_scheduler_proto_rawDesc = "" +
 	"\x19api/proto/scheduler.proto\x12\fscheduler.v1\";\n" +
 	"\x04Node\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\tR\x06nodeId\x12\x1a\n" +
-	"\bendpoint\x18\x02 \x01(\tR\bendpoint\"\xac\x01\n" +
+	"\bendpoint\x18\x02 \x01(\tR\bendpoint\"\x84\x02\n" +
 	"\x13ScheduleRequestHint\x12L\n" +
 	"\x10new_cold_sandbox\x18\x01 \x01(\v2 .scheduler.v1.NewColdSandboxHintH\x00R\x0enewColdSandbox\x12?\n" +
 	"\vnew_sandbox\x18\x02 \x01(\v2\x1c.scheduler.v1.NewSandboxHintH\x00R\n" +
-	"newSandboxB\x06\n" +
-	"\x04kind\"\xef\x01\n" +
+	"newSandbox\x12V\n" +
+	"\x15locality_requirements\x18\x03 \x03(\v2!.scheduler.v1.LocalityRequirementR\x14localityRequirementsB\x06\n" +
+	"\x04kind\"'\n" +
+	"\x13LocalityRequirement\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"\xef\x01\n" +
 	"\x12NewColdSandboxHint\x12\x1b\n" +
 	"\tcpu_count\x18\x01 \x01(\rR\bcpuCount\x12\x1b\n" +
 	"\tmemory_mb\x18\x02 \x01(\x04R\bmemoryMb\x12\x16\n" +
@@ -2327,9 +2393,11 @@ const file_api_proto_scheduler_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x03(\v2..scheduler.v1.NewColdSandboxHint.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x95\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb6\x01\n" +
 	"\x0eNewSandboxHint\x12F\n" +
-	"\bmetadata\x18\x01 \x03(\v2*.scheduler.v1.NewSandboxHint.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x01 \x03(\v2*.scheduler.v1.NewSandboxHint.MetadataEntryR\bmetadata\x12\x1f\n" +
+	"\vtemplate_id\x18\x02 \x01(\tR\n" +
+	"templateId\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"N\n" +
@@ -2519,105 +2587,107 @@ func file_api_proto_scheduler_proto_rawDescGZIP() []byte {
 }
 
 var file_api_proto_scheduler_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_api_proto_scheduler_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_api_proto_scheduler_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_api_proto_scheduler_proto_goTypes = []any{
 	(NodeStatus)(0),                    // 0: scheduler.v1.NodeStatus
 	(SandboxEventType)(0),              // 1: scheduler.v1.SandboxEventType
 	(*Node)(nil),                       // 2: scheduler.v1.Node
 	(*ScheduleRequestHint)(nil),        // 3: scheduler.v1.ScheduleRequestHint
-	(*NewColdSandboxHint)(nil),         // 4: scheduler.v1.NewColdSandboxHint
-	(*NewSandboxHint)(nil),             // 5: scheduler.v1.NewSandboxHint
-	(*ScheduleRequest)(nil),            // 6: scheduler.v1.ScheduleRequest
-	(*ScheduleResponse)(nil),           // 7: scheduler.v1.ScheduleResponse
-	(*ListNodesRequest)(nil),           // 8: scheduler.v1.ListNodesRequest
-	(*ListNodesResponse)(nil),          // 9: scheduler.v1.ListNodesResponse
-	(*LookupNodeRequest)(nil),          // 10: scheduler.v1.LookupNodeRequest
-	(*LookupNodeResponse)(nil),         // 11: scheduler.v1.LookupNodeResponse
-	(*RecordAssignmentRequest)(nil),    // 12: scheduler.v1.RecordAssignmentRequest
-	(*RecordAssignmentResponse)(nil),   // 13: scheduler.v1.RecordAssignmentResponse
-	(*MachineInfo)(nil),                // 14: scheduler.v1.MachineInfo
-	(*DiskMetric)(nil),                 // 15: scheduler.v1.DiskMetric
-	(*NodeSnapshot)(nil),               // 16: scheduler.v1.NodeSnapshot
-	(*P2PEndpoint)(nil),                // 17: scheduler.v1.P2pEndpoint
-	(*ObservedNode)(nil),               // 18: scheduler.v1.ObservedNode
-	(*HeartbeatRequest)(nil),           // 19: scheduler.v1.HeartbeatRequest
-	(*HeartbeatResponse)(nil),          // 20: scheduler.v1.HeartbeatResponse
-	(*SandboxEvent)(nil),               // 21: scheduler.v1.SandboxEvent
-	(*ReportSandboxEventRequest)(nil),  // 22: scheduler.v1.ReportSandboxEventRequest
-	(*ReportSandboxEventResponse)(nil), // 23: scheduler.v1.ReportSandboxEventResponse
-	(*ListObservedNodesRequest)(nil),   // 24: scheduler.v1.ListObservedNodesRequest
-	(*ListObservedNodesResponse)(nil),  // 25: scheduler.v1.ListObservedNodesResponse
-	(*P2PPeer)(nil),                    // 26: scheduler.v1.P2pPeer
-	(*ListP2PPeersRequest)(nil),        // 27: scheduler.v1.ListP2pPeersRequest
-	(*ListP2PPeersResponse)(nil),       // 28: scheduler.v1.ListP2pPeersResponse
-	(*RecordP2PArtifactRequest)(nil),   // 29: scheduler.v1.RecordP2pArtifactRequest
-	(*RecordP2PArtifactResponse)(nil),  // 30: scheduler.v1.RecordP2pArtifactResponse
-	(*ForgetP2PArtifactRequest)(nil),   // 31: scheduler.v1.ForgetP2pArtifactRequest
-	(*ForgetP2PArtifactResponse)(nil),  // 32: scheduler.v1.ForgetP2pArtifactResponse
-	(*LookupP2PArtifactRequest)(nil),   // 33: scheduler.v1.LookupP2pArtifactRequest
-	(*LookupP2PArtifactResponse)(nil),  // 34: scheduler.v1.LookupP2pArtifactResponse
-	(*GetNodeRequest)(nil),             // 35: scheduler.v1.GetNodeRequest
-	(*GetNodeResponse)(nil),            // 36: scheduler.v1.GetNodeResponse
-	(*UnregisterNodeRequest)(nil),      // 37: scheduler.v1.UnregisterNodeRequest
-	(*UnregisterNodeResponse)(nil),     // 38: scheduler.v1.UnregisterNodeResponse
-	nil,                                // 39: scheduler.v1.NewColdSandboxHint.MetadataEntry
-	nil,                                // 40: scheduler.v1.NewSandboxHint.MetadataEntry
+	(*LocalityRequirement)(nil),        // 4: scheduler.v1.LocalityRequirement
+	(*NewColdSandboxHint)(nil),         // 5: scheduler.v1.NewColdSandboxHint
+	(*NewSandboxHint)(nil),             // 6: scheduler.v1.NewSandboxHint
+	(*ScheduleRequest)(nil),            // 7: scheduler.v1.ScheduleRequest
+	(*ScheduleResponse)(nil),           // 8: scheduler.v1.ScheduleResponse
+	(*ListNodesRequest)(nil),           // 9: scheduler.v1.ListNodesRequest
+	(*ListNodesResponse)(nil),          // 10: scheduler.v1.ListNodesResponse
+	(*LookupNodeRequest)(nil),          // 11: scheduler.v1.LookupNodeRequest
+	(*LookupNodeResponse)(nil),         // 12: scheduler.v1.LookupNodeResponse
+	(*RecordAssignmentRequest)(nil),    // 13: scheduler.v1.RecordAssignmentRequest
+	(*RecordAssignmentResponse)(nil),   // 14: scheduler.v1.RecordAssignmentResponse
+	(*MachineInfo)(nil),                // 15: scheduler.v1.MachineInfo
+	(*DiskMetric)(nil),                 // 16: scheduler.v1.DiskMetric
+	(*NodeSnapshot)(nil),               // 17: scheduler.v1.NodeSnapshot
+	(*P2PEndpoint)(nil),                // 18: scheduler.v1.P2pEndpoint
+	(*ObservedNode)(nil),               // 19: scheduler.v1.ObservedNode
+	(*HeartbeatRequest)(nil),           // 20: scheduler.v1.HeartbeatRequest
+	(*HeartbeatResponse)(nil),          // 21: scheduler.v1.HeartbeatResponse
+	(*SandboxEvent)(nil),               // 22: scheduler.v1.SandboxEvent
+	(*ReportSandboxEventRequest)(nil),  // 23: scheduler.v1.ReportSandboxEventRequest
+	(*ReportSandboxEventResponse)(nil), // 24: scheduler.v1.ReportSandboxEventResponse
+	(*ListObservedNodesRequest)(nil),   // 25: scheduler.v1.ListObservedNodesRequest
+	(*ListObservedNodesResponse)(nil),  // 26: scheduler.v1.ListObservedNodesResponse
+	(*P2PPeer)(nil),                    // 27: scheduler.v1.P2pPeer
+	(*ListP2PPeersRequest)(nil),        // 28: scheduler.v1.ListP2pPeersRequest
+	(*ListP2PPeersResponse)(nil),       // 29: scheduler.v1.ListP2pPeersResponse
+	(*RecordP2PArtifactRequest)(nil),   // 30: scheduler.v1.RecordP2pArtifactRequest
+	(*RecordP2PArtifactResponse)(nil),  // 31: scheduler.v1.RecordP2pArtifactResponse
+	(*ForgetP2PArtifactRequest)(nil),   // 32: scheduler.v1.ForgetP2pArtifactRequest
+	(*ForgetP2PArtifactResponse)(nil),  // 33: scheduler.v1.ForgetP2pArtifactResponse
+	(*LookupP2PArtifactRequest)(nil),   // 34: scheduler.v1.LookupP2pArtifactRequest
+	(*LookupP2PArtifactResponse)(nil),  // 35: scheduler.v1.LookupP2pArtifactResponse
+	(*GetNodeRequest)(nil),             // 36: scheduler.v1.GetNodeRequest
+	(*GetNodeResponse)(nil),            // 37: scheduler.v1.GetNodeResponse
+	(*UnregisterNodeRequest)(nil),      // 38: scheduler.v1.UnregisterNodeRequest
+	(*UnregisterNodeResponse)(nil),     // 39: scheduler.v1.UnregisterNodeResponse
+	nil,                                // 40: scheduler.v1.NewColdSandboxHint.MetadataEntry
+	nil,                                // 41: scheduler.v1.NewSandboxHint.MetadataEntry
 }
 var file_api_proto_scheduler_proto_depIdxs = []int32{
-	4,  // 0: scheduler.v1.ScheduleRequestHint.new_cold_sandbox:type_name -> scheduler.v1.NewColdSandboxHint
-	5,  // 1: scheduler.v1.ScheduleRequestHint.new_sandbox:type_name -> scheduler.v1.NewSandboxHint
-	39, // 2: scheduler.v1.NewColdSandboxHint.metadata:type_name -> scheduler.v1.NewColdSandboxHint.MetadataEntry
-	40, // 3: scheduler.v1.NewSandboxHint.metadata:type_name -> scheduler.v1.NewSandboxHint.MetadataEntry
-	3,  // 4: scheduler.v1.ScheduleRequest.hint:type_name -> scheduler.v1.ScheduleRequestHint
-	2,  // 5: scheduler.v1.ScheduleResponse.node:type_name -> scheduler.v1.Node
-	2,  // 6: scheduler.v1.ListNodesResponse.nodes:type_name -> scheduler.v1.Node
-	2,  // 7: scheduler.v1.LookupNodeResponse.node:type_name -> scheduler.v1.Node
-	2,  // 8: scheduler.v1.RecordAssignmentRequest.node:type_name -> scheduler.v1.Node
-	0,  // 9: scheduler.v1.NodeSnapshot.status:type_name -> scheduler.v1.NodeStatus
-	15, // 10: scheduler.v1.NodeSnapshot.disks:type_name -> scheduler.v1.DiskMetric
-	14, // 11: scheduler.v1.ObservedNode.machine_info:type_name -> scheduler.v1.MachineInfo
-	16, // 12: scheduler.v1.ObservedNode.snapshot:type_name -> scheduler.v1.NodeSnapshot
-	14, // 13: scheduler.v1.HeartbeatRequest.machine_info:type_name -> scheduler.v1.MachineInfo
-	16, // 14: scheduler.v1.HeartbeatRequest.snapshot:type_name -> scheduler.v1.NodeSnapshot
-	17, // 15: scheduler.v1.HeartbeatRequest.p2p_endpoint:type_name -> scheduler.v1.P2pEndpoint
-	1,  // 16: scheduler.v1.SandboxEvent.event_type:type_name -> scheduler.v1.SandboxEventType
-	21, // 17: scheduler.v1.ReportSandboxEventRequest.events:type_name -> scheduler.v1.SandboxEvent
-	18, // 18: scheduler.v1.ListObservedNodesResponse.nodes:type_name -> scheduler.v1.ObservedNode
-	17, // 19: scheduler.v1.P2pPeer.endpoint:type_name -> scheduler.v1.P2pEndpoint
-	26, // 20: scheduler.v1.ListP2pPeersResponse.peers:type_name -> scheduler.v1.P2pPeer
-	26, // 21: scheduler.v1.LookupP2pArtifactResponse.peers:type_name -> scheduler.v1.P2pPeer
-	18, // 22: scheduler.v1.GetNodeResponse.node:type_name -> scheduler.v1.ObservedNode
-	6,  // 23: scheduler.v1.Scheduler.Schedule:input_type -> scheduler.v1.ScheduleRequest
-	8,  // 24: scheduler.v1.Scheduler.ListNodes:input_type -> scheduler.v1.ListNodesRequest
-	10, // 25: scheduler.v1.Scheduler.LookupNode:input_type -> scheduler.v1.LookupNodeRequest
-	12, // 26: scheduler.v1.Scheduler.RecordAssignment:input_type -> scheduler.v1.RecordAssignmentRequest
-	19, // 27: scheduler.v1.Scheduler.Heartbeat:input_type -> scheduler.v1.HeartbeatRequest
-	22, // 28: scheduler.v1.Scheduler.ReportSandboxEvent:input_type -> scheduler.v1.ReportSandboxEventRequest
-	24, // 29: scheduler.v1.Scheduler.ListObservedNodes:input_type -> scheduler.v1.ListObservedNodesRequest
-	27, // 30: scheduler.v1.Scheduler.ListP2pPeers:input_type -> scheduler.v1.ListP2pPeersRequest
-	29, // 31: scheduler.v1.Scheduler.RecordP2pArtifact:input_type -> scheduler.v1.RecordP2pArtifactRequest
-	31, // 32: scheduler.v1.Scheduler.ForgetP2pArtifact:input_type -> scheduler.v1.ForgetP2pArtifactRequest
-	33, // 33: scheduler.v1.Scheduler.LookupP2pArtifact:input_type -> scheduler.v1.LookupP2pArtifactRequest
-	35, // 34: scheduler.v1.Scheduler.GetNode:input_type -> scheduler.v1.GetNodeRequest
-	37, // 35: scheduler.v1.Scheduler.UnregisterNode:input_type -> scheduler.v1.UnregisterNodeRequest
-	7,  // 36: scheduler.v1.Scheduler.Schedule:output_type -> scheduler.v1.ScheduleResponse
-	9,  // 37: scheduler.v1.Scheduler.ListNodes:output_type -> scheduler.v1.ListNodesResponse
-	11, // 38: scheduler.v1.Scheduler.LookupNode:output_type -> scheduler.v1.LookupNodeResponse
-	13, // 39: scheduler.v1.Scheduler.RecordAssignment:output_type -> scheduler.v1.RecordAssignmentResponse
-	20, // 40: scheduler.v1.Scheduler.Heartbeat:output_type -> scheduler.v1.HeartbeatResponse
-	23, // 41: scheduler.v1.Scheduler.ReportSandboxEvent:output_type -> scheduler.v1.ReportSandboxEventResponse
-	25, // 42: scheduler.v1.Scheduler.ListObservedNodes:output_type -> scheduler.v1.ListObservedNodesResponse
-	28, // 43: scheduler.v1.Scheduler.ListP2pPeers:output_type -> scheduler.v1.ListP2pPeersResponse
-	30, // 44: scheduler.v1.Scheduler.RecordP2pArtifact:output_type -> scheduler.v1.RecordP2pArtifactResponse
-	32, // 45: scheduler.v1.Scheduler.ForgetP2pArtifact:output_type -> scheduler.v1.ForgetP2pArtifactResponse
-	34, // 46: scheduler.v1.Scheduler.LookupP2pArtifact:output_type -> scheduler.v1.LookupP2pArtifactResponse
-	36, // 47: scheduler.v1.Scheduler.GetNode:output_type -> scheduler.v1.GetNodeResponse
-	38, // 48: scheduler.v1.Scheduler.UnregisterNode:output_type -> scheduler.v1.UnregisterNodeResponse
-	36, // [36:49] is the sub-list for method output_type
-	23, // [23:36] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	5,  // 0: scheduler.v1.ScheduleRequestHint.new_cold_sandbox:type_name -> scheduler.v1.NewColdSandboxHint
+	6,  // 1: scheduler.v1.ScheduleRequestHint.new_sandbox:type_name -> scheduler.v1.NewSandboxHint
+	4,  // 2: scheduler.v1.ScheduleRequestHint.locality_requirements:type_name -> scheduler.v1.LocalityRequirement
+	40, // 3: scheduler.v1.NewColdSandboxHint.metadata:type_name -> scheduler.v1.NewColdSandboxHint.MetadataEntry
+	41, // 4: scheduler.v1.NewSandboxHint.metadata:type_name -> scheduler.v1.NewSandboxHint.MetadataEntry
+	3,  // 5: scheduler.v1.ScheduleRequest.hint:type_name -> scheduler.v1.ScheduleRequestHint
+	2,  // 6: scheduler.v1.ScheduleResponse.node:type_name -> scheduler.v1.Node
+	2,  // 7: scheduler.v1.ListNodesResponse.nodes:type_name -> scheduler.v1.Node
+	2,  // 8: scheduler.v1.LookupNodeResponse.node:type_name -> scheduler.v1.Node
+	2,  // 9: scheduler.v1.RecordAssignmentRequest.node:type_name -> scheduler.v1.Node
+	0,  // 10: scheduler.v1.NodeSnapshot.status:type_name -> scheduler.v1.NodeStatus
+	16, // 11: scheduler.v1.NodeSnapshot.disks:type_name -> scheduler.v1.DiskMetric
+	15, // 12: scheduler.v1.ObservedNode.machine_info:type_name -> scheduler.v1.MachineInfo
+	17, // 13: scheduler.v1.ObservedNode.snapshot:type_name -> scheduler.v1.NodeSnapshot
+	15, // 14: scheduler.v1.HeartbeatRequest.machine_info:type_name -> scheduler.v1.MachineInfo
+	17, // 15: scheduler.v1.HeartbeatRequest.snapshot:type_name -> scheduler.v1.NodeSnapshot
+	18, // 16: scheduler.v1.HeartbeatRequest.p2p_endpoint:type_name -> scheduler.v1.P2pEndpoint
+	1,  // 17: scheduler.v1.SandboxEvent.event_type:type_name -> scheduler.v1.SandboxEventType
+	22, // 18: scheduler.v1.ReportSandboxEventRequest.events:type_name -> scheduler.v1.SandboxEvent
+	19, // 19: scheduler.v1.ListObservedNodesResponse.nodes:type_name -> scheduler.v1.ObservedNode
+	18, // 20: scheduler.v1.P2pPeer.endpoint:type_name -> scheduler.v1.P2pEndpoint
+	27, // 21: scheduler.v1.ListP2pPeersResponse.peers:type_name -> scheduler.v1.P2pPeer
+	27, // 22: scheduler.v1.LookupP2pArtifactResponse.peers:type_name -> scheduler.v1.P2pPeer
+	19, // 23: scheduler.v1.GetNodeResponse.node:type_name -> scheduler.v1.ObservedNode
+	7,  // 24: scheduler.v1.Scheduler.Schedule:input_type -> scheduler.v1.ScheduleRequest
+	9,  // 25: scheduler.v1.Scheduler.ListNodes:input_type -> scheduler.v1.ListNodesRequest
+	11, // 26: scheduler.v1.Scheduler.LookupNode:input_type -> scheduler.v1.LookupNodeRequest
+	13, // 27: scheduler.v1.Scheduler.RecordAssignment:input_type -> scheduler.v1.RecordAssignmentRequest
+	20, // 28: scheduler.v1.Scheduler.Heartbeat:input_type -> scheduler.v1.HeartbeatRequest
+	23, // 29: scheduler.v1.Scheduler.ReportSandboxEvent:input_type -> scheduler.v1.ReportSandboxEventRequest
+	25, // 30: scheduler.v1.Scheduler.ListObservedNodes:input_type -> scheduler.v1.ListObservedNodesRequest
+	28, // 31: scheduler.v1.Scheduler.ListP2pPeers:input_type -> scheduler.v1.ListP2pPeersRequest
+	30, // 32: scheduler.v1.Scheduler.RecordP2pArtifact:input_type -> scheduler.v1.RecordP2pArtifactRequest
+	32, // 33: scheduler.v1.Scheduler.ForgetP2pArtifact:input_type -> scheduler.v1.ForgetP2pArtifactRequest
+	34, // 34: scheduler.v1.Scheduler.LookupP2pArtifact:input_type -> scheduler.v1.LookupP2pArtifactRequest
+	36, // 35: scheduler.v1.Scheduler.GetNode:input_type -> scheduler.v1.GetNodeRequest
+	38, // 36: scheduler.v1.Scheduler.UnregisterNode:input_type -> scheduler.v1.UnregisterNodeRequest
+	8,  // 37: scheduler.v1.Scheduler.Schedule:output_type -> scheduler.v1.ScheduleResponse
+	10, // 38: scheduler.v1.Scheduler.ListNodes:output_type -> scheduler.v1.ListNodesResponse
+	12, // 39: scheduler.v1.Scheduler.LookupNode:output_type -> scheduler.v1.LookupNodeResponse
+	14, // 40: scheduler.v1.Scheduler.RecordAssignment:output_type -> scheduler.v1.RecordAssignmentResponse
+	21, // 41: scheduler.v1.Scheduler.Heartbeat:output_type -> scheduler.v1.HeartbeatResponse
+	24, // 42: scheduler.v1.Scheduler.ReportSandboxEvent:output_type -> scheduler.v1.ReportSandboxEventResponse
+	26, // 43: scheduler.v1.Scheduler.ListObservedNodes:output_type -> scheduler.v1.ListObservedNodesResponse
+	29, // 44: scheduler.v1.Scheduler.ListP2pPeers:output_type -> scheduler.v1.ListP2pPeersResponse
+	31, // 45: scheduler.v1.Scheduler.RecordP2pArtifact:output_type -> scheduler.v1.RecordP2pArtifactResponse
+	33, // 46: scheduler.v1.Scheduler.ForgetP2pArtifact:output_type -> scheduler.v1.ForgetP2pArtifactResponse
+	35, // 47: scheduler.v1.Scheduler.LookupP2pArtifact:output_type -> scheduler.v1.LookupP2pArtifactResponse
+	37, // 48: scheduler.v1.Scheduler.GetNode:output_type -> scheduler.v1.GetNodeResponse
+	39, // 49: scheduler.v1.Scheduler.UnregisterNode:output_type -> scheduler.v1.UnregisterNodeResponse
+	37, // [37:50] is the sub-list for method output_type
+	24, // [24:37] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_api_proto_scheduler_proto_init() }
@@ -2635,7 +2705,7 @@ func file_api_proto_scheduler_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_proto_scheduler_proto_rawDesc), len(file_api_proto_scheduler_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   39,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/services/api/proto/scheduler.proto
+++ b/services/api/proto/scheduler.proto
@@ -34,6 +34,13 @@ message ScheduleRequestHint {
     NewColdSandboxHint new_cold_sandbox = 1;
     NewSandboxHint new_sandbox = 2;
   }
+  // Stable artifact identities that can be used to prefer nodes which already
+  // provide content needed by this request. Requirements are advisory.
+  repeated LocalityRequirement locality_requirements = 3;
+}
+
+message LocalityRequirement {
+  string key = 1;
 }
 
 // NewColdSandboxHint describes a POST /sandboxes-cold request.
@@ -51,6 +58,8 @@ message NewColdSandboxHint {
 message NewSandboxHint {
   // Sandbox metadata key/value pairs parsed from the request body.
   map<string, string> metadata = 1;
+  // Template identifier supplied by POST /sandboxes.
+  string template_id = 2;
 }
 
 message ScheduleRequest {

--- a/services/gateway/internal/schedule_hint.go
+++ b/services/gateway/internal/schedule_hint.go
@@ -42,7 +42,6 @@ func buildScheduleHint(r *http.Request) (*schedulerv1.ScheduleRequestHint, error
 			Kind: &schedulerv1.ScheduleRequestHint_NewSandbox{
 				NewSandbox: newSandbox,
 			},
-			LocalityRequirements: snapshotLocalityRequirements(newSandbox.GetTemplateId()),
 		}, nil
 	default:
 		return nil, nil

--- a/services/gateway/internal/schedule_hint.go
+++ b/services/gateway/internal/schedule_hint.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -36,10 +37,12 @@ func buildScheduleHint(r *http.Request) (*schedulerv1.ScheduleRequestHint, error
 		if err != nil {
 			return nil, err
 		}
+		newSandbox := parseNewSandboxHint(body)
 		return &schedulerv1.ScheduleRequestHint{
 			Kind: &schedulerv1.ScheduleRequestHint_NewSandbox{
-				NewSandbox: parseNewSandboxHint(body),
+				NewSandbox: newSandbox,
 			},
+			LocalityRequirements: snapshotLocalityRequirements(newSandbox.GetTemplateId()),
 		}, nil
 	default:
 		return nil, nil
@@ -134,7 +137,8 @@ func parseNewColdSandboxHint(body []byte) *schedulerv1.NewColdSandboxHint {
 // newSandboxBody mirrors the subset of NewSandbox (src/api/openapi.yml) that is
 // relevant for scheduling.
 type newSandboxBody struct {
-	Metadata map[string]string `json:"metadata"`
+	TemplateID string            `json:"templateID"`
+	Metadata   map[string]string `json:"metadata"`
 }
 
 // parseNewSandboxHint extracts the structured sandbox hint from the request
@@ -149,6 +153,19 @@ func parseNewSandboxHint(body []byte) *schedulerv1.NewSandboxHint {
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return hint
 	}
+	hint.TemplateId = parsed.TemplateID
 	hint.Metadata = parsed.Metadata
 	return hint
+}
+
+func snapshotLocalityRequirements(templateID string) []*schedulerv1.LocalityRequirement {
+	templateID = strings.TrimSpace(templateID)
+	if templateID == "" {
+		return nil
+	}
+	prefix := fmt.Sprintf("snapshot/v1/artifacts/%s/", templateID)
+	return []*schedulerv1.LocalityRequirement{
+		{Key: prefix + "vm_state.bin"},
+		{Key: prefix + "firecracker-manifest.json"},
+	}
 }

--- a/services/gateway/internal/schedule_hint_test.go
+++ b/services/gateway/internal/schedule_hint_test.go
@@ -40,12 +40,8 @@ func TestBuildScheduleHintNewSandbox(t *testing.T) {
 	if got := hint.GetNewSandbox().GetTemplateId(); got != "tmpl" {
 		t.Fatalf("template_id = %q, want tmpl", got)
 	}
-	wantRequirements := []string{
-		"snapshot/v1/artifacts/tmpl/vm_state.bin",
-		"snapshot/v1/artifacts/tmpl/firecracker-manifest.json",
-	}
-	if got := localityRequirementKeys(hint.GetLocalityRequirements()); !equalStrings(got, wantRequirements) {
-		t.Fatalf("locality requirements = %v, want %v", got, wantRequirements)
+	if got := hint.GetLocalityRequirements(); len(got) != 0 {
+		t.Fatalf("raw schedule hint must not derive locality keys from an unresolved template reference: %v", got)
 	}
 
 	// Body must remain available for the upstream request.
@@ -195,10 +191,10 @@ func TestSnapshotLocalityRequirements(t *testing.T) {
 	}
 
 	want := []string{
-		"snapshot/v1/artifacts/snapshot-1/vm_state.bin",
-		"snapshot/v1/artifacts/snapshot-1/firecracker-manifest.json",
+		"snapshot/v1/artifacts/550e8400-e29b-41d4-a716-446655440000/vm_state.bin",
+		"snapshot/v1/artifacts/550e8400-e29b-41d4-a716-446655440000/firecracker-manifest.json",
 	}
-	if got := localityRequirementKeys(snapshotLocalityRequirements(" snapshot-1 ")); !equalStrings(got, want) {
+	if got := localityRequirementKeys(snapshotLocalityRequirements(" 550e8400-e29b-41d4-a716-446655440000 ")); !equalStrings(got, want) {
 		t.Fatalf("requirements = %v, want %v", got, want)
 	}
 }

--- a/services/gateway/internal/schedule_hint_test.go
+++ b/services/gateway/internal/schedule_hint_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	schedulerv1 "agentenv/services/api/proto"
 )
 
 func newHintRequest(t *testing.T, method, target, body string) *http.Request {
@@ -34,6 +36,16 @@ func TestBuildScheduleHintNewSandbox(t *testing.T) {
 	}
 	if hint.GetNewColdSandbox() != nil {
 		t.Fatalf("did not expect cold sandbox hint")
+	}
+	if got := hint.GetNewSandbox().GetTemplateId(); got != "tmpl" {
+		t.Fatalf("template_id = %q, want tmpl", got)
+	}
+	wantRequirements := []string{
+		"snapshot/v1/artifacts/tmpl/vm_state.bin",
+		"snapshot/v1/artifacts/tmpl/firecracker-manifest.json",
+	}
+	if got := localityRequirementKeys(hint.GetLocalityRequirements()); !equalStrings(got, wantRequirements) {
+		t.Fatalf("locality requirements = %v, want %v", got, wantRequirements)
 	}
 
 	// Body must remain available for the upstream request.
@@ -156,6 +168,47 @@ func TestParseNewColdSandboxHint(t *testing.T) {
 			t.Fatalf("images = %v", got)
 		}
 	})
+}
+
+func TestParseNewSandboxHint(t *testing.T) {
+	t.Run("extracts template and metadata", func(t *testing.T) {
+		hint := parseNewSandboxHint([]byte(`{"templateID":"tmpl","metadata":{"team":"infra"}}`))
+		if hint.GetTemplateId() != "tmpl" {
+			t.Fatalf("template_id = %q, want tmpl", hint.GetTemplateId())
+		}
+		if hint.GetMetadata()["team"] != "infra" {
+			t.Fatalf("metadata = %v", hint.GetMetadata())
+		}
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		hint := parseNewSandboxHint([]byte("{not json"))
+		if hint.GetTemplateId() != "" || len(hint.GetMetadata()) != 0 {
+			t.Fatalf("expected best-effort empty hint, got %v", hint)
+		}
+	})
+}
+
+func TestSnapshotLocalityRequirements(t *testing.T) {
+	if got := snapshotLocalityRequirements("  "); got != nil {
+		t.Fatalf("empty template requirements = %v, want nil", got)
+	}
+
+	want := []string{
+		"snapshot/v1/artifacts/snapshot-1/vm_state.bin",
+		"snapshot/v1/artifacts/snapshot-1/firecracker-manifest.json",
+	}
+	if got := localityRequirementKeys(snapshotLocalityRequirements(" snapshot-1 ")); !equalStrings(got, want) {
+		t.Fatalf("requirements = %v, want %v", got, want)
+	}
+}
+
+func localityRequirementKeys(requirements []*schedulerv1.LocalityRequirement) []string {
+	keys := make([]string, 0, len(requirements))
+	for _, requirement := range requirements {
+		keys = append(keys, requirement.GetKey())
+	}
+	return keys
 }
 
 func TestCaptureRequestBodyNil(t *testing.T) {

--- a/services/gateway/internal/server.go
+++ b/services/gateway/internal/server.go
@@ -58,6 +58,7 @@ type Server struct {
 	templateAliasLookupTimeout     time.Duration
 	templateAliasScheduleReserve   time.Duration
 	templateAliasLookupConcurrency int
+	templateAliasResolutionSlots   chan struct{}
 	maxRespSize                    int64
 	// debugMode, when true, enables debug-only behaviors such as exposing
 	// the backend node id on proxied responses via the x-agentenv-node-id
@@ -87,6 +88,7 @@ func NewServer(logger *zap.Logger, schedulerClient schedulerv1.SchedulerClient, 
 		templateAliasLookupTimeout:     defaultTemplateAliasLookupTimeout,
 		templateAliasScheduleReserve:   defaultTemplateAliasScheduleReserve,
 		templateAliasLookupConcurrency: defaultTemplateAliasLookupConcurrency,
+		templateAliasResolutionSlots:   make(chan struct{}, defaultTemplateAliasResolutionConcurrency),
 		maxRespSize:                    options.MaxResponseSize,
 		debugMode:                      options.DebugMode,
 		sandboxProxyDomains:            sandboxProxyDomains,

--- a/services/gateway/internal/server.go
+++ b/services/gateway/internal/server.go
@@ -49,17 +49,12 @@ type ServerOptions struct {
 }
 
 type Server struct {
-	logger                         *zap.Logger
-	scheduler                      schedulerv1.SchedulerClient
-	queryOnlyScheduler             schedulerv1.SchedulerClient
-	httpClient                     *http.Client
-	templateAliasHTTPClient        *http.Client
-	requestTimeout                 time.Duration
-	templateAliasLookupTimeout     time.Duration
-	templateAliasScheduleReserve   time.Duration
-	templateAliasLookupConcurrency int
-	templateAliasResolutionSlots   chan struct{}
-	maxRespSize                    int64
+	logger             *zap.Logger
+	scheduler          schedulerv1.SchedulerClient
+	queryOnlyScheduler schedulerv1.SchedulerClient
+	httpClient         *http.Client
+	requestTimeout     time.Duration
+	maxRespSize        int64
 	// debugMode, when true, enables debug-only behaviors such as exposing
 	// the backend node id on proxied responses via the x-agentenv-node-id
 	// header. Off by default; toggled via GatewayConfig.DebugMode.
@@ -79,19 +74,14 @@ func NewServer(logger *zap.Logger, schedulerClient schedulerv1.SchedulerClient, 
 	}
 
 	return &Server{
-		logger:                         logger,
-		scheduler:                      schedulerClient,
-		queryOnlyScheduler:             queryOnlyScheduler,
-		httpClient:                     &http.Client{},
-		templateAliasHTTPClient:        &http.Client{Timeout: defaultTemplateAliasHTTPTimeout},
-		requestTimeout:                 options.RequestTimeout,
-		templateAliasLookupTimeout:     defaultTemplateAliasLookupTimeout,
-		templateAliasScheduleReserve:   defaultTemplateAliasScheduleReserve,
-		templateAliasLookupConcurrency: defaultTemplateAliasLookupConcurrency,
-		templateAliasResolutionSlots:   make(chan struct{}, defaultTemplateAliasResolutionConcurrency),
-		maxRespSize:                    options.MaxResponseSize,
-		debugMode:                      options.DebugMode,
-		sandboxProxyDomains:            sandboxProxyDomains,
+		logger:              logger,
+		scheduler:           schedulerClient,
+		queryOnlyScheduler:  queryOnlyScheduler,
+		httpClient:          &http.Client{},
+		requestTimeout:      options.RequestTimeout,
+		maxRespSize:         options.MaxResponseSize,
+		debugMode:           options.DebugMode,
+		sandboxProxyDomains: sandboxProxyDomains,
 	}, nil
 }
 
@@ -228,7 +218,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to read request body", http.StatusBadRequest)
 			return
 		}
-		resolvedHint := s.resolveSnapshotLocalityHint(routingCtx, r, hint)
+		resolvedHint := resolveSnapshotLocalityHint(hint)
 		rpcStart := time.Now()
 		resp, err := s.scheduler.Schedule(routingCtx, &schedulerv1.ScheduleRequest{
 			Hint: resolvedHint,

--- a/services/gateway/internal/server.go
+++ b/services/gateway/internal/server.go
@@ -49,12 +49,16 @@ type ServerOptions struct {
 }
 
 type Server struct {
-	logger             *zap.Logger
-	scheduler          schedulerv1.SchedulerClient
-	queryOnlyScheduler schedulerv1.SchedulerClient
-	httpClient         *http.Client
-	requestTimeout     time.Duration
-	maxRespSize        int64
+	logger                         *zap.Logger
+	scheduler                      schedulerv1.SchedulerClient
+	queryOnlyScheduler             schedulerv1.SchedulerClient
+	httpClient                     *http.Client
+	templateAliasHTTPClient        *http.Client
+	requestTimeout                 time.Duration
+	templateAliasLookupTimeout     time.Duration
+	templateAliasScheduleReserve   time.Duration
+	templateAliasLookupConcurrency int
+	maxRespSize                    int64
 	// debugMode, when true, enables debug-only behaviors such as exposing
 	// the backend node id on proxied responses via the x-agentenv-node-id
 	// header. Off by default; toggled via GatewayConfig.DebugMode.
@@ -74,14 +78,18 @@ func NewServer(logger *zap.Logger, schedulerClient schedulerv1.SchedulerClient, 
 	}
 
 	return &Server{
-		logger:              logger,
-		scheduler:           schedulerClient,
-		queryOnlyScheduler:  queryOnlyScheduler,
-		httpClient:          &http.Client{},
-		requestTimeout:      options.RequestTimeout,
-		maxRespSize:         options.MaxResponseSize,
-		debugMode:           options.DebugMode,
-		sandboxProxyDomains: sandboxProxyDomains,
+		logger:                         logger,
+		scheduler:                      schedulerClient,
+		queryOnlyScheduler:             queryOnlyScheduler,
+		httpClient:                     &http.Client{},
+		templateAliasHTTPClient:        &http.Client{Timeout: defaultTemplateAliasHTTPTimeout},
+		requestTimeout:                 options.RequestTimeout,
+		templateAliasLookupTimeout:     defaultTemplateAliasLookupTimeout,
+		templateAliasScheduleReserve:   defaultTemplateAliasScheduleReserve,
+		templateAliasLookupConcurrency: defaultTemplateAliasLookupConcurrency,
+		maxRespSize:                    options.MaxResponseSize,
+		debugMode:                      options.DebugMode,
+		sandboxProxyDomains:            sandboxProxyDomains,
 	}, nil
 }
 

--- a/services/gateway/internal/server.go
+++ b/services/gateway/internal/server.go
@@ -218,9 +218,10 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to read request body", http.StatusBadRequest)
 			return
 		}
+		resolvedHint := s.resolveSnapshotLocalityHint(routingCtx, r, hint)
 		rpcStart := time.Now()
 		resp, err := s.scheduler.Schedule(routingCtx, &schedulerv1.ScheduleRequest{
-			Hint: hint,
+			Hint: resolvedHint,
 		})
 		recordGatewaySchedulerRPC("Schedule", rpcStart, err)
 		if err != nil {

--- a/services/gateway/internal/template_resolution.go
+++ b/services/gateway/internal/template_resolution.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	schedulerv1 "agentenv/services/api/proto"
@@ -19,6 +20,9 @@ const (
 	defaultTemplateAliasLookupTimeout     = 2 * time.Second
 	defaultTemplateAliasScheduleReserve   = 5 * time.Second
 	defaultTemplateAliasLookupConcurrency = 8
+	// Alias resolution is advisory, so cap concurrent cluster fan-outs globally
+	// and skip locality when the gateway is already at capacity.
+	defaultTemplateAliasResolutionConcurrency = 8
 )
 
 type templateAliasResponse struct {
@@ -47,6 +51,13 @@ func (s *Server) resolveSnapshotLocalityHint(
 			return hint
 		}
 
+		release, ok := s.tryAcquireTemplateAliasResolution()
+		if !ok {
+			hint.LocalityRequirements = nil
+			return hint
+		}
+		defer release()
+
 		var err error
 		lookupCtx, cancel, ok := s.templateAliasLookupContext(ctx)
 		if !ok {
@@ -67,6 +78,19 @@ func (s *Server) resolveSnapshotLocalityHint(
 
 	hint.LocalityRequirements = snapshotLocalityRequirements(canonicalID)
 	return hint
+}
+
+func (s *Server) tryAcquireTemplateAliasResolution() (func(), bool) {
+	slots := s.templateAliasResolutionSlots
+	if slots == nil {
+		return func() {}, true
+	}
+	select {
+	case slots <- struct{}{}:
+		return func() { <-slots }, true
+	default:
+		return func() {}, false
+	}
 }
 
 func (s *Server) templateAliasLookupContext(parent context.Context) (context.Context, context.CancelFunc, bool) {
@@ -153,7 +177,6 @@ func (s *Server) resolveTemplateAlias(
 		canonicalID string
 		err         error
 	}
-	results := make(chan result, len(nodes))
 	lookupCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	concurrency := s.templateAliasLookupConcurrency
@@ -163,27 +186,51 @@ func (s *Server) resolveTemplateAlias(
 	if concurrency > len(nodes) {
 		concurrency = len(nodes)
 	}
-	semaphore := make(chan struct{}, concurrency)
-
-	for _, node := range nodes {
-		node := node
+	results := make(chan result, concurrency)
+	nextNode := make(chan *schedulerv1.Node)
+	var workers sync.WaitGroup
+	workers.Add(concurrency)
+	for range concurrency {
 		go func() {
-			select {
-			case semaphore <- struct{}{}:
-				defer func() { <-semaphore }()
-			case <-lookupCtx.Done():
-				results <- result{err: lookupCtx.Err()}
-				return
-			}
+			defer workers.Done()
+			for {
+				var node *schedulerv1.Node
+				var ok bool
+				select {
+				case node, ok = <-nextNode:
+					if !ok {
+						return
+					}
+				case <-lookupCtx.Done():
+					return
+				}
 
-			canonicalID, err := s.resolveTemplateAliasOnNode(lookupCtx, incoming, node, alias)
-			results <- result{canonicalID: canonicalID, err: err}
+				canonicalID, err := s.resolveTemplateAliasOnNode(lookupCtx, incoming, node, alias)
+				select {
+				case results <- result{canonicalID: canonicalID, err: err}:
+				case <-lookupCtx.Done():
+					return
+				}
+			}
 		}()
 	}
+	go func() {
+		defer close(nextNode)
+		for _, node := range nodes {
+			select {
+			case nextNode <- node:
+			case <-lookupCtx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		workers.Wait()
+		close(results)
+	}()
 
 	var firstErr error
-	for range nodes {
-		resolved := <-results
+	for resolved := range results {
 		if resolved.err == nil {
 			cancel()
 			return resolved.canonicalID, nil
@@ -191,6 +238,12 @@ func (s *Server) resolveTemplateAlias(
 		if firstErr == nil {
 			firstErr = resolved.err
 		}
+	}
+	if firstErr == nil {
+		firstErr = lookupCtx.Err()
+	}
+	if firstErr == nil {
+		firstErr = fmt.Errorf("template alias resolution produced no result")
 	}
 	return "", firstErr
 }

--- a/services/gateway/internal/template_resolution.go
+++ b/services/gateway/internal/template_resolution.go
@@ -1,309 +1,47 @@
 package gateway
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
 	"strings"
-	"sync"
-	"time"
 
 	schedulerv1 "agentenv/services/api/proto"
 
 	"github.com/google/uuid"
-	"go.uber.org/zap"
 )
 
-const (
-	defaultTemplateAliasHTTPTimeout       = 2 * time.Second
-	defaultTemplateAliasLookupTimeout     = 2 * time.Second
-	defaultTemplateAliasScheduleReserve   = 5 * time.Second
-	defaultTemplateAliasLookupConcurrency = 8
-	maxTemplateAliasResponseBytes         = 4 * 1024
-	// Alias resolution is advisory, so cap concurrent cluster fan-outs globally
-	// and skip locality when the gateway is already at capacity.
-	defaultTemplateAliasResolutionConcurrency = 8
-)
-
-type templateAliasResponse struct {
-	TemplateID string `json:"templateID"`
-}
-
-// resolveSnapshotLocalityHint replaces the request's template alias with the
-// canonical snapshot ID before deriving fixed snapshot artifact keys. Alias
-// resolution is best-effort: locality is only a placement preference, so a
-// resolver failure must not prevent the normal sandbox request from being
-// scheduled.
-func (s *Server) resolveSnapshotLocalityHint(
-	ctx context.Context,
-	incoming *http.Request,
+// resolveSnapshotLocalityHint derives fixed snapshot artifact requirements only
+// from canonical snapshot IDs. Template aliases intentionally fall back to
+// normal scheduling: the Gateway has no authoritative pre-scheduling alias
+// resolver, while querying every node would expand credential exposure and
+// could observe inconsistent alias mappings.
+func resolveSnapshotLocalityHint(
 	hint *schedulerv1.ScheduleRequestHint,
 ) *schedulerv1.ScheduleRequestHint {
 	if hint == nil || hint.GetNewSandbox() == nil {
 		return hint
 	}
 
-	templateID := strings.TrimSpace(hint.GetNewSandbox().GetTemplateId())
-	canonicalID, ok := canonicalSnapshotID(templateID)
+	canonicalID, ok := canonicalSnapshotID(hint.GetNewSandbox().GetTemplateId())
 	if !ok {
-		if !isSnapshotAlias(templateID) {
-			hint.LocalityRequirements = nil
-			return hint
-		}
-
-		release, ok := s.tryAcquireTemplateAliasResolution()
-		if !ok {
-			hint.LocalityRequirements = nil
-			return hint
-		}
-		defer release()
-
-		var err error
-		lookupCtx, cancel, ok := s.templateAliasLookupContext(ctx)
-		if !ok {
-			hint.LocalityRequirements = nil
-			return hint
-		}
-		canonicalID, err = s.resolveTemplateAlias(lookupCtx, incoming, templateID)
-		cancel()
-		if err != nil {
-			s.logger.Debug("snapshot alias locality resolution unavailable",
-				zap.String("template_id", templateID),
-				zap.Error(err),
-			)
-			hint.LocalityRequirements = nil
-			return hint
-		}
+		hint.LocalityRequirements = nil
+		return hint
 	}
 
 	hint.LocalityRequirements = snapshotLocalityRequirements(canonicalID)
 	return hint
 }
 
-func (s *Server) tryAcquireTemplateAliasResolution() (func(), bool) {
-	slots := s.templateAliasResolutionSlots
-	if slots == nil {
-		return func() {}, true
-	}
-	select {
-	case slots <- struct{}{}:
-		return func() { <-slots }, true
-	default:
-		return func() {}, false
-	}
-}
-
-func (s *Server) templateAliasLookupContext(parent context.Context) (context.Context, context.CancelFunc, bool) {
-	lookupTimeout := s.templateAliasLookupTimeout
-	if lookupTimeout <= 0 {
-		lookupTimeout = defaultTemplateAliasLookupTimeout
-	}
-
-	reserve := s.templateAliasScheduleReserve
-	if reserve < 0 {
-		reserve = 0
-	}
-	if deadline, ok := parent.Deadline(); ok {
-		remaining := time.Until(deadline)
-		if remaining <= reserve {
-			return nil, func() {}, false
-		}
-		if available := remaining - reserve; lookupTimeout > available {
-			lookupTimeout = available
-		}
-	}
-	if lookupTimeout <= 0 {
-		return nil, func() {}, false
-	}
-
-	lookupCtx, cancel := context.WithTimeout(parent, lookupTimeout)
-	return lookupCtx, cancel, true
-}
-
 func canonicalSnapshotID(value string) (string, bool) {
-	parsed, err := uuid.Parse(strings.TrimSpace(value))
+	value = strings.TrimSpace(value)
+	if len(value) != 36 ||
+		value[8] != '-' ||
+		value[13] != '-' ||
+		value[18] != '-' ||
+		value[23] != '-' {
+		return "", false
+	}
+	parsed, err := uuid.Parse(value)
 	if err != nil {
 		return "", false
 	}
 	return parsed.String(), true
-}
-
-func isSnapshotAlias(value string) bool {
-	if value == "" {
-		return false
-	}
-	for _, char := range value {
-		if !(char == '-' ||
-			char == '_' ||
-			(char >= '0' && char <= '9') ||
-			(char >= 'a' && char <= 'z') ||
-			(char >= 'A' && char <= 'Z')) {
-			return false
-		}
-	}
-	return true
-}
-
-func (s *Server) resolveTemplateAlias(
-	ctx context.Context,
-	incoming *http.Request,
-	alias string,
-) (string, error) {
-	rpcStart := time.Now()
-	resp, err := s.scheduler.ListNodes(ctx, &schedulerv1.ListNodesRequest{})
-	recordGatewaySchedulerRPC("ListNodes", rpcStart, err)
-	if err != nil {
-		return "", fmt.Errorf("list nodes for template alias resolution: %w", err)
-	}
-
-	nodes := make([]*schedulerv1.Node, 0, len(resp.GetNodes()))
-	seenEndpoints := make(map[string]struct{}, len(resp.GetNodes()))
-	for _, node := range resp.GetNodes() {
-		if node == nil || strings.TrimSpace(node.GetEndpoint()) == "" {
-			continue
-		}
-		endpoint := strings.TrimSpace(node.GetEndpoint())
-		if _, seen := seenEndpoints[endpoint]; seen {
-			continue
-		}
-		seenEndpoints[endpoint] = struct{}{}
-		nodes = append(nodes, node)
-	}
-	if len(nodes) == 0 {
-		return "", fmt.Errorf("no nodes available for template alias resolution")
-	}
-
-	type result struct {
-		canonicalID string
-		err         error
-	}
-	lookupCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	concurrency := s.templateAliasLookupConcurrency
-	if concurrency <= 0 {
-		concurrency = defaultTemplateAliasLookupConcurrency
-	}
-	if concurrency > len(nodes) {
-		concurrency = len(nodes)
-	}
-	results := make(chan result, concurrency)
-	nextNode := make(chan *schedulerv1.Node)
-	var workers sync.WaitGroup
-	workers.Add(concurrency)
-	for range concurrency {
-		go func() {
-			defer workers.Done()
-			for {
-				var node *schedulerv1.Node
-				var ok bool
-				select {
-				case node, ok = <-nextNode:
-					if !ok {
-						return
-					}
-				case <-lookupCtx.Done():
-					return
-				}
-
-				canonicalID, err := s.resolveTemplateAliasOnNode(lookupCtx, incoming, node, alias)
-				select {
-				case results <- result{canonicalID: canonicalID, err: err}:
-				case <-lookupCtx.Done():
-					return
-				}
-			}
-		}()
-	}
-	go func() {
-		defer close(nextNode)
-		for _, node := range nodes {
-			select {
-			case nextNode <- node:
-			case <-lookupCtx.Done():
-				return
-			}
-		}
-	}()
-	go func() {
-		workers.Wait()
-		close(results)
-	}()
-
-	var firstErr error
-	for resolved := range results {
-		if resolved.err == nil {
-			cancel()
-			return resolved.canonicalID, nil
-		}
-		if firstErr == nil {
-			firstErr = resolved.err
-		}
-	}
-	if firstErr == nil {
-		firstErr = lookupCtx.Err()
-	}
-	if firstErr == nil {
-		firstErr = fmt.Errorf("template alias resolution produced no result")
-	}
-	return "", firstErr
-}
-
-func (s *Server) resolveTemplateAliasOnNode(
-	ctx context.Context,
-	incoming *http.Request,
-	node *schedulerv1.Node,
-	alias string,
-) (string, error) {
-	if !isSnapshotAlias(alias) {
-		return "", fmt.Errorf("invalid template alias %q", alias)
-	}
-	path := "/templates/aliases/" + alias
-	target, err := joinUpstream(strings.TrimSpace(node.GetEndpoint()), path, path, "")
-	if err != nil {
-		return "", fmt.Errorf("build template alias lookup URL: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
-	if err != nil {
-		return "", fmt.Errorf("build template alias lookup request: %w", err)
-	}
-	if incoming != nil {
-		req.Header = incoming.Header.Clone()
-		req.Host = incoming.Host
-		injectForwardedHeaders(req.Header, incoming)
-	}
-	req.Header.Del("Content-Length")
-
-	client := s.templateAliasHTTPClient
-	if client == nil {
-		client = s.httpClient
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("query template alias on node %s: %w", node.GetNodeId(), err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return "", fmt.Errorf("node %s returned status %d for template alias", node.GetNodeId(), resp.StatusCode)
-	}
-
-	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxTemplateAliasResponseBytes+1))
-	if err != nil {
-		return "", fmt.Errorf("read template alias response from node %s: %w", node.GetNodeId(), err)
-	}
-	if len(payload) > maxTemplateAliasResponseBytes {
-		return "", fmt.Errorf("template alias response from node %s exceeds size limit", node.GetNodeId())
-	}
-	var body templateAliasResponse
-	if err := json.Unmarshal(payload, &body); err != nil {
-		return "", fmt.Errorf("decode template alias response from node %s: %w", node.GetNodeId(), err)
-	}
-	canonicalID, ok := canonicalSnapshotID(body.TemplateID)
-	if !ok {
-		return "", fmt.Errorf("node %s returned invalid canonical template ID %q", node.GetNodeId(), body.TemplateID)
-	}
-	return canonicalID, nil
 }

--- a/services/gateway/internal/template_resolution.go
+++ b/services/gateway/internal/template_resolution.go
@@ -14,6 +14,13 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	defaultTemplateAliasHTTPTimeout       = 2 * time.Second
+	defaultTemplateAliasLookupTimeout     = 2 * time.Second
+	defaultTemplateAliasScheduleReserve   = 5 * time.Second
+	defaultTemplateAliasLookupConcurrency = 8
+)
+
 type templateAliasResponse struct {
 	TemplateID string `json:"templateID"`
 }
@@ -41,7 +48,13 @@ func (s *Server) resolveSnapshotLocalityHint(
 		}
 
 		var err error
-		canonicalID, err = s.resolveTemplateAlias(ctx, incoming, templateID)
+		lookupCtx, cancel, ok := s.templateAliasLookupContext(ctx)
+		if !ok {
+			hint.LocalityRequirements = nil
+			return hint
+		}
+		canonicalID, err = s.resolveTemplateAlias(lookupCtx, incoming, templateID)
+		cancel()
 		if err != nil {
 			s.logger.Debug("snapshot alias locality resolution unavailable",
 				zap.String("template_id", templateID),
@@ -54,6 +67,33 @@ func (s *Server) resolveSnapshotLocalityHint(
 
 	hint.LocalityRequirements = snapshotLocalityRequirements(canonicalID)
 	return hint
+}
+
+func (s *Server) templateAliasLookupContext(parent context.Context) (context.Context, context.CancelFunc, bool) {
+	lookupTimeout := s.templateAliasLookupTimeout
+	if lookupTimeout <= 0 {
+		lookupTimeout = defaultTemplateAliasLookupTimeout
+	}
+
+	reserve := s.templateAliasScheduleReserve
+	if reserve < 0 {
+		reserve = 0
+	}
+	if deadline, ok := parent.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining <= reserve {
+			return nil, func() {}, false
+		}
+		if available := remaining - reserve; lookupTimeout > available {
+			lookupTimeout = available
+		}
+	}
+	if lookupTimeout <= 0 {
+		return nil, func() {}, false
+	}
+
+	lookupCtx, cancel := context.WithTimeout(parent, lookupTimeout)
+	return lookupCtx, cancel, true
 }
 
 func canonicalSnapshotID(value string) (string, bool) {
@@ -116,10 +156,26 @@ func (s *Server) resolveTemplateAlias(
 	results := make(chan result, len(nodes))
 	lookupCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	concurrency := s.templateAliasLookupConcurrency
+	if concurrency <= 0 {
+		concurrency = defaultTemplateAliasLookupConcurrency
+	}
+	if concurrency > len(nodes) {
+		concurrency = len(nodes)
+	}
+	semaphore := make(chan struct{}, concurrency)
 
 	for _, node := range nodes {
 		node := node
 		go func() {
+			select {
+			case semaphore <- struct{}{}:
+				defer func() { <-semaphore }()
+			case <-lookupCtx.Done():
+				results <- result{err: lookupCtx.Err()}
+				return
+			}
+
 			canonicalID, err := s.resolveTemplateAliasOnNode(lookupCtx, incoming, node, alias)
 			results <- result{canonicalID: canonicalID, err: err}
 		}()
@@ -165,7 +221,11 @@ func (s *Server) resolveTemplateAliasOnNode(
 	}
 	req.Header.Del("Content-Length")
 
-	resp, err := s.httpClient.Do(req)
+	client := s.templateAliasHTTPClient
+	if client == nil {
+		client = s.httpClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("query template alias on node %s: %w", node.GetNodeId(), err)
 	}

--- a/services/gateway/internal/template_resolution.go
+++ b/services/gateway/internal/template_resolution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -20,6 +21,7 @@ const (
 	defaultTemplateAliasLookupTimeout     = 2 * time.Second
 	defaultTemplateAliasScheduleReserve   = 5 * time.Second
 	defaultTemplateAliasLookupConcurrency = 8
+	maxTemplateAliasResponseBytes         = 4 * 1024
 	// Alias resolution is advisory, so cap concurrent cluster fan-outs globally
 	// and skip locality when the gateway is already at capacity.
 	defaultTemplateAliasResolutionConcurrency = 8
@@ -288,8 +290,15 @@ func (s *Server) resolveTemplateAliasOnNode(
 		return "", fmt.Errorf("node %s returned status %d for template alias", node.GetNodeId(), resp.StatusCode)
 	}
 
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxTemplateAliasResponseBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read template alias response from node %s: %w", node.GetNodeId(), err)
+	}
+	if len(payload) > maxTemplateAliasResponseBytes {
+		return "", fmt.Errorf("template alias response from node %s exceeds size limit", node.GetNodeId())
+	}
 	var body templateAliasResponse
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.Unmarshal(payload, &body); err != nil {
 		return "", fmt.Errorf("decode template alias response from node %s: %w", node.GetNodeId(), err)
 	}
 	canonicalID, ok := canonicalSnapshotID(body.TemplateID)

--- a/services/gateway/internal/template_resolution.go
+++ b/services/gateway/internal/template_resolution.go
@@ -1,0 +1,187 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	schedulerv1 "agentenv/services/api/proto"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+type templateAliasResponse struct {
+	TemplateID string `json:"templateID"`
+}
+
+// resolveSnapshotLocalityHint replaces the request's template alias with the
+// canonical snapshot ID before deriving fixed snapshot artifact keys. Alias
+// resolution is best-effort: locality is only a placement preference, so a
+// resolver failure must not prevent the normal sandbox request from being
+// scheduled.
+func (s *Server) resolveSnapshotLocalityHint(
+	ctx context.Context,
+	incoming *http.Request,
+	hint *schedulerv1.ScheduleRequestHint,
+) *schedulerv1.ScheduleRequestHint {
+	if hint == nil || hint.GetNewSandbox() == nil {
+		return hint
+	}
+
+	templateID := strings.TrimSpace(hint.GetNewSandbox().GetTemplateId())
+	canonicalID, ok := canonicalSnapshotID(templateID)
+	if !ok {
+		if !isSnapshotAlias(templateID) {
+			hint.LocalityRequirements = nil
+			return hint
+		}
+
+		var err error
+		canonicalID, err = s.resolveTemplateAlias(ctx, incoming, templateID)
+		if err != nil {
+			s.logger.Debug("snapshot alias locality resolution unavailable",
+				zap.String("template_id", templateID),
+				zap.Error(err),
+			)
+			hint.LocalityRequirements = nil
+			return hint
+		}
+	}
+
+	hint.LocalityRequirements = snapshotLocalityRequirements(canonicalID)
+	return hint
+}
+
+func canonicalSnapshotID(value string) (string, bool) {
+	parsed, err := uuid.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return "", false
+	}
+	return parsed.String(), true
+}
+
+func isSnapshotAlias(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if !(char == '-' ||
+			char == '_' ||
+			(char >= '0' && char <= '9') ||
+			(char >= 'a' && char <= 'z') ||
+			(char >= 'A' && char <= 'Z')) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Server) resolveTemplateAlias(
+	ctx context.Context,
+	incoming *http.Request,
+	alias string,
+) (string, error) {
+	rpcStart := time.Now()
+	resp, err := s.scheduler.ListNodes(ctx, &schedulerv1.ListNodesRequest{})
+	recordGatewaySchedulerRPC("ListNodes", rpcStart, err)
+	if err != nil {
+		return "", fmt.Errorf("list nodes for template alias resolution: %w", err)
+	}
+
+	nodes := make([]*schedulerv1.Node, 0, len(resp.GetNodes()))
+	seenEndpoints := make(map[string]struct{}, len(resp.GetNodes()))
+	for _, node := range resp.GetNodes() {
+		if node == nil || strings.TrimSpace(node.GetEndpoint()) == "" {
+			continue
+		}
+		endpoint := strings.TrimSpace(node.GetEndpoint())
+		if _, seen := seenEndpoints[endpoint]; seen {
+			continue
+		}
+		seenEndpoints[endpoint] = struct{}{}
+		nodes = append(nodes, node)
+	}
+	if len(nodes) == 0 {
+		return "", fmt.Errorf("no nodes available for template alias resolution")
+	}
+
+	type result struct {
+		canonicalID string
+		err         error
+	}
+	results := make(chan result, len(nodes))
+	lookupCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, node := range nodes {
+		node := node
+		go func() {
+			canonicalID, err := s.resolveTemplateAliasOnNode(lookupCtx, incoming, node, alias)
+			results <- result{canonicalID: canonicalID, err: err}
+		}()
+	}
+
+	var firstErr error
+	for range nodes {
+		resolved := <-results
+		if resolved.err == nil {
+			cancel()
+			return resolved.canonicalID, nil
+		}
+		if firstErr == nil {
+			firstErr = resolved.err
+		}
+	}
+	return "", firstErr
+}
+
+func (s *Server) resolveTemplateAliasOnNode(
+	ctx context.Context,
+	incoming *http.Request,
+	node *schedulerv1.Node,
+	alias string,
+) (string, error) {
+	if !isSnapshotAlias(alias) {
+		return "", fmt.Errorf("invalid template alias %q", alias)
+	}
+	path := "/templates/aliases/" + alias
+	target, err := joinUpstream(strings.TrimSpace(node.GetEndpoint()), path, path, "")
+	if err != nil {
+		return "", fmt.Errorf("build template alias lookup URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return "", fmt.Errorf("build template alias lookup request: %w", err)
+	}
+	if incoming != nil {
+		req.Header = incoming.Header.Clone()
+		req.Host = incoming.Host
+		injectForwardedHeaders(req.Header, incoming)
+	}
+	req.Header.Del("Content-Length")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("query template alias on node %s: %w", node.GetNodeId(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("node %s returned status %d for template alias", node.GetNodeId(), resp.StatusCode)
+	}
+
+	var body templateAliasResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode template alias response from node %s: %w", node.GetNodeId(), err)
+	}
+	canonicalID, ok := canonicalSnapshotID(body.TemplateID)
+	if !ok {
+		return "", fmt.Errorf("node %s returned invalid canonical template ID %q", node.GetNodeId(), body.TemplateID)
+	}
+	return canonicalID, nil
+}

--- a/services/gateway/internal/template_resolution_test.go
+++ b/services/gateway/internal/template_resolution_test.go
@@ -1,0 +1,91 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	schedulerv1 "agentenv/services/api/proto"
+	"google.golang.org/grpc"
+)
+
+func TestResolveSnapshotLocalityHintResolvesTemplateAlias(t *testing.T) {
+	const canonicalID = "550e8400-e29b-41d4-a716-446655440000"
+
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/templates/aliases/warm-template" {
+			t.Fatalf("unexpected alias lookup: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"templateID": canonicalID,
+			"public":     false,
+		})
+	}))
+	defer node.Close()
+
+	server := newTestServer(t, stubSchedulerClient{
+		listNodesFunc: func(_ context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
+			return &schedulerv1.ListNodesResponse{Nodes: []*schedulerv1.Node{{
+				NodeId:   "node-a",
+				Endpoint: node.URL,
+			}}}, nil
+		},
+	}, 0, 1024)
+
+	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"warm-template"}`)
+	hint, err := buildScheduleHint(request)
+	if err != nil {
+		t.Fatalf("buildScheduleHint returned error: %v", err)
+	}
+	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
+
+	want := []string{
+		"snapshot/v1/artifacts/" + canonicalID + "/vm_state.bin",
+		"snapshot/v1/artifacts/" + canonicalID + "/firecracker-manifest.json",
+	}
+	if got := localityRequirementKeys(hint.GetLocalityRequirements()); !equalStrings(got, want) {
+		t.Fatalf("locality requirements = %v, want %v", got, want)
+	}
+}
+
+func TestResolveSnapshotLocalityHintNormalizesCanonicalID(t *testing.T) {
+	server := newTestServer(t, stubSchedulerClient{}, 0, 1024)
+	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"550E8400-E29B-41D4-A716-446655440000"}`)
+	hint, err := buildScheduleHint(request)
+	if err != nil {
+		t.Fatalf("buildScheduleHint returned error: %v", err)
+	}
+	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
+
+	keys := localityRequirementKeys(hint.GetLocalityRequirements())
+	if len(keys) != 2 || keys[0] != "snapshot/v1/artifacts/550e8400-e29b-41d4-a716-446655440000/vm_state.bin" {
+		t.Fatalf("unexpected normalized locality requirements: %v", keys)
+	}
+}
+
+func TestResolveSnapshotLocalityHintDropsUnresolvedAlias(t *testing.T) {
+	node := httptest.NewServer(http.NotFoundHandler())
+	defer node.Close()
+
+	server := newTestServer(t, stubSchedulerClient{
+		listNodesFunc: func(_ context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
+			return &schedulerv1.ListNodesResponse{Nodes: []*schedulerv1.Node{{
+				NodeId:   "node-a",
+				Endpoint: node.URL,
+			}}}, nil
+		},
+	}, 0, 1024)
+
+	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"missing-template"}`)
+	hint, err := buildScheduleHint(request)
+	if err != nil {
+		t.Fatalf("buildScheduleHint returned error: %v", err)
+	}
+	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
+	if got := hint.GetLocalityRequirements(); len(got) != 0 {
+		t.Fatalf("unresolved alias produced locality requirements: %v", got)
+	}
+}

--- a/services/gateway/internal/template_resolution_test.go
+++ b/services/gateway/internal/template_resolution_test.go
@@ -71,6 +71,24 @@ func TestResolveSnapshotLocalityHintNormalizesCanonicalID(t *testing.T) {
 	}
 }
 
+func TestResolveTemplateAliasRejectsOversizedResponse(t *testing.T) {
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"templateID":"`+strings.Repeat("a", maxTemplateAliasResponseBytes)+`"}`)
+	}))
+	defer node.Close()
+
+	server := newTestServer(t, stubSchedulerClient{}, 0, 1024)
+	_, err := server.resolveTemplateAliasOnNode(
+		context.Background(),
+		nil,
+		&schedulerv1.Node{NodeId: "node-a", Endpoint: node.URL},
+		"warm-template",
+	)
+	if err == nil || !strings.Contains(err.Error(), "exceeds size limit") {
+		t.Fatalf("oversized alias response error = %v, want size-limit error", err)
+	}
+}
+
 func TestResolveSnapshotLocalityHintDropsUnresolvedAlias(t *testing.T) {
 	node := httptest.NewServer(http.NotFoundHandler())
 	defer node.Close()

--- a/services/gateway/internal/template_resolution_test.go
+++ b/services/gateway/internal/template_resolution_test.go
@@ -2,13 +2,11 @@ package gateway
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,175 +14,58 @@ import (
 	"google.golang.org/grpc"
 )
 
-func TestResolveSnapshotLocalityHintResolvesTemplateAlias(t *testing.T) {
-	const canonicalID = "550e8400-e29b-41d4-a716-446655440000"
-
-	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet || r.URL.Path != "/templates/aliases/warm-template" {
-			t.Fatalf("unexpected alias lookup: %s %s", r.Method, r.URL.Path)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"templateID": canonicalID,
-			"public":     false,
-		})
-	}))
-	defer node.Close()
-
-	server := newTestServer(t, stubSchedulerClient{
-		listNodesFunc: func(_ context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
-			return &schedulerv1.ListNodesResponse{Nodes: []*schedulerv1.Node{{
-				NodeId:   "node-a",
-				Endpoint: node.URL,
-			}}}, nil
-		},
-	}, 0, 1024)
-
-	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"warm-template"}`)
+func TestResolveSnapshotLocalityHintNormalizesCanonicalID(t *testing.T) {
+	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"550E8400-E29B-41D4-A716-446655440000"}`)
 	hint, err := buildScheduleHint(request)
 	if err != nil {
 		t.Fatalf("buildScheduleHint returned error: %v", err)
 	}
-	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
+	hint = resolveSnapshotLocalityHint(hint)
 
 	want := []string{
-		"snapshot/v1/artifacts/" + canonicalID + "/vm_state.bin",
-		"snapshot/v1/artifacts/" + canonicalID + "/firecracker-manifest.json",
+		"snapshot/v1/artifacts/550e8400-e29b-41d4-a716-446655440000/vm_state.bin",
+		"snapshot/v1/artifacts/550e8400-e29b-41d4-a716-446655440000/firecracker-manifest.json",
 	}
 	if got := localityRequirementKeys(hint.GetLocalityRequirements()); !equalStrings(got, want) {
 		t.Fatalf("locality requirements = %v, want %v", got, want)
 	}
 }
 
-func TestResolveSnapshotLocalityHintNormalizesCanonicalID(t *testing.T) {
-	server := newTestServer(t, stubSchedulerClient{}, 0, 1024)
-	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"550E8400-E29B-41D4-A716-446655440000"}`)
-	hint, err := buildScheduleHint(request)
-	if err != nil {
-		t.Fatalf("buildScheduleHint returned error: %v", err)
-	}
-	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
-
-	keys := localityRequirementKeys(hint.GetLocalityRequirements())
-	if len(keys) != 2 || keys[0] != "snapshot/v1/artifacts/550e8400-e29b-41d4-a716-446655440000/vm_state.bin" {
-		t.Fatalf("unexpected normalized locality requirements: %v", keys)
-	}
-}
-
-func TestResolveTemplateAliasRejectsOversizedResponse(t *testing.T) {
-	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = io.WriteString(w, `{"templateID":"`+strings.Repeat("a", maxTemplateAliasResponseBytes)+`"}`)
-	}))
-	defer node.Close()
-
-	server := newTestServer(t, stubSchedulerClient{}, 0, 1024)
-	_, err := server.resolveTemplateAliasOnNode(
-		context.Background(),
-		nil,
-		&schedulerv1.Node{NodeId: "node-a", Endpoint: node.URL},
+func TestResolveSnapshotLocalityHintSkipsAliases(t *testing.T) {
+	for _, templateID := range []string{
 		"warm-template",
-	)
-	if err == nil || !strings.Contains(err.Error(), "exceeds size limit") {
-		t.Fatalf("oversized alias response error = %v, want size-limit error", err)
+		"550e8400e29b41d4a716446655440000",
+		"550e8400-e29b-41d4-a716-44665544000z",
+	} {
+		t.Run(templateID, func(t *testing.T) {
+			request := newHintRequest(t, http.MethodPost, "/sandboxes", fmt.Sprintf(`{"templateID":%q}`, templateID))
+			hint, err := buildScheduleHint(request)
+			if err != nil {
+				t.Fatalf("buildScheduleHint returned error: %v", err)
+			}
+			hint = resolveSnapshotLocalityHint(hint)
+			if got := len(hint.GetLocalityRequirements()); got != 0 {
+				t.Fatalf("alias %q produced %d locality requirements", templateID, got)
+			}
+		})
 	}
 }
 
-func TestResolveSnapshotLocalityHintDropsUnresolvedAlias(t *testing.T) {
-	node := httptest.NewServer(http.NotFoundHandler())
-	defer node.Close()
-
-	server := newTestServer(t, stubSchedulerClient{
-		listNodesFunc: func(_ context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
-			return &schedulerv1.ListNodesResponse{Nodes: []*schedulerv1.Node{{
-				NodeId:   "node-a",
-				Endpoint: node.URL,
-			}}}, nil
-		},
-	}, 0, 1024)
-
-	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"missing-template"}`)
-	hint, err := buildScheduleHint(request)
-	if err != nil {
-		t.Fatalf("buildScheduleHint returned error: %v", err)
-	}
-	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
-	if got := hint.GetLocalityRequirements(); len(got) != 0 {
-		t.Fatalf("unresolved alias produced locality requirements: %v", got)
-	}
-}
-
-func TestResolveSnapshotLocalityHintSkipsWhenGlobalResolutionBusy(t *testing.T) {
-	var listNodesCalls atomic.Int32
-	server := newTestServer(t, stubSchedulerClient{
-		listNodesFunc: func(_ context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
-			listNodesCalls.Add(1)
-			return nil, fmt.Errorf("unexpected ListNodes call")
-		},
-	}, 0, 1024)
-	server.templateAliasResolutionSlots = make(chan struct{}, 1)
-	server.templateAliasResolutionSlots <- struct{}{}
-	defer func() { <-server.templateAliasResolutionSlots }()
-
-	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"busy-template"}`)
-	hint, err := buildScheduleHint(request)
-	if err != nil {
-		t.Fatalf("buildScheduleHint returned error: %v", err)
-	}
-	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
-
-	if got := len(hint.GetLocalityRequirements()); got != 0 {
-		t.Fatalf("busy resolver produced locality requirements: %d", got)
-	}
-	if got := listNodesCalls.Load(); got != 0 {
-		t.Fatalf("ListNodes calls = %d, want 0 while global resolver is busy", got)
-	}
-}
-
-func TestHandleProxyContinuesSchedulingAfterTemplateAliasLookupTimeout(t *testing.T) {
-	lookupStarted := make(chan struct{})
-	aliasNode := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		close(lookupStarted)
-		<-r.Context().Done()
-	}))
-	defer aliasNode.Close()
-
+func TestHandleProxyAliasDoesNotFanOut(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"sandboxID":"sbx-created"}`))
+		_, _ = io.WriteString(w, `{"sandboxID":"sbx-created"}`)
 	}))
 	defer upstream.Close()
 
-	type scheduleObservation struct {
-		ctxErr        error
-		remaining     time.Duration
-		hasDeadline   bool
-		localityCount int
-	}
-	scheduled := make(chan scheduleObservation, 1)
 	server := newTestServer(t, stubSchedulerClient{
-		listNodesFunc: func(ctx context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
-			if err := ctx.Err(); err != nil {
-				return nil, err
-			}
-			return &schedulerv1.ListNodesResponse{Nodes: []*schedulerv1.Node{{
-				NodeId:   "alias-node",
-				Endpoint: aliasNode.URL,
-			}}}, nil
-		},
-		scheduleFunc: func(ctx context.Context, req *schedulerv1.ScheduleRequest, _ ...grpc.CallOption) (*schedulerv1.ScheduleResponse, error) {
-			deadline, hasDeadline := ctx.Deadline()
-			scheduled <- scheduleObservation{
-				ctxErr:        ctx.Err(),
-				remaining:     time.Until(deadline),
-				hasDeadline:   hasDeadline,
-				localityCount: len(req.GetHint().GetLocalityRequirements()),
-			}
-			if err := ctx.Err(); err != nil {
-				return nil, err
+		scheduleFunc: func(_ context.Context, req *schedulerv1.ScheduleRequest, _ ...grpc.CallOption) (*schedulerv1.ScheduleResponse, error) {
+			if got := len(req.GetHint().GetLocalityRequirements()); got != 0 {
+				return nil, fmt.Errorf("alias produced %d locality requirements", got)
 			}
 			return &schedulerv1.ScheduleResponse{Node: &schedulerv1.Node{
-				NodeId:   "node-1",
+				NodeId:   "node-a",
 				Endpoint: upstream.URL,
 			}}, nil
 		},
@@ -192,17 +73,15 @@ func TestHandleProxyContinuesSchedulingAfterTemplateAliasLookupTimeout(t *testin
 			return &schedulerv1.RecordAssignmentResponse{}, nil
 		},
 	}, time.Second, 1024)
-	server.templateAliasLookupTimeout = 50 * time.Millisecond
-	server.templateAliasScheduleReserve = 20 * time.Millisecond
 
 	gateway := httptest.NewServer(server.Handler())
 	defer gateway.Close()
 
-	req, err := http.NewRequest(http.MethodPost, gateway.URL+"/sandboxes", strings.NewReader(`{"templateID":"hanging-template"}`))
-	if err != nil {
-		t.Fatalf("build request failed: %v", err)
-	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.Post(
+		gateway.URL+"/sandboxes",
+		"application/json",
+		strings.NewReader(`{"templateID":"warm-template"}`),
+	)
 	if err != nil {
 		t.Fatalf("gateway request failed: %v", err)
 	}
@@ -210,79 +89,7 @@ func TestHandleProxyContinuesSchedulingAfterTemplateAliasLookupTimeout(t *testin
 	if _, err := io.ReadAll(resp.Body); err != nil {
 		t.Fatalf("read gateway response failed: %v", err)
 	}
-
-	select {
-	case <-lookupStarted:
-	default:
-		t.Fatal("template alias lookup did not reach the hanging node")
-	}
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusCreated)
-	}
-
-	observation := <-scheduled
-	if observation.localityCount != 0 {
-		t.Fatalf("locality requirements = %d, want 0 after lookup timeout", observation.localityCount)
-	}
-	if err := observation.ctxErr; err != nil {
-		t.Fatalf("schedule context already canceled: %v", err)
-	}
-	if !observation.hasDeadline || observation.remaining <= server.templateAliasScheduleReserve {
-		t.Fatalf("schedule context did not retain a useful deadline: %s", observation.remaining)
-	}
-}
-
-func TestResolveTemplateAliasBoundsConcurrentNodeLookups(t *testing.T) {
-	const (
-		nodeCount   = 5
-		concurrency = 2
-	)
-
-	var active atomic.Int32
-	var maxActive atomic.Int32
-	servers := make([]*httptest.Server, 0, nodeCount)
-	nodes := make([]*schedulerv1.Node, 0, nodeCount)
-	for i := 0; i < nodeCount; i++ {
-		nodeID := fmt.Sprintf("node-%d", i)
-		node := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-			current := active.Add(1)
-			for {
-				previous := maxActive.Load()
-				if current <= previous || maxActive.CompareAndSwap(previous, current) {
-					break
-				}
-			}
-			defer active.Add(-1)
-			<-r.Context().Done()
-		}))
-		servers = append(servers, node)
-		nodes = append(nodes, &schedulerv1.Node{NodeId: nodeID, Endpoint: node.URL})
-	}
-	defer func() {
-		for _, node := range servers {
-			node.Close()
-		}
-	}()
-
-	server := newTestServer(t, stubSchedulerClient{
-		listNodesFunc: func(_ context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
-			return &schedulerv1.ListNodesResponse{Nodes: nodes}, nil
-		},
-	}, 0, 1024)
-	server.templateAliasLookupTimeout = 50 * time.Millisecond
-	server.templateAliasLookupConcurrency = concurrency
-
-	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"slow-template"}`)
-	hint, err := buildScheduleHint(request)
-	if err != nil {
-		t.Fatalf("buildScheduleHint returned error: %v", err)
-	}
-	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
-
-	if got := len(hint.GetLocalityRequirements()); got != 0 {
-		t.Fatalf("timed-out alias produced locality requirements: %d", got)
-	}
-	if got := maxActive.Load(); got == 0 || got > concurrency {
-		t.Fatalf("maximum concurrent alias lookups = %d, want between 1 and %d", got, concurrency)
 	}
 }

--- a/services/gateway/internal/template_resolution_test.go
+++ b/services/gateway/internal/template_resolution_test.go
@@ -95,6 +95,33 @@ func TestResolveSnapshotLocalityHintDropsUnresolvedAlias(t *testing.T) {
 	}
 }
 
+func TestResolveSnapshotLocalityHintSkipsWhenGlobalResolutionBusy(t *testing.T) {
+	var listNodesCalls atomic.Int32
+	server := newTestServer(t, stubSchedulerClient{
+		listNodesFunc: func(_ context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
+			listNodesCalls.Add(1)
+			return nil, fmt.Errorf("unexpected ListNodes call")
+		},
+	}, 0, 1024)
+	server.templateAliasResolutionSlots = make(chan struct{}, 1)
+	server.templateAliasResolutionSlots <- struct{}{}
+	defer func() { <-server.templateAliasResolutionSlots }()
+
+	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"busy-template"}`)
+	hint, err := buildScheduleHint(request)
+	if err != nil {
+		t.Fatalf("buildScheduleHint returned error: %v", err)
+	}
+	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
+
+	if got := len(hint.GetLocalityRequirements()); got != 0 {
+		t.Fatalf("busy resolver produced locality requirements: %d", got)
+	}
+	if got := listNodesCalls.Load(); got != 0 {
+		t.Fatalf("ListNodes calls = %d, want 0 while global resolver is busy", got)
+	}
+}
+
 func TestHandleProxyContinuesSchedulingAfterTemplateAliasLookupTimeout(t *testing.T) {
 	lookupStarted := make(chan struct{})
 	aliasNode := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {

--- a/services/gateway/internal/template_resolution_test.go
+++ b/services/gateway/internal/template_resolution_test.go
@@ -3,9 +3,14 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	schedulerv1 "agentenv/services/api/proto"
 	"google.golang.org/grpc"
@@ -87,5 +92,152 @@ func TestResolveSnapshotLocalityHintDropsUnresolvedAlias(t *testing.T) {
 	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
 	if got := hint.GetLocalityRequirements(); len(got) != 0 {
 		t.Fatalf("unresolved alias produced locality requirements: %v", got)
+	}
+}
+
+func TestHandleProxyContinuesSchedulingAfterTemplateAliasLookupTimeout(t *testing.T) {
+	lookupStarted := make(chan struct{})
+	aliasNode := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(lookupStarted)
+		<-r.Context().Done()
+	}))
+	defer aliasNode.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"sandboxID":"sbx-created"}`))
+	}))
+	defer upstream.Close()
+
+	type scheduleObservation struct {
+		ctxErr        error
+		remaining     time.Duration
+		hasDeadline   bool
+		localityCount int
+	}
+	scheduled := make(chan scheduleObservation, 1)
+	server := newTestServer(t, stubSchedulerClient{
+		listNodesFunc: func(ctx context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return &schedulerv1.ListNodesResponse{Nodes: []*schedulerv1.Node{{
+				NodeId:   "alias-node",
+				Endpoint: aliasNode.URL,
+			}}}, nil
+		},
+		scheduleFunc: func(ctx context.Context, req *schedulerv1.ScheduleRequest, _ ...grpc.CallOption) (*schedulerv1.ScheduleResponse, error) {
+			deadline, hasDeadline := ctx.Deadline()
+			scheduled <- scheduleObservation{
+				ctxErr:        ctx.Err(),
+				remaining:     time.Until(deadline),
+				hasDeadline:   hasDeadline,
+				localityCount: len(req.GetHint().GetLocalityRequirements()),
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return &schedulerv1.ScheduleResponse{Node: &schedulerv1.Node{
+				NodeId:   "node-1",
+				Endpoint: upstream.URL,
+			}}, nil
+		},
+		recordAssignmentFunc: func(_ context.Context, _ *schedulerv1.RecordAssignmentRequest, _ ...grpc.CallOption) (*schedulerv1.RecordAssignmentResponse, error) {
+			return &schedulerv1.RecordAssignmentResponse{}, nil
+		},
+	}, time.Second, 1024)
+	server.templateAliasLookupTimeout = 50 * time.Millisecond
+	server.templateAliasScheduleReserve = 20 * time.Millisecond
+
+	gateway := httptest.NewServer(server.Handler())
+	defer gateway.Close()
+
+	req, err := http.NewRequest(http.MethodPost, gateway.URL+"/sandboxes", strings.NewReader(`{"templateID":"hanging-template"}`))
+	if err != nil {
+		t.Fatalf("build request failed: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("gateway request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("read gateway response failed: %v", err)
+	}
+
+	select {
+	case <-lookupStarted:
+	default:
+		t.Fatal("template alias lookup did not reach the hanging node")
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	observation := <-scheduled
+	if observation.localityCount != 0 {
+		t.Fatalf("locality requirements = %d, want 0 after lookup timeout", observation.localityCount)
+	}
+	if err := observation.ctxErr; err != nil {
+		t.Fatalf("schedule context already canceled: %v", err)
+	}
+	if !observation.hasDeadline || observation.remaining <= server.templateAliasScheduleReserve {
+		t.Fatalf("schedule context did not retain a useful deadline: %s", observation.remaining)
+	}
+}
+
+func TestResolveTemplateAliasBoundsConcurrentNodeLookups(t *testing.T) {
+	const (
+		nodeCount   = 5
+		concurrency = 2
+	)
+
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	servers := make([]*httptest.Server, 0, nodeCount)
+	nodes := make([]*schedulerv1.Node, 0, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		nodeID := fmt.Sprintf("node-%d", i)
+		node := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			current := active.Add(1)
+			for {
+				previous := maxActive.Load()
+				if current <= previous || maxActive.CompareAndSwap(previous, current) {
+					break
+				}
+			}
+			defer active.Add(-1)
+			<-r.Context().Done()
+		}))
+		servers = append(servers, node)
+		nodes = append(nodes, &schedulerv1.Node{NodeId: nodeID, Endpoint: node.URL})
+	}
+	defer func() {
+		for _, node := range servers {
+			node.Close()
+		}
+	}()
+
+	server := newTestServer(t, stubSchedulerClient{
+		listNodesFunc: func(_ context.Context, _ *schedulerv1.ListNodesRequest, _ ...grpc.CallOption) (*schedulerv1.ListNodesResponse, error) {
+			return &schedulerv1.ListNodesResponse{Nodes: nodes}, nil
+		},
+	}, 0, 1024)
+	server.templateAliasLookupTimeout = 50 * time.Millisecond
+	server.templateAliasLookupConcurrency = concurrency
+
+	request := newHintRequest(t, http.MethodPost, "/sandboxes", `{"templateID":"slow-template"}`)
+	hint, err := buildScheduleHint(request)
+	if err != nil {
+		t.Fatalf("buildScheduleHint returned error: %v", err)
+	}
+	hint = server.resolveSnapshotLocalityHint(context.Background(), request, hint)
+
+	if got := len(hint.GetLocalityRequirements()); got != 0 {
+		t.Fatalf("timed-out alias produced locality requirements: %d", got)
+	}
+	if got := maxActive.Load(); got == 0 || got > concurrency {
+		t.Fatalf("maximum concurrent alias lookups = %d, want between 1 and %d", got, concurrency)
 	}
 }

--- a/services/go.mod
+++ b/services/go.mod
@@ -3,6 +3,7 @@ module agentenv/services
 go 1.25.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/prometheus/client_golang v1.20.5
 	github.com/redis/go-redis/v9 v9.7.3
@@ -29,7 +30,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect

--- a/services/scheduler/internal/locality.go
+++ b/services/scheduler/internal/locality.go
@@ -29,12 +29,11 @@ func PreferLocalNodes(
 	providers ArtifactProviderLookup,
 ) ([]RichNode, LocalityPreferenceStats) {
 	stats := LocalityPreferenceStats{}
+	keys := deduplicateLocalityRequirementKeys(requirements)
+	stats.RequirementCount = len(keys)
 	if len(nodes) == 0 || providers == nil {
 		return nodes, stats
 	}
-
-	keys := deduplicateLocalityRequirementKeys(requirements)
-	stats.RequirementCount = len(keys)
 	if len(keys) == 0 {
 		return nodes, stats
 	}

--- a/services/scheduler/internal/locality.go
+++ b/services/scheduler/internal/locality.go
@@ -1,0 +1,102 @@
+package scheduler
+
+import (
+	"strings"
+
+	schedulerv1 "agentenv/services/api/proto"
+)
+
+type ArtifactProviderLookup interface {
+	LookupAll(clusterID string, backend string, key string) []string
+}
+
+type LocalityPreferenceStats struct {
+	RequirementCount  int
+	ProviderNodeCount int
+	MaxCoverage       int
+}
+
+type localityNamespace struct {
+	clusterID string
+	backend   string
+}
+
+// PreferLocalNodes keeps candidates tied for the highest positive artifact
+// coverage. With no usable locality information it preserves the input set.
+func PreferLocalNodes(
+	nodes []RichNode,
+	requirements []*schedulerv1.LocalityRequirement,
+	providers ArtifactProviderLookup,
+) ([]RichNode, LocalityPreferenceStats) {
+	stats := LocalityPreferenceStats{}
+	if len(nodes) == 0 || providers == nil {
+		return nodes, stats
+	}
+
+	keys := deduplicateLocalityRequirementKeys(requirements)
+	stats.RequirementCount = len(keys)
+	if len(keys) == 0 {
+		return nodes, stats
+	}
+
+	candidates := make(map[localityNamespace]map[string]struct{})
+	for _, node := range nodes {
+		namespace := localityNamespace{
+			clusterID: strings.TrimSpace(node.ClusterID),
+			backend:   strings.TrimSpace(node.P2pBackend),
+		}
+		if namespace.clusterID == "" || namespace.backend == "" {
+			continue
+		}
+		if candidates[namespace] == nil {
+			candidates[namespace] = make(map[string]struct{})
+		}
+		candidates[namespace][node.ID] = struct{}{}
+	}
+
+	scores := make(map[string]int)
+	providerNodes := make(map[string]struct{})
+	for namespace, namespaceCandidates := range candidates {
+		for _, key := range keys {
+			for _, nodeID := range providers.LookupAll(namespace.clusterID, namespace.backend, key) {
+				if _, eligible := namespaceCandidates[nodeID]; !eligible {
+					continue
+				}
+				scores[nodeID]++
+				providerNodes[nodeID] = struct{}{}
+				if scores[nodeID] > stats.MaxCoverage {
+					stats.MaxCoverage = scores[nodeID]
+				}
+			}
+		}
+	}
+	stats.ProviderNodeCount = len(providerNodes)
+
+	if stats.MaxCoverage == 0 {
+		return nodes, stats
+	}
+	preferred := make([]RichNode, 0, len(nodes))
+	for _, node := range nodes {
+		if scores[node.ID] == stats.MaxCoverage {
+			preferred = append(preferred, node)
+		}
+	}
+	return preferred, stats
+}
+
+func deduplicateLocalityRequirementKeys(requirements []*schedulerv1.LocalityRequirement) []string {
+	seen := make(map[string]struct{}, len(requirements))
+	keys := make([]string, 0, len(requirements))
+	for _, requirement := range requirements {
+		key := strings.TrimSpace(requirement.GetKey())
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/services/scheduler/internal/locality.go
+++ b/services/scheduler/internal/locality.go
@@ -58,7 +58,12 @@ func PreferLocalNodes(
 	providerNodes := make(map[string]struct{})
 	for namespace, namespaceCandidates := range candidates {
 		for _, key := range keys {
+			seenProviders := make(map[string]struct{})
 			for _, nodeID := range providers.LookupAll(namespace.clusterID, namespace.backend, key) {
+				if _, seen := seenProviders[nodeID]; seen {
+					continue
+				}
+				seenProviders[nodeID] = struct{}{}
 				if _, eligible := namespaceCandidates[nodeID]; !eligible {
 					continue
 				}

--- a/services/scheduler/internal/locality.go
+++ b/services/scheduler/internal/locality.go
@@ -7,7 +7,12 @@ import (
 )
 
 type ArtifactProviderLookup interface {
-	LookupAll(clusterID string, backend string, key string) []string
+	LookupEligible(
+		clusterID string,
+		backend string,
+		key string,
+		eligibleNodeIDs map[string]struct{},
+	) []string
 }
 
 type LocalityPreferenceStats struct {
@@ -58,7 +63,12 @@ func PreferLocalNodes(
 	for namespace, namespaceCandidates := range candidates {
 		for _, key := range keys {
 			seenProviders := make(map[string]struct{})
-			for _, nodeID := range providers.LookupAll(namespace.clusterID, namespace.backend, key) {
+			for _, nodeID := range providers.LookupEligible(
+				namespace.clusterID,
+				namespace.backend,
+				key,
+				namespaceCandidates,
+			) {
 				if _, seen := seenProviders[nodeID]; seen {
 					continue
 				}

--- a/services/scheduler/internal/locality_test.go
+++ b/services/scheduler/internal/locality_test.go
@@ -130,7 +130,12 @@ func TestPreferLocalNodesCountsRequirementsBeforeEarlyReturn(t *testing.T) {
 
 type duplicateArtifactProvider struct{}
 
-func (duplicateArtifactProvider) LookupAll(string, string, string) []string {
+func (duplicateArtifactProvider) LookupEligible(
+	string,
+	string,
+	string,
+	map[string]struct{},
+) []string {
 	return []string{"node-a", "node-a"}
 }
 

--- a/services/scheduler/internal/locality_test.go
+++ b/services/scheduler/internal/locality_test.go
@@ -117,6 +117,35 @@ func TestPreferLocalNodesSkipsCandidatesWithoutLocalityContext(t *testing.T) {
 	}
 }
 
+func TestPreferLocalNodesCountsRequirementsBeforeEarlyReturn(t *testing.T) {
+	_, stats := PreferLocalNodes(
+		nil,
+		localityTestRequirements("key-a", "key-a", "key-b"),
+		NewInMemoryArtifactStore(10, 0),
+	)
+	if stats.RequirementCount != 2 {
+		t.Fatalf("requirement count = %d, want 2", stats.RequirementCount)
+	}
+}
+
+type duplicateArtifactProvider struct{}
+
+func (duplicateArtifactProvider) LookupAll(string, string, string) []string {
+	return []string{"node-a", "node-a"}
+}
+
+func TestPreferLocalNodesDeduplicatesProviderNodeIDs(t *testing.T) {
+	preferred, stats := PreferLocalNodes(
+		localityTestNodes("cluster", "iroh", "node-a"),
+		localityTestRequirements("key-a"),
+		duplicateArtifactProvider{},
+	)
+	assertLocalityNodeIDs(t, preferred, "node-a")
+	if stats.MaxCoverage != 1 || stats.ProviderNodeCount != 1 {
+		t.Fatalf("unexpected duplicate provider stats: %+v", stats)
+	}
+}
+
 func localityTestNodes(clusterID, backend string, nodeIDs ...string) []RichNode {
 	nodes := make([]RichNode, 0, len(nodeIDs))
 	for _, nodeID := range nodeIDs {

--- a/services/scheduler/internal/locality_test.go
+++ b/services/scheduler/internal/locality_test.go
@@ -1,0 +1,150 @@
+package scheduler
+
+import (
+	"testing"
+
+	schedulerv1 "agentenv/services/api/proto"
+)
+
+func TestPreferLocalNodesSelectsHighestCoverage(t *testing.T) {
+	store := NewInMemoryArtifactStore(10, 1)
+	for _, key := range []string{"key-a", "key-b", "key-c"} {
+		store.Record("cluster", "iroh", key, "node-a")
+	}
+	for _, key := range []string{"key-a", "key-b"} {
+		store.Record("cluster", "iroh", key, "node-b")
+	}
+
+	preferred, stats := PreferLocalNodes(
+		localityTestNodes("cluster", "iroh", "node-a", "node-b"),
+		localityTestRequirements("key-a", "key-b", "key-c"),
+		store,
+	)
+	assertLocalityNodeIDs(t, preferred, "node-a")
+	if stats.RequirementCount != 3 || stats.ProviderNodeCount != 2 || stats.MaxCoverage != 3 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+}
+
+func TestPreferLocalNodesRetainsHighestCoverageTies(t *testing.T) {
+	store := NewInMemoryArtifactStore(10, 0)
+	for _, nodeID := range []string{"node-a", "node-b"} {
+		store.Record("cluster", "iroh", "key", nodeID)
+	}
+
+	preferred, _ := PreferLocalNodes(
+		localityTestNodes("cluster", "iroh", "node-a", "node-b", "node-c"),
+		localityTestRequirements("key"),
+		store,
+	)
+	assertLocalityNodeIDs(t, preferred, "node-a", "node-b")
+}
+
+func TestPreferLocalNodesPreservesCandidatesWithoutUsefulLocality(t *testing.T) {
+	tests := []struct {
+		name         string
+		requirements []*schedulerv1.LocalityRequirement
+		record       func(*InMemoryArtifactStore)
+	}{
+		{name: "no requirements"},
+		{name: "empty requirements", requirements: localityTestRequirements("", "  ")},
+		{name: "no inventory", requirements: localityTestRequirements("key")},
+		{
+			name:         "only non-candidate provider",
+			requirements: localityTestRequirements("key"),
+			record: func(store *InMemoryArtifactStore) {
+				store.Record("cluster", "iroh", "key", "removed-node")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := NewInMemoryArtifactStore(10, 0)
+			if test.record != nil {
+				test.record(store)
+			}
+			nodes := localityTestNodes("cluster", "iroh", "node-a", "node-b")
+			preferred, _ := PreferLocalNodes(nodes, test.requirements, store)
+			assertLocalityNodeIDs(t, preferred, "node-a", "node-b")
+		})
+	}
+}
+
+func TestPreferLocalNodesIsolatesClusterAndBackend(t *testing.T) {
+	store := NewInMemoryArtifactStore(10, 0)
+	store.Record("cluster-a", "iroh", "key", "node-a")
+	store.Record("cluster-b", "iroh", "key", "node-b")
+	store.Record("cluster-a", "other", "key", "node-c")
+
+	nodes := []RichNode{
+		{Node: Node{ID: "node-a"}, ClusterID: "cluster-a", P2pBackend: "iroh"},
+		{Node: Node{ID: "node-b"}, ClusterID: "cluster-a", P2pBackend: "iroh"},
+		{Node: Node{ID: "node-c"}, ClusterID: "cluster-a", P2pBackend: "iroh"},
+	}
+	preferred, _ := PreferLocalNodes(nodes, localityTestRequirements("key"), store)
+	assertLocalityNodeIDs(t, preferred, "node-a")
+}
+
+func TestPreferLocalNodesDeduplicatesRequirements(t *testing.T) {
+	store := NewInMemoryArtifactStore(10, 0)
+	store.Record("cluster", "iroh", "key-a", "node-a")
+	store.Record("cluster", "iroh", "key-b", "node-b")
+
+	preferred, stats := PreferLocalNodes(
+		localityTestNodes("cluster", "iroh", "node-a", "node-b"),
+		localityTestRequirements("key-a", "key-a", " key-a ", "key-b"),
+		store,
+	)
+	assertLocalityNodeIDs(t, preferred, "node-a", "node-b")
+	if stats.RequirementCount != 2 || stats.MaxCoverage != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+}
+
+func TestPreferLocalNodesSkipsCandidatesWithoutLocalityContext(t *testing.T) {
+	store := NewInMemoryArtifactStore(10, 0)
+	store.Record("cluster", "iroh", "key", "node-a")
+	nodes := []RichNode{
+		{Node: Node{ID: "node-a"}},
+		{Node: Node{ID: "node-b"}, ClusterID: "cluster", P2pBackend: "iroh"},
+	}
+
+	preferred, stats := PreferLocalNodes(nodes, localityTestRequirements("key"), store)
+	assertLocalityNodeIDs(t, preferred, "node-a", "node-b")
+	if stats.MaxCoverage != 0 {
+		t.Fatalf("unexpected locality hit without node context: %+v", stats)
+	}
+}
+
+func localityTestNodes(clusterID, backend string, nodeIDs ...string) []RichNode {
+	nodes := make([]RichNode, 0, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
+		nodes = append(nodes, RichNode{
+			Node:       Node{ID: nodeID},
+			ClusterID:  clusterID,
+			P2pBackend: backend,
+		})
+	}
+	return nodes
+}
+
+func localityTestRequirements(keys ...string) []*schedulerv1.LocalityRequirement {
+	requirements := make([]*schedulerv1.LocalityRequirement, 0, len(keys))
+	for _, key := range keys {
+		requirements = append(requirements, &schedulerv1.LocalityRequirement{Key: key})
+	}
+	return requirements
+}
+
+func assertLocalityNodeIDs(t *testing.T, nodes []RichNode, want ...string) {
+	t.Helper()
+	if len(nodes) != len(want) {
+		t.Fatalf("node count = %d, want %d: %+v", len(nodes), len(want), nodes)
+	}
+	for i, node := range nodes {
+		if node.ID != want[i] {
+			t.Fatalf("node[%d] = %q, want %q", i, node.ID, want[i])
+		}
+	}
+}

--- a/services/scheduler/internal/node_registry.go
+++ b/services/scheduler/internal/node_registry.go
@@ -21,11 +21,9 @@ type NodeRegistry interface {
 	ListP2pPeers(clusterID string, backend string, excludeNodeID string, now time.Time) []*schedulerv1.P2PPeer
 	FilterP2pPeers(clusterID string, backend string, nodeIDs []string, excludeNodeID string, now time.Time) []*schedulerv1.P2PPeer
 	GetObserved(nodeID string, clusterID string, now time.Time) (*schedulerv1.ObservedNode, bool)
-	// PeekObserved returns the latest heartbeat-reported NodeSnapshot for a node.
-	// Unlike GetObserved, it does not derive status from discovery state or TTL,
-	// and returns only the raw snapshot suitable for scheduling decisions.
-	// Returns nil if the node has never sent a heartbeat.
-	PeekObserved(nodeID string) *schedulerv1.NodeSnapshot
+	// PeekSchedulingContext returns raw heartbeat state suitable for placement.
+	// Unlike GetObserved, it does not derive status from discovery state or TTL.
+	PeekSchedulingContext(nodeID string) NodeSchedulingContext
 	UnregisterObserved(nodeID string, serviceInstanceID string) error
 }
 
@@ -331,18 +329,21 @@ func (r *AtomicNodeRegistry) GetObserved(nodeID string, clusterID string, now ti
 	return r.deriveObservedNodeViewLocked(record, nowMs), true
 }
 
-func (r *AtomicNodeRegistry) PeekObserved(nodeID string) *schedulerv1.NodeSnapshot {
+func (r *AtomicNodeRegistry) PeekSchedulingContext(nodeID string) NodeSchedulingContext {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	record, ok := r.observed[nodeID]
 	if !ok || record.node == nil {
-		return nil
+		return NodeSchedulingContext{}
 	}
-	snapshot := record.node.GetSnapshot()
-	if snapshot == nil {
-		return nil
+	context := NodeSchedulingContext{
+		Snapshot:  cloneSnapshot(record.node.GetSnapshot()),
+		ClusterID: record.node.GetClusterId(),
 	}
-	return cloneSnapshot(snapshot)
+	if record.p2pEndpoint.GetAddress() != "" {
+		context.P2pBackend = record.p2pEndpoint.GetBackend()
+	}
+	return context
 }
 
 func (r *AtomicNodeRegistry) UnregisterObserved(nodeID string, serviceInstanceID string) error {

--- a/services/scheduler/internal/node_registry_test.go
+++ b/services/scheduler/internal/node_registry_test.go
@@ -124,6 +124,50 @@ func TestHeartbeatStoresP2PEndpointForPeerListing(t *testing.T) {
 	}
 }
 
+func TestPeekSchedulingContext(t *testing.T) {
+	registry := NewAtomicNodeRegistry([]Node{{ID: "node-a", Endpoint: "http://node-a"}}, 30*time.Second)
+	now := time.Unix(100, 0)
+	registry.Heartbeat(&schedulerv1.HeartbeatRequest{
+		NodeId:            "node-a",
+		ClusterId:         "cluster-a",
+		ServiceInstanceId: "svc-a",
+		Snapshot:          &schedulerv1.NodeSnapshot{AllocatedCpu: 2},
+		P2PEndpoint:       &schedulerv1.P2PEndpoint{Backend: "iroh", Address: "node-a-iroh-endpoint"},
+	}, now)
+
+	context := registry.PeekSchedulingContext("node-a")
+	if context.ClusterID != "cluster-a" || context.P2pBackend != "iroh" {
+		t.Fatalf("unexpected locality context: %+v", context)
+	}
+	if context.Snapshot.GetAllocatedCpu() != 2 {
+		t.Fatalf("unexpected snapshot: %+v", context.Snapshot)
+	}
+
+	// Scheduling callers must not be able to mutate registry-owned state.
+	context.Snapshot.AllocatedCpu = 99
+	if got := registry.PeekSchedulingContext("node-a").Snapshot.GetAllocatedCpu(); got != 2 {
+		t.Fatalf("registry snapshot was mutated through scheduling context: %d", got)
+	}
+}
+
+func TestPeekSchedulingContextWithoutP2PEndpoint(t *testing.T) {
+	registry := NewAtomicNodeRegistry([]Node{{ID: "node-a", Endpoint: "http://node-a"}}, 30*time.Second)
+	registry.Heartbeat(&schedulerv1.HeartbeatRequest{
+		NodeId:            "node-a",
+		ClusterId:         "cluster-a",
+		ServiceInstanceId: "svc-a",
+		Snapshot:          &schedulerv1.NodeSnapshot{AllocatedCpu: 2},
+	}, time.Unix(100, 0))
+
+	context := registry.PeekSchedulingContext("node-a")
+	if context.ClusterID != "cluster-a" || context.P2pBackend != "" {
+		t.Fatalf("unexpected scheduling context: %+v", context)
+	}
+	if missing := registry.PeekSchedulingContext("missing"); missing != (NodeSchedulingContext{}) {
+		t.Fatalf("missing node context = %+v, want zero value", missing)
+	}
+}
+
 func TestUnregisterRemovesP2PEndpointPeer(t *testing.T) {
 	registry := NewAtomicNodeRegistry([]Node{{ID: "node-a", Endpoint: "http://node-a"}}, 30*time.Second)
 	now := time.Unix(100, 0)

--- a/services/scheduler/internal/service.go
+++ b/services/scheduler/internal/service.go
@@ -90,6 +90,12 @@ func (s *Service) Schedule(_ context.Context, req *schedulerv1.ScheduleRequest) 
 		recordSchedulerSchedule(s.strategy.Name(), start, err)
 	}()
 
+	requirements := req.GetHint().GetLocalityRequirements()
+	if len(requirements) > maxLocalityRequirements {
+		err = status.Error(codes.InvalidArgument, "too many locality requirements")
+		return nil, err
+	}
+
 	discovered := s.nodes.Snapshot( /* allowLingering */ false)
 	rich := make([]RichNode, 0, len(discovered))
 	for _, n := range discovered {
@@ -103,11 +109,6 @@ func (s *Service) Schedule(_ context.Context, req *schedulerv1.ScheduleRequest) 
 	}
 
 	eligible := FilterByResourceLimit(rich, s.resourceLimit)
-	requirements := req.GetHint().GetLocalityRequirements()
-	if len(requirements) > maxLocalityRequirements {
-		err = status.Error(codes.InvalidArgument, "too many locality requirements")
-		return nil, err
-	}
 	preferred, locality := PreferLocalNodes(
 		eligible,
 		requirements,

--- a/services/scheduler/internal/service.go
+++ b/services/scheduler/internal/service.go
@@ -25,6 +25,12 @@ type Service struct {
 	resourceLimit *config.NodeResourceLimit
 }
 
+// maxLocalityRequirements bounds the amount of scheduler work driven by one
+// Schedule request. The gateway currently emits two fixed snapshot artifact
+// requirements, so this leaves room for future hint expansion without adding
+// a per-deployment tuning knob for an internal safety limit.
+const maxLocalityRequirements = 32
+
 func NewService(logger *zap.Logger, nodes NodeRegistry, strategy Strategy, store BindingStore, opts ...ServiceOption) *Service {
 	if logger == nil {
 		logger = zap.NewNop()

--- a/services/scheduler/internal/service.go
+++ b/services/scheduler/internal/service.go
@@ -97,14 +97,23 @@ func (s *Service) Schedule(_ context.Context, req *schedulerv1.ScheduleRequest) 
 	}
 
 	eligible := FilterByResourceLimit(rich, s.resourceLimit)
+	preferred, locality := PreferLocalNodes(
+		eligible,
+		req.GetHint().GetLocalityRequirements(),
+		s.artifacts,
+	)
 
-	node, selectErr := s.strategy.Select(eligible, req.GetHint())
+	node, selectErr := s.strategy.Select(preferred, req.GetHint())
 	if selectErr != nil {
 		s.logger.Debug("scheduler selection failed",
 			zap.String("strategy", s.strategy.Name()),
 			zap.String("hint", summarizeScheduleHint(req.GetHint())),
 			zap.Int("candidate_nodes", len(rich)),
 			zap.Int("eligible_nodes", len(eligible)),
+			zap.Int("preferred_nodes", len(preferred)),
+			zap.Int("locality_requirements", locality.RequirementCount),
+			zap.Int("locality_provider_nodes", locality.ProviderNodeCount),
+			zap.Int("locality_max_coverage", locality.MaxCoverage),
 			zap.Error(selectErr),
 		)
 		if errors.Is(selectErr, ErrNoNodes) {
@@ -121,6 +130,10 @@ func (s *Service) Schedule(_ context.Context, req *schedulerv1.ScheduleRequest) 
 		zap.String("endpoint", node.Endpoint),
 		zap.Int("candidate_nodes", len(rich)),
 		zap.Int("eligible_nodes", len(eligible)),
+		zap.Int("preferred_nodes", len(preferred)),
+		zap.Int("locality_requirements", locality.RequirementCount),
+		zap.Int("locality_provider_nodes", locality.ProviderNodeCount),
+		zap.Int("locality_max_coverage", locality.MaxCoverage),
 	)
 	return &schedulerv1.ScheduleResponse{Node: node.Node.ToProto()}, nil
 }

--- a/services/scheduler/internal/service.go
+++ b/services/scheduler/internal/service.go
@@ -97,9 +97,14 @@ func (s *Service) Schedule(_ context.Context, req *schedulerv1.ScheduleRequest) 
 	}
 
 	eligible := FilterByResourceLimit(rich, s.resourceLimit)
+	requirements := req.GetHint().GetLocalityRequirements()
+	if len(requirements) > maxLocalityRequirements {
+		err = status.Error(codes.InvalidArgument, "too many locality requirements")
+		return nil, err
+	}
 	preferred, locality := PreferLocalNodes(
 		eligible,
-		req.GetHint().GetLocalityRequirements(),
+		requirements,
 		s.artifacts,
 	)
 

--- a/services/scheduler/internal/service.go
+++ b/services/scheduler/internal/service.go
@@ -87,9 +87,12 @@ func (s *Service) Schedule(_ context.Context, req *schedulerv1.ScheduleRequest) 
 	discovered := s.nodes.Snapshot( /* allowLingering */ false)
 	rich := make([]RichNode, 0, len(discovered))
 	for _, n := range discovered {
+		context := s.nodes.PeekSchedulingContext(n.ID)
 		rich = append(rich, RichNode{
-			Node:     n,
-			Snapshot: s.nodes.PeekObserved(n.ID),
+			Node:       n,
+			Snapshot:   context.Snapshot,
+			ClusterID:  context.ClusterID,
+			P2pBackend: context.P2pBackend,
 		})
 	}
 

--- a/services/scheduler/internal/service_test.go
+++ b/services/scheduler/internal/service_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	schedulerv1 "agentenv/services/api/proto"
+	"agentenv/services/shared/config"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -260,6 +261,82 @@ func TestScheduleOnlyConsidersReadyNodes(t *testing.T) {
 			t.Fatalf("iteration %d: expected node-a, got %s", i, got)
 		}
 	}
+}
+
+func TestSchedulePrefersNodeWithSnapshotArtifacts(t *testing.T) {
+	registry := NewAtomicNodeRegistry([]Node{
+		{ID: "node-a", Endpoint: "http://node-a"},
+		{ID: "node-b", Endpoint: "http://node-b"},
+	}, defaultObservedReportTTL)
+	artifacts := NewInMemoryArtifactStore(10, 1)
+	service := NewService(
+		zap.NewNop(),
+		registry,
+		NewStrategy("round_robin"),
+		NewInMemoryBindingStore(defaultObservedReportTTL),
+		WithArtifactStore(artifacts),
+	)
+	registerLocalityNodeForTest(t, service, "node-a", 0)
+	registerLocalityNodeForTest(t, service, "node-b", 0)
+	artifacts.Record("cluster-1", "iroh", "snapshot-key", "node-b")
+
+	resp, err := service.Schedule(context.Background(), localityScheduleRequest("snapshot-key"))
+	if err != nil {
+		t.Fatalf("schedule failed: %v", err)
+	}
+	if got := resp.GetNode().GetNodeId(); got != "node-b" {
+		t.Fatalf("selected node = %q, want node-b", got)
+	}
+}
+
+func TestScheduleDoesNotRestoreResourceFilteredLocalNode(t *testing.T) {
+	registry := NewAtomicNodeRegistry([]Node{
+		{ID: "node-a", Endpoint: "http://node-a"},
+		{ID: "node-b", Endpoint: "http://node-b"},
+	}, defaultObservedReportTTL)
+	artifacts := NewInMemoryArtifactStore(10, 0)
+	service := NewService(
+		zap.NewNop(),
+		registry,
+		NewStrategy("round_robin"),
+		NewInMemoryBindingStore(defaultObservedReportTTL),
+		WithArtifactStore(artifacts),
+		WithNodeResourceLimit(&config.NodeResourceLimit{MaxSandboxCount: uint32Ptr(0)}),
+	)
+	registerLocalityNodeForTest(t, service, "node-a", 1)
+	registerLocalityNodeForTest(t, service, "node-b", 0)
+	artifacts.Record("cluster-1", "iroh", "snapshot-key", "node-a")
+
+	resp, err := service.Schedule(context.Background(), localityScheduleRequest("snapshot-key"))
+	if err != nil {
+		t.Fatalf("schedule failed: %v", err)
+	}
+	if got := resp.GetNode().GetNodeId(); got != "node-b" {
+		t.Fatalf("selected node = %q, want resource-eligible node-b", got)
+	}
+}
+
+func registerLocalityNodeForTest(t *testing.T, service *Service, nodeID string, sandboxCount uint32) {
+	t.Helper()
+	_, err := service.Heartbeat(context.Background(), &schedulerv1.HeartbeatRequest{
+		NodeId:            nodeID,
+		ClusterId:         "cluster-1",
+		ServiceInstanceId: "svc-" + nodeID,
+		Snapshot: &schedulerv1.NodeSnapshot{
+			Status:       schedulerv1.NodeStatus_NODE_STATUS_READY,
+			SandboxCount: sandboxCount,
+		},
+		P2PEndpoint: &schedulerv1.P2PEndpoint{Backend: "iroh", Address: "addr-" + nodeID},
+	})
+	if err != nil {
+		t.Fatalf("heartbeat %s failed: %v", nodeID, err)
+	}
+}
+
+func localityScheduleRequest(keys ...string) *schedulerv1.ScheduleRequest {
+	return &schedulerv1.ScheduleRequest{Hint: &schedulerv1.ScheduleRequestHint{
+		LocalityRequirements: localityTestRequirements(keys...),
+	}}
 }
 
 func TestGetObservedNodeAfterHeartbeat(t *testing.T) {

--- a/services/scheduler/internal/service_test.go
+++ b/services/scheduler/internal/service_test.go
@@ -17,6 +17,16 @@ import (
 
 type failingBindingStore struct{}
 
+type snapshotCountingNodeRegistry struct {
+	NodeRegistry
+	snapshotCalls int
+}
+
+func (r *snapshotCountingNodeRegistry) Snapshot(allowLingering bool) []Node {
+	r.snapshotCalls++
+	return r.NodeRegistry.Snapshot(allowLingering)
+}
+
 func (failingBindingStore) Get(string, time.Time) (Node, bool, error) {
 	return Node{}, false, errors.New("binding store failed")
 }
@@ -296,15 +306,42 @@ func TestScheduleRejectsTooManyLocalityRequirements(t *testing.T) {
 		keys[i] = fmt.Sprintf("locality-key-%d", i)
 	}
 
+	registry := &snapshotCountingNodeRegistry{
+		NodeRegistry: NewAtomicNodeRegistry(nil, defaultObservedReportTTL),
+	}
 	service := NewService(
 		zap.NewNop(),
-		NewAtomicNodeRegistry(nil, defaultObservedReportTTL),
+		registry,
 		NewStrategy("round_robin"),
 		NewInMemoryBindingStore(defaultObservedReportTTL),
 	)
 	_, err := service.Schedule(context.Background(), localityScheduleRequest(keys...))
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("schedule error code = %s, want InvalidArgument (err=%v)", status.Code(err), err)
+	}
+	if registry.snapshotCalls != 0 {
+		t.Fatalf("registry Snapshot calls = %d, want 0 for invalid request", registry.snapshotCalls)
+	}
+}
+
+func TestScheduleAllowsMaxLocalityRequirements(t *testing.T) {
+	keys := make([]string, maxLocalityRequirements)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("locality-key-%d", i)
+	}
+
+	service := NewService(
+		zap.NewNop(),
+		NewAtomicNodeRegistry([]Node{{ID: "node-a", Endpoint: "http://node-a"}}, defaultObservedReportTTL),
+		NewStrategy("round_robin"),
+		NewInMemoryBindingStore(defaultObservedReportTTL),
+	)
+	resp, err := service.Schedule(context.Background(), localityScheduleRequest(keys...))
+	if err != nil {
+		t.Fatalf("schedule with maximum locality requirements failed: %v", err)
+	}
+	if got := resp.GetNode().GetNodeId(); got != "node-a" {
+		t.Fatalf("selected node = %q, want node-a", got)
 	}
 }
 

--- a/services/scheduler/internal/service_test.go
+++ b/services/scheduler/internal/service_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -286,6 +287,24 @@ func TestSchedulePrefersNodeWithSnapshotArtifacts(t *testing.T) {
 	}
 	if got := resp.GetNode().GetNodeId(); got != "node-b" {
 		t.Fatalf("selected node = %q, want node-b", got)
+	}
+}
+
+func TestScheduleRejectsTooManyLocalityRequirements(t *testing.T) {
+	keys := make([]string, maxLocalityRequirements+1)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("locality-key-%d", i)
+	}
+
+	service := NewService(
+		zap.NewNop(),
+		NewAtomicNodeRegistry(nil, defaultObservedReportTTL),
+		NewStrategy("round_robin"),
+		NewInMemoryBindingStore(defaultObservedReportTTL),
+	)
+	_, err := service.Schedule(context.Background(), localityScheduleRequest(keys...))
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("schedule error code = %s, want InvalidArgument (err=%v)", status.Code(err), err)
 	}
 }
 

--- a/services/scheduler/internal/store.go
+++ b/services/scheduler/internal/store.go
@@ -21,6 +21,7 @@ type ArtifactStore interface {
 	Record(clusterID string, backend string, key string, nodeID string)
 	Forget(clusterID string, backend string, key string, nodeID string)
 	Lookup(clusterID string, backend string, key string) []string
+	LookupAll(clusterID string, backend string, key string) []string
 	ForgetNode(nodeID string)
 }
 
@@ -221,6 +222,14 @@ func (s *InMemoryArtifactStore) Forget(clusterID string, backend string, key str
 }
 
 func (s *InMemoryArtifactStore) Lookup(clusterID string, backend string, key string) []string {
+	return s.lookup(clusterID, backend, key, s.lookupNodeLimit)
+}
+
+func (s *InMemoryArtifactStore) LookupAll(clusterID string, backend string, key string) []string {
+	return s.lookup(clusterID, backend, key, 0)
+}
+
+func (s *InMemoryArtifactStore) lookup(clusterID string, backend string, key string, limit int) []string {
 	indexKey, ok := normalizeArtifactIndexKey(clusterID, backend, key)
 	if !ok {
 		return nil
@@ -234,13 +243,13 @@ func (s *InMemoryArtifactStore) Lookup(clusterID string, backend string, key str
 	}
 	s.lru.Get(indexKey)
 	resultCapacity := len(nodes)
-	if s.lookupNodeLimit > 0 && s.lookupNodeLimit < resultCapacity {
-		resultCapacity = s.lookupNodeLimit
+	if limit > 0 && limit < resultCapacity {
+		resultCapacity = limit
 	}
 	result := make([]string, 0, resultCapacity)
 	for nodeID := range nodes {
 		result = append(result, nodeID)
-		if s.lookupNodeLimit > 0 && len(result) >= s.lookupNodeLimit {
+		if limit > 0 && len(result) >= limit {
 			break
 		}
 	}

--- a/services/scheduler/internal/store.go
+++ b/services/scheduler/internal/store.go
@@ -21,7 +21,12 @@ type ArtifactStore interface {
 	Record(clusterID string, backend string, key string, nodeID string)
 	Forget(clusterID string, backend string, key string, nodeID string)
 	Lookup(clusterID string, backend string, key string) []string
-	LookupAll(clusterID string, backend string, key string) []string
+	LookupEligible(
+		clusterID string,
+		backend string,
+		key string,
+		eligibleNodeIDs map[string]struct{},
+	) []string
 	ForgetNode(nodeID string)
 }
 
@@ -225,8 +230,34 @@ func (s *InMemoryArtifactStore) Lookup(clusterID string, backend string, key str
 	return s.lookup(clusterID, backend, key, s.lookupNodeLimit)
 }
 
-func (s *InMemoryArtifactStore) LookupAll(clusterID string, backend string, key string) []string {
-	return s.lookup(clusterID, backend, key, 0)
+func (s *InMemoryArtifactStore) LookupEligible(
+	clusterID string,
+	backend string,
+	key string,
+	eligibleNodeIDs map[string]struct{},
+) []string {
+	indexKey, ok := normalizeArtifactIndexKey(clusterID, backend, key)
+	if !ok || len(eligibleNodeIDs) == 0 {
+		return nil
+	}
+
+	s.mu.RLock()
+	nodes := s.entries[indexKey]
+	if len(nodes) == 0 {
+		s.mu.RUnlock()
+		return nil
+	}
+	s.lru.Get(indexKey)
+	resultCapacity := min(len(nodes), len(eligibleNodeIDs))
+	result := make([]string, 0, resultCapacity)
+	for nodeID := range eligibleNodeIDs {
+		if _, exists := nodes[nodeID]; exists {
+			result = append(result, nodeID)
+		}
+	}
+	s.mu.RUnlock()
+
+	return result
 }
 
 func (s *InMemoryArtifactStore) lookup(clusterID string, backend string, key string, limit int) []string {

--- a/services/scheduler/internal/store_test.go
+++ b/services/scheduler/internal/store_test.go
@@ -216,14 +216,25 @@ func TestArtifactStoreLookupLimitsReturnedNodes(t *testing.T) {
 	}
 }
 
-func TestArtifactStoreLookupAllIgnoresReturnedNodeLimit(t *testing.T) {
+func TestArtifactStoreLookupEligibleIntersectsCandidates(t *testing.T) {
 	store := NewInMemoryArtifactStore(10, 1)
-	for _, nodeID := range []string{"node-a", "node-b", "node-c"} {
+	for _, nodeID := range []string{"node-a", "node-b", "stale-node"} {
 		store.Record("cluster", "backend", "key", nodeID)
 	}
 
-	if got := len(store.LookupAll("cluster", "backend", "key")); got != 3 {
-		t.Fatalf("LookupAll returned %d nodes, want 3", got)
+	eligible := map[string]struct{}{
+		"node-a":       {},
+		"node-b":       {},
+		"missing-node": {},
+	}
+	nodes := store.LookupEligible("cluster", "backend", "key", eligible)
+	if len(nodes) != 2 {
+		t.Fatalf("LookupEligible returned %v, want node-a and node-b", nodes)
+	}
+	for _, nodeID := range nodes {
+		if nodeID != "node-a" && nodeID != "node-b" {
+			t.Fatalf("LookupEligible returned unexpected node %q", nodeID)
+		}
 	}
 }
 

--- a/services/scheduler/internal/store_test.go
+++ b/services/scheduler/internal/store_test.go
@@ -216,6 +216,17 @@ func TestArtifactStoreLookupLimitsReturnedNodes(t *testing.T) {
 	}
 }
 
+func TestArtifactStoreLookupAllIgnoresReturnedNodeLimit(t *testing.T) {
+	store := NewInMemoryArtifactStore(10, 1)
+	for _, nodeID := range []string{"node-a", "node-b", "node-c"} {
+		store.Record("cluster", "backend", "key", nodeID)
+	}
+
+	if got := len(store.LookupAll("cluster", "backend", "key")); got != 3 {
+		t.Fatalf("LookupAll returned %d nodes, want 3", got)
+	}
+}
+
 func TestArtifactStoreLookupReturnsAllNodesWhenLimitIsNonPositive(t *testing.T) {
 	for _, limit := range []int{0, -1} {
 		store := NewInMemoryArtifactStore(10, limit)

--- a/services/scheduler/internal/types.go
+++ b/services/scheduler/internal/types.go
@@ -11,7 +11,17 @@ type Node struct {
 // Strategy implementations can use Snapshot for load-aware scheduling.
 type RichNode struct {
 	Node
-	Snapshot *schedulerv1.NodeSnapshot // nil if no heartbeat received yet
+	Snapshot   *schedulerv1.NodeSnapshot // nil if no heartbeat received yet
+	ClusterID  string
+	P2pBackend string
+}
+
+// NodeSchedulingContext contains heartbeat state used only for placement.
+// P2P endpoint addresses remain private to peer discovery.
+type NodeSchedulingContext struct {
+	Snapshot   *schedulerv1.NodeSnapshot
+	ClusterID  string
+	P2pBackend string
 }
 
 func (n Node) ToProto() *schedulerv1.Node {


### PR DESCRIPTION
## What

This PR implements the first P2P-backed snapshot locality preference slice for #15.

For `POST /sandboxes`, when `templateID` is a canonical snapshot UUID in the standard hyphenated form, the Gateway derives two advisory locality requirements using the existing fixed snapshot artifact identities:

- `snapshot/v1/artifacts/{snapshot_id}/vm_state.bin`
- `snapshot/v1/artifacts/{snapshot_id}/firecracker-manifest.json`

After resource-limit filtering, the Scheduler prefers eligible nodes that advertise the highest coverage of those artifacts in the existing P2P artifact index. The configured scheduling strategy performs the final selection among tied nodes.

Template aliases remain supported, but intentionally do not produce locality hints because the Gateway has no authoritative pre-scheduling alias resolver. Alias requests therefore use the existing scheduling behavior.

## Why

The scheduler currently ignores whether an eligible node already provides the snapshot artifacts needed to start a sandbox. It can therefore select a cold node even when another feasible node advertises the required artifacts through the existing P2P index.

This change introduces a bounded, advisory locality preference without duplicating load-aware selection or changing runtime fallback behavior. It establishes the request and inventory path needed for later locality work while keeping the scheduler's artifact store limited to artifact-key-to-node mappings.

## Related issue

Refs #15

This PR is one focused part of #15 and does not close the full issue.

## Scope and non-goals

In scope:

- derive fixed snapshot artifact requirements from canonical snapshot IDs;
- carry advisory locality requirements through the internal scheduling protocol;
- prefer the eligible nodes with the highest positive artifact coverage;
- preserve existing selection behavior when locality data is absent or stale;
- bound request inspection, requirement count, and artifact lookup work;
- remove a node's artifact mappings when it is unregistered;
- document and test the new scheduling flow.

Non-goals:

- resolving template aliases before scheduling;
- resolving OCI image references into OverlayBD layer requirements;
- indexing non-P2P local caches;
- adding locality requirements for `POST /sandboxes-cold`;
- introducing a monolithic `cache_aware` strategy;
- implementing or duplicating load-aware node selection;
- changing hard resource filtering or runtime artifact fallback behavior.

## Design and behavior changes

The scheduling flow becomes:

```text
ready nodes
    -> hard resource-limit filtering
    -> snapshot artifact locality preference
    -> configured strategy selection
    -> selected node
```

The Gateway inspects only exact `POST /sandboxes` creation requests. It buffers at most 64 KiB while extracting `templateID` and restores the original body for upstream forwarding. Oversized, malformed, empty, alias-based, and non-canonical template IDs produce no locality requirements and continue through normal scheduling.

For a canonical snapshot UUID, the Gateway normalizes the ID and emits the two fixed artifact keys listed above. It does not query runtime nodes to resolve aliases. Such fan-out would be non-authoritative, could observe inconsistent alias mappings, would amplify unauthenticated request work, and could expand credential exposure.

The Scheduler validates the request-controlled locality requirement count before node discovery. After resource filtering, `PreferLocalNodes`:

- trims and deduplicates requirement keys;
- isolates lookups by cluster ID and P2P backend;
- scores only already-eligible candidates;
- retains all nodes tied for the highest positive coverage;
- preserves the complete eligible set when no useful locality data exists.

Artifact lookup intersects provider records with the eligible node-ID set inside the store, so scheduling work scales with current candidates rather than all historical providers. Locality does not create reservations or other request-lifetime state.

Locality remains advisory. Stale or missing records do not fail sandbox creation, and the selected runtime continues through its normal local cache, P2P, snapshot repository, or registry fallback path.

## Compatibility and operations

- Public API or generated protocol: Adds optional `ScheduleRequestHint.locality_requirements`, `LocalityRequirement.key`, and `NewSandboxHint.template_id` fields to the internal scheduler protobuf. The additions are wire-compatible. Older senders omit them, and receivers without locality support ignore the unknown fields.
- Configuration or defaults: No configuration fields or defaults change. Existing `round_robin` and `random` strategy behavior is unchanged when locality requirements or provider records are unavailable.
- Snapshot manifest, artifact layout, or storage format: No format or layout changes. The implementation reuses the existing `snapshot/v1/artifacts/{snapshot_id}/...` identities.
- Upgrade and rollback: No persistent migration is required. Gateway and Scheduler versions can be rolled back without changing snapshot data or the artifact index; rollback removes the placement preference and restores the previous selection behavior.
- Host requirements, permissions, ports, or dependencies: No new host permissions, services, ports, or runtime packages. `github.com/google/uuid` is promoted from an indirect to a direct Go dependency at the same version.

## Validation

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [x] Relevant Rust integration tests
- [x] `make -C services test` (required when `services/` changes)
- [x] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
make -C services proto PROTOC=<protoc 3.21.12>
gofmt -w services/api/proto/scheduler.pb.go services/api/proto/scheduler_grpc.pb.go
# PASS: protoc-gen-go 1.36.11 and protoc-gen-go-grpc 1.6.2; no tracked diff

make -C services build
make -C services test
make -C services fmt-check
make -C services vet
# PASS with Go 1.25.0

cd services
go test -race ./gateway/internal ./scheduler/internal
# PASS with Go 1.25.0

git diff --check
# PASS
```

The Services commands above were run locally. `fmt-check` was verified from an LF-normalized export of the same commit because this WSL checkout uses `core.autocrlf=true`.

The following remote Services CI and integration jobs also passed for commit `b2f9346577b001bba28fb038d46ae0beb233c956`:

- Services CI: https://github.com/shudorcl/AgentENV/actions/runs/30394461927
- Integration Tests: https://github.com/shudorcl/AgentENV/actions/runs/30394461784

Skipped checks and reasons:

- Root Rust formatting, Clippy, and unit-test targets were not run because this PR changes only the Go control-plane module and its generated Go protobuf. The remote AgentENV integration, single-node E2E, and docker-compose E2E jobs passed.
- No benchmark was run. The scheduling hot path is bounded to at most 32 locality requirements, and provider lookup is intersected with the current eligible candidate set. The PR adds focused boundary and stale-record tests, but does not claim a measured performance improvement.

## Risks and reviewer notes

- Locality metadata is eventually consistent and can be stale. The preference is deliberately advisory, and no positive match preserves the complete eligible candidate set.
- Requests with aliases receive no locality optimization. Supporting aliases safely requires an authoritative control-plane resolver and is left for a follow-up.
- Hint extraction occurs before upstream authentication. Request-body inspection is therefore bounded to 64 KiB and does not fan out to runtime nodes.
- The locality requirement list is request-controlled. The Scheduler rejects more than 32 requirements before node snapshotting or enrichment.
- Popular artifacts may have many historical providers. `LookupEligible` bounds work to the current eligible candidate IDs, and unregistering a node removes its artifact mappings.
- Reviewers should start with `services/gateway/internal/schedule_hint.go`, `services/gateway/internal/template_resolution.go`, `services/scheduler/internal/locality.go`, and `services/scheduler/internal/service.go`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
