### PR TITLE
fix(sandbox): resume sandbox upon recoverable pause failure

### DIFF
--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -2808,6 +2808,16 @@ async fn orchestrator_delete_paused_sandbox_removes_metadata() -> Result<()> {
 async fn pause_failure_rolls_back_to_running_and_preserves_handle() -> Result<()> {
     setup();
     let behavior = Arc::new(MockBehavior::new());
+    let resume_calls = Arc::new(StdMutex::new(0usize));
+    let resume_calls_for_hook = Arc::clone(&resume_calls);
+    behavior.set_on_operation(
+        MockOperation::Resume,
+        Arc::new(move || {
+            *resume_calls_for_hook
+                .lock()
+                .expect("resume call counter mutex poisoned") += 1;
+        }),
+    );
     behavior.push_action(
         MockOperation::Pause,
         MockAction::Fail {
@@ -2815,7 +2825,8 @@ async fn pause_failure_rolls_back_to_running_and_preserves_handle() -> Result<()
         },
     );
     let orchestrator =
-        make_orchestrator_with_factory(MockBackendFactory::with_behavior(behavior)).await;
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(Arc::clone(&behavior)))
+            .await;
 
     let created = orchestrator
         .create_sandbox(create_request(Some(60), &[("team", "pause-failure")]))
@@ -2859,8 +2870,65 @@ async fn pause_failure_rolls_back_to_running_and_preserves_handle() -> Result<()
         created.resources.memory_mib,
     )
     .await;
+    assert_eq!(
+        *resume_calls
+            .lock()
+            .expect("resume call counter mutex poisoned"),
+        1,
+        "recoverable pause failure should resume the backend before returning"
+    );
 
     orchestrator.delete_sandbox(sandbox_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_failure_with_failed_recovery_removes_sandbox() -> Result<()> {
+    setup();
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::Pause,
+        MockAction::Fail {
+            message: "forced pause failure".to_string(),
+        },
+    );
+    behavior.push_action(
+        MockOperation::Resume,
+        MockAction::Fail {
+            message: "forced resume failure".to_string(),
+        },
+    );
+    let orchestrator =
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(Arc::clone(&behavior)))
+            .await;
+
+    let created = orchestrator
+        .create_sandbox(create_request(
+            Some(60),
+            &[("team", "pause-recovery-failure")],
+        ))
+        .await?;
+    let sandbox_id = created.id;
+
+    let err = orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("pause should fail terminally when the backend cannot recover");
+    let message = format!("{err:#}");
+    assert!(matches!(
+        err,
+        OrchestratorError::SandboxOperationFailed {
+            operation: SandboxOperation::Pause,
+            ..
+        }
+    ));
+    assert!(message.contains("forced pause failure"), "{message}");
+    assert!(message.contains("forced resume failure"), "{message}");
+
+    assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
+    assert_proxy_not_found(&orchestrator, &sandbox_id).await?;
+    assert_eq!(behavior.stop_calls(), 1);
+    assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;
     Ok(())
 }
 

--- a/src/sandbox/backend.rs
+++ b/src/sandbox/backend.rs
@@ -192,6 +192,9 @@ pub trait SandboxBackend: Send + 'static {
     /// [`SandboxCaptureError::Terminal`] indicates snapshot capture mutated the live
     /// runtime before failing, so callers must not keep treating the sandbox
     /// as safely runnable.
