### PR TITLE
fix(cli): validate Dockerfile before creating template

### DIFF
--- a/crates/aenv/src/commands/build.rs
+++ b/crates/aenv/src/commands/build.rs
@@ -27,6 +27,7 @@ pub fn run(args: Args) -> Result<()> {
         .with_context(|| format!("reading {}", args.dockerfile.display()))?;
     let alias = parse_alias(args.name.as_deref(), &args.dockerfile);
     let user_image = args.user_image.or_else(|| first_from_image(&dockerfile));
+    let build_plan = dockerfile_build_plan(&dockerfile)?;
 
     let req = CreateTemplateV3 {
         name: alias.to_string(),
@@ -35,7 +36,6 @@ pub fn run(args: Args) -> Result<()> {
         memory_mb: args.resources.memory_mb,
     };
     let resp = client.create_template_v3(&req)?;
-    let build_plan = dockerfile_build_plan(&dockerfile)?;
     client.start_template_build_v2(
         &resp.template_id,
         &resp.build_id,


### PR DESCRIPTION
## What

Validate and translate the Dockerfile before creating the remote template record.

## Why

`aenv build` currently sends `POST /v3/templates` before checking whether the Dockerfile contains unsupported instructions. A later validation error leaves a `Waiting` template/build behind and can retain the requested alias even though no build was started.

## Related issue

N/A — focused CLI bug fix.

## Scope and non-goals

Only the preflight order changes. Supported Dockerfiles keep the same request payloads and build flow.

## Design and behavior changes

Build the local Dockerfile plan before the first remote mutation. Invalid Dockerfiles now fail without creating server-side state.

## Compatibility and operations

- Public API or generated protocol: N/A
- Configuration or defaults: N/A
- Snapshot manifest, artifact layout, or storage format: N/A
- Upgrade and rollback: N/A
- Host requirements, permissions, ports, or dependencies: N/A

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aenv --all-targets -- -D warnings`
- [x] `cargo test -p aenv commands::build::tests`

Commands and results:

```text
cargo test -p aenv commands::build::tests
13 passed; 0 failed

cargo fmt --all -- --check
passed

cargo clippy -p aenv --all-targets -- -D warnings
passed
```

## Risks and reviewer notes

Low risk: the change only moves an existing fallible, local validation step before template creation.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] Existing Dockerfile parser tests cover supported instructions and the rejected `COPY`/`ADD` paths.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] No generated code was changed.