+    ///
+    /// For simplicity, [`SandboxCaptureError::Recoverable`] must guarantee the sandbox
+    /// has already been restored to a running state before the error is returned.
     async fn pause(
         &mut self,
         artifact_root: Option<&Path>,

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -183,16 +183,26 @@ impl SandboxBackend for FirecrackerSandbox {
         &mut self,
         artifact_root: Option<&Path>,
     ) -> SandboxCaptureResult<Arc<dyn PausedSandboxState>> {
-        let snapshot_config = match artifact_root {
-            Some(artifact_root) => {
-                let (snapshot_config, _) = FirecrackerSandbox::pause_to_dir(self, artifact_root)
-                    .await
-                    .map_err(SandboxCaptureError::from)?;
-                snapshot_config
-            }
-            None => FirecrackerSandbox::pause(self)
+        let pause_result = match artifact_root {
+            Some(artifact_root) => FirecrackerSandbox::pause_to_dir(self, artifact_root)
                 .await
-                .map_err(SandboxCaptureError::from)?,
+                .map(|(snapshot_config, _)| snapshot_config),
+            None => FirecrackerSandbox::pause(self).await,
+        };
+        let snapshot_config = match pause_result {
+            Ok(snapshot_config) => snapshot_config,
+            Err(err) => {
+                let pause_err = SandboxCaptureError::from(err);
+                if pause_err.is_terminal() {
+                    return Err(pause_err);
+                }
+                if let Err(resume_err) = FirecrackerSandbox::resume(self).await {
+                    return Err(SandboxCaptureError::terminal(anyhow::anyhow!(
+                        "pause failed and sandbox could not be resumed: pause error: {pause_err}; resume error: {resume_err:#}"
+                    )));
+                }
+                return Err(pause_err);
+            }
         };
         Ok(Arc::new(FirecrackerPausedState::new(snapshot_config)))
     }

--- a/src/sandbox/mock.rs
+++ b/src/sandbox/mock.rs
@@ -278,9 +278,21 @@ impl SandboxBackend for MockSandboxBackend {
         &mut self,
         _artifact_root: Option<&Path>,
     ) -> SandboxCaptureResult<Arc<dyn PausedSandboxState>> {
-        self.behavior
+        let pause_result = self
+            .behavior
             .apply_capture_result(MockOperation::Pause)
-            .await?;
+            .await;
+        if let Err(pause_err) = pause_result {
+            if pause_err.is_terminal() {
+                return Err(pause_err);
+            }
+            if let Err(resume_err) = self.behavior.apply_async(MockOperation::Resume).await {
+                return Err(SandboxCaptureError::terminal(anyhow!(
+                    "pause failed and sandbox could not be resumed: pause error: {pause_err}; resume error: {resume_err:#}"
+                )));
+            }
+            return Err(pause_err);
+        }
         Ok(Arc::new(MockSnapshot))
     }
 


### PR DESCRIPTION
## What

Ensure `SandboxBackend::pause()` returns a recoverable error only after the sandbox has been restored to a running state.

For the Firecracker backend, a recoverable pause failure now triggers an in-place resume before the error is returned. If recovery also fails, the error is promoted to terminal so the orchestrator stops and removes the sandbox instead of publishing a frozen VM as `Running`.

## Why

Firecracker is paused before snapshot artifacts are fully created. A later snapshot-processing failure could therefore leave the VM paused while the orchestrator restored its handle, proxy route, and `Running` metadata. The sandbox appeared healthy and routable but could not make progress.

Keeping the recovery guarantee at the backend boundary lets the orchestrator retain its simple error handling without depending on backend-specific intermediate states.

## Related issue

Closes #41

## Scope and non-goals

Included:

- Define the recoverable `pause()` contract at the sandbox backend boundary.
- Resume Firecracker after recoverable pause failures.
- Promote failed recovery to a terminal error with both failure causes.
- Keep the mock backend aligned with the production contract.
- Add focused orchestrator regression coverage.

Not included:

- Lifecycle concurrency or delete-path refactoring.
- Changes to the low-level `FirecrackerSandbox::pause_to_dir()` semantics.
- New public APIs, configuration, or persisted state.

## Design and behavior changes

```text
backend pause failure
        |
        +-- terminal ----------------------> return Terminal
        |
        `-- recoverable --> resume backend
                              |
                              +-- success --> return original Recoverable
                              |
                              `-- failure --> return Terminal(pause + resume errors)
```

The orchestrator can safely restore the handle, proxy route, and `Running` metadata for a recoverable error because the backend now guarantees that recovery has already completed.

## Compatibility and operations

- Public API or generated protocol: N/A; no API or generated-code changes.
- Configuration or defaults: N/A.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: No migration required; rollback restores the previous pause failure behavior.
- Host requirements, permissions, ports, or dependencies: N/A.

## Validation

- [x] `make fmt` (equivalent command run directly)
- [x] `make clippy` (equivalent focused command run directly)
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
cargo test -p agentenv --lib pause_ -- --nocapture
# 17 passed; 0 failed

cargo fmt --all -- --check
# passed

cargo clippy -p agentenv --all-targets -- -D warnings
# passed
```

Skipped checks and reasons:

- Services tests were not run because `services/` is unchanged.
- Code generation and benchmarks are not applicable.

## Risks and reviewer notes

N/A

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.