### PR TITLE
fix(template): provision a missing default user at the end of a build

### DIFF
--- a/docs/src/concepts/templates.md
+++ b/docs/src/concepts/templates.md
@@ -59,7 +59,7 @@ Supported Dockerfile instructions:
 | `ENV` | Set an environment variable |
 | `ARG` | Set a build-time variable |
 | `WORKDIR` | Create the directory if needed and set it as the working directory |
-| `USER` | Set the default user |
+| `USER` | Set the default user (a missing named account is created at the end of the build) |
 | `ENTRYPOINT` | Becomes the template `startCmd` |
 | `CMD` | Becomes `startCmd` if no `ENTRYPOINT` is present |
 | `EXPOSE` / `VOLUME` / `LABEL` | Accepted but stored as metadata only |

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -333,6 +333,11 @@ struct ProvisionEntity<'a> {
     create_fallback: &'static str,
 }
 
+/// Bound on one provisioning command: the probes can wait on NSS providers
+/// and useradd/groupadd on passwd/group locks, and an unbounded hang here
+/// would wedge the build worker.
+const PROVISION_TIMEOUT: Duration = Duration::from_secs(60);
+
 async fn ensure_entity(sandbox: &impl SandboxExecutor, entity: ProvisionEntity<'_>) -> Result<()> {
     let ProvisionEntity {
         kind,
@@ -364,8 +369,9 @@ async fn ensure_entity(sandbox: &impl SandboxExecutor, entity: ProvisionEntity<'
     );
     // /bin/sh, not bash: the images most likely to be missing the entry
     // (Alpine/BusyBox) are also the ones without bash, and the script is POSIX.
+    let opts = ProcessOpts::default().with_timeout(PROVISION_TIMEOUT);
     let result = sandbox
-        .run_command_with_opts("/bin/sh", &["-c", &script], &ProcessOpts::default())
+        .run_command_with_opts("/bin/sh", &["-c", &script], &opts)
         .await;
     match result {
         Ok(output) if output.exit_code == 0 => Ok(()),
@@ -587,7 +593,7 @@ mod tests {
     use anyhow::{anyhow, Result};
     use async_trait::async_trait;
 
-    use super::{ensure_default_user, prepare_startup, run_ready_command};
+    use super::{ensure_default_user, prepare_startup, run_ready_command, PROVISION_TIMEOUT};
     use crate::sandbox::{Executor, ProcessHandle, ProcessOpts, ProcessOutput, SandboxExecutor};
     use crate::snapshot::{CommandContext, StartupCommand};
 
@@ -734,6 +740,22 @@ mod tests {
 
     fn context_with_user(user: Option<&str>) -> CommandContext {
         CommandContext::default().with_user(user.map(str::to_string))
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_runs_under_a_bounded_timeout() {
+        let sandbox = RecordingSandbox {
+            timeouts: Mutex::new(Vec::new()),
+        };
+        ensure_default_user(&sandbox, &context_with_user(Some("user")))
+            .await
+            .unwrap();
+        let timeouts = sandbox
+            .timeouts
+            .lock()
+            .expect("timeouts mutex should not be poisoned")
+            .clone();
+        assert_eq!(timeouts, vec![Some(PROVISION_TIMEOUT)]);
     }
 
     #[tokio::test]

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -274,11 +274,15 @@ impl TemplateBuildRunner {
 /// clients assume.
 ///
 /// Numeric USER values are left alone (Docker allows a UID with no passwd
-/// entry), and an image where the account cannot be created (no useradd or
-/// adduser) keeps building with a warning rather than failing: such an image
-/// worked before this provisioning existed, and only envd calls that resolve
-/// the default user will fail. Executor errors (envd unreachable, sandbox
-/// gone) are not downgraded — they fail the build.
+/// entry). An image with no account-management tooling at all (neither
+/// useradd/groupadd nor adduser/addgroup) keeps building with a warning
+/// rather than failing: such an image worked before this provisioning
+/// existed, and only envd calls that resolve the default user will fail.
+/// Any other failure aborts the build — a creation tool that is present but
+/// fails (permission denied, read-only filesystem, corrupt passwd database)
+/// leaves the template with a default identity known not to resolve, and
+/// executor errors (envd unreachable, sandbox gone) are infrastructure
+/// failures.
 ///
 /// A `USER name:group` value names the account and the group independently
 /// (Docker resolves the two separately and requires no membership), so a
@@ -338,6 +342,10 @@ struct ProvisionEntity<'a> {
 /// would wedge the build worker.
 const PROVISION_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Exit code the provisioning script reserves for "this image ships no
+/// account-management tooling" — the one failure that stays a warning.
+const PROVISION_MISSING_TOOLING_EXIT: i32 = 66;
+
 async fn ensure_entity(sandbox: &impl SandboxExecutor, entity: ProvisionEntity<'_>) -> Result<()> {
     let ProvisionEntity {
         kind,
@@ -364,8 +372,20 @@ async fn ensure_entity(sandbox: &impl SandboxExecutor, entity: ProvisionEntity<'
     }
 
     let quoted = shell_quote(name);
+    let create_bin = create.split_whitespace().next().unwrap_or(create);
+    let fallback_bin = create_fallback
+        .split_whitespace()
+        .next()
+        .unwrap_or(create_fallback);
+    // Dispatch on which creation tool the image ships instead of chaining
+    // fallbacks: a chained `useradd || adduser` would mask a real failure of
+    // the present tool behind the fallback's "command not found", and its
+    // exit code could not be told apart from "no tooling at all".
     let script = format!(
-        "{exists_probe} {quoted} >/dev/null 2>&1 || {create} {quoted} 2>/dev/null || {create_fallback} {quoted}"
+        "{exists_probe} {quoted} >/dev/null 2>&1 && exit 0; \
+         command -v {create_bin} >/dev/null 2>&1 && exec {create} {quoted}; \
+         command -v {fallback_bin} >/dev/null 2>&1 && exec {create_fallback} {quoted}; \
+         exit {PROVISION_MISSING_TOOLING_EXIT}"
     );
     // /bin/sh, not bash: the images most likely to be missing the entry
     // (Alpine/BusyBox) are also the ones without bash, and the script is POSIX.
@@ -375,22 +395,29 @@ async fn ensure_entity(sandbox: &impl SandboxExecutor, entity: ProvisionEntity<'
         .await;
     match result {
         Ok(output) if output.exit_code == 0 => Ok(()),
-        Ok(output) => {
+        // An image with no account-management tooling built fine before this
+        // provisioning existed, so it keeps building; only envd calls that
+        // resolve the default user will fail at runtime.
+        Ok(output) if output.exit_code == PROVISION_MISSING_TOOLING_EXIT => {
             warn!(
                 entity = name,
                 kind,
-                exit_code = output.exit_code,
-                "template default {kind} is missing and could not be created; \
-                 envd operations that resolve it will fail at runtime{}",
-                command_output_suffix(&output.stdout, &output.stderr)
+                "image has neither {create_bin} nor {fallback_bin}; template default {kind} \
+                 left unprovisioned, and envd operations that resolve it will fail at runtime"
             );
             Ok(())
         }
-        // A nonzero exit means the image cannot host the entry (no
-        // useradd/groupadd tooling) — that image built fine before
-        // provisioning existed, so it stays a warning. An executor error is
-        // different: envd unreachable, sandbox gone — those must fail the
-        // build.
+        // A present tool that fails (permission denied, read-only filesystem,
+        // corrupt passwd database) leaves the template with a default identity
+        // known not to resolve — fail the build now rather than at every later
+        // SDK call against the published template.
+        Ok(output) => bail!(
+            "failed to provision template default {kind} {name}: exit status {}{}",
+            output.exit_code,
+            command_output_suffix(&output.stdout, &output.stderr)
+        ),
+        // Executor errors are infrastructure failures: envd unreachable,
+        // sandbox gone — those must fail the build too.
         Err(error) => Err(error).with_context(|| format!("provision template default {kind}")),
     }
 }
@@ -593,7 +620,10 @@ mod tests {
     use anyhow::{anyhow, Result};
     use async_trait::async_trait;
 
-    use super::{ensure_default_user, prepare_startup, run_ready_command, PROVISION_TIMEOUT};
+    use super::{
+        ensure_default_user, prepare_startup, run_ready_command, PROVISION_MISSING_TOOLING_EXIT,
+        PROVISION_TIMEOUT,
+    };
     use crate::sandbox::{Executor, ProcessHandle, ProcessOpts, ProcessOutput, SandboxExecutor};
     use crate::snapshot::{CommandContext, StartupCommand};
 
@@ -866,13 +896,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_user_provisioning_failure_warns_but_keeps_the_build() {
+    async fn default_user_provisioning_without_tooling_warns_but_keeps_the_build() {
         // An image without useradd/adduser built fine before provisioning
-        // existed; a failed creation must not turn it into a build failure.
-        let sandbox = ScriptRecordingSandbox::with_exit_code(127);
+        // existed; missing tooling must not turn it into a build failure.
+        let sandbox = ScriptRecordingSandbox::with_exit_code(PROVISION_MISSING_TOOLING_EXIT);
         ensure_default_user(&sandbox, &context_with_user(Some("user")))
             .await
-            .expect("provisioning failure should not fail the build");
+            .expect("missing tooling should not fail the build");
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_tool_failure_fails_the_build() {
+        // A present tool that fails (permission denied, read-only filesystem)
+        // leaves the template's default identity unresolvable — that must
+        // surface at build time, not at every later SDK call.
+        let sandbox = ScriptRecordingSandbox::with_exit_code(1);
+        ensure_default_user(&sandbox, &context_with_user(Some("user")))
+            .await
+            .expect_err("a failing creation tool must fail the build");
     }
 
     #[tokio::test]

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -277,7 +277,8 @@ impl TemplateBuildRunner {
 /// entry), and an image where the account cannot be created (no useradd or
 /// adduser) keeps building with a warning rather than failing: such an image
 /// worked before this provisioning existed, and only envd calls that resolve
-/// the default user will fail.
+/// the default user will fail. Executor errors (envd unreachable, sandbox
+/// gone) are not downgraded — they fail the build.
 async fn ensure_default_user(
     sandbox: &impl SandboxExecutor,
     build_context: &CommandContext,
@@ -292,6 +293,19 @@ async fn ensure_default_user(
         || account == "root"
         || account.chars().all(|c| c.is_ascii_digit())
     {
+        return Ok(());
+    }
+    // Only provision names that are plausibly Unix accounts; anything else
+    // (e.g. a value starting with "-") would be misparsed as options by the
+    // tools below, so leave it alone.
+    let mut chars = account.chars();
+    let valid_name = matches!(chars.next(), Some(c) if c.is_ascii_alphanumeric() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-');
+    if !valid_name {
+        warn!(
+            user = account,
+            "template default user is not a valid account name; leaving it as-is"
+        );
         return Ok(());
     }
 
@@ -316,15 +330,11 @@ async fn ensure_default_user(
             );
             Ok(())
         }
-        Err(error) => {
-            warn!(
-                user = account,
-                error = %format_args!("{error:#}"),
-                "template default user is missing and could not be created; \
-                 envd operations that resolve this user will fail at runtime"
-            );
-            Ok(())
-        }
+        // A nonzero exit means the image cannot host the account (no
+        // useradd/adduser) — that image built fine before provisioning
+        // existed, so it stays a warning. An executor error is different:
+        // envd unreachable, sandbox gone — those must fail the build.
+        Err(error) => Err(error).context("provision template default user"),
     }
 }
 
@@ -713,6 +723,47 @@ mod tests {
         assert_eq!(scripts.len(), 1);
         assert!(scripts[0].contains("useradd -m app"));
         assert!(!scripts[0].contains("staff"));
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_skips_invalid_account_names() {
+        let sandbox = ScriptRecordingSandbox::with_exit_code(0);
+        ensure_default_user(&sandbox, &context_with_user(Some("-u")))
+            .await
+            .unwrap();
+        assert!(sandbox.scripts().is_empty());
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_propagates_executor_errors() {
+        struct BrokenSandbox;
+
+        #[async_trait(?Send)]
+        impl SandboxExecutor for BrokenSandbox {
+            fn executor(&self) -> Result<Executor<'_>> {
+                Err(anyhow!("not used"))
+            }
+            async fn run_command_with_opts(
+                &self,
+                _cmd: &str,
+                _args: &[&str],
+                _opts: &ProcessOpts,
+            ) -> Result<ProcessOutput> {
+                Err(anyhow!("envd unreachable"))
+            }
+            async fn start_process(
+                &self,
+                _cmd: &str,
+                _args: &[&str],
+                _opts: &ProcessOpts,
+            ) -> Result<ProcessHandle> {
+                Err(anyhow!("not used"))
+            }
+        }
+
+        ensure_default_user(&BrokenSandbox, &context_with_user(Some("user")))
+            .await
+            .expect_err("infrastructure failures must fail the build");
     }
 
     #[tokio::test]

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -299,8 +299,10 @@ async fn ensure_default_user(
     let script = format!(
         "id -u {quoted} >/dev/null 2>&1 || useradd -m {quoted} 2>/dev/null || adduser -D {quoted}"
     );
+    // /bin/sh, not bash: the images most likely to be missing the account
+    // (Alpine/BusyBox) are also the ones without bash, and the script is POSIX.
     let result = sandbox
-        .run_command_with_opts("/bin/bash", &["-lc", &script], &ProcessOpts::default())
+        .run_command_with_opts("/bin/sh", &["-c", &script], &ProcessOpts::default())
         .await;
     match result {
         Ok(output) if output.exit_code == 0 => Ok(()),

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -4,9 +4,10 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use overlaybd::config::UpperMode;
+use shell_util::shell_quote;
 use tempfile::TempDir;
 use tokio::time::Instant;
-use tracing::{debug, Span};
+use tracing::{debug, warn, Span};
 
 use super::build_spec::TemplateBuildStep;
 use super::errors::{command_output_suffix, TemplateBuildFailure};
@@ -222,6 +223,7 @@ impl TemplateBuildRunner {
                         let build_context = step_executor
                             .execute(&sandbox, &steps, initial_context)
                             .await?;
+                        ensure_default_user(&sandbox, &build_context).await?;
                         let startup = prepare_startup(startup, override_startup, &build_context);
                         run_startup_commands(&sandbox, startup.as_ref()).await?;
                         let runtime_versions = SnapshotRuntimeVersions::probe(&sandbox).await?;
@@ -256,6 +258,70 @@ impl TemplateBuildRunner {
         match handle.join() {
             Ok(result) => result,
             Err(_) => bail!("snapshot build worker thread panicked"),
+        }
+    }
+}
+
+/// Provision the template's default user when the image does not have it.
+///
+/// envd resolves operations against the template's default user. E2B Cloud
+/// guarantees the account exists through its base images, and the e2b SDK
+/// bakes that convention in: `from_dockerfile` injects `USER user` whenever a
+/// Dockerfile does not set one. Arbitrary OCI images do not ship that
+/// account, so every SDK filesystem call against the resulting sandbox fails
+/// at runtime with envd's "invalid default user". Creating the missing
+/// account at build time aligns template builds with what E2B-compatible
+/// clients assume.
+///
+/// Numeric USER values are left alone (Docker allows a UID with no passwd
+/// entry), and an image where the account cannot be created (no useradd or
+/// adduser) keeps building with a warning rather than failing: such an image
+/// worked before this provisioning existed, and only envd calls that resolve
+/// the default user will fail.
+async fn ensure_default_user(
+    sandbox: &impl SandboxExecutor,
+    build_context: &CommandContext,
+) -> Result<()> {
+    let Some(user) = build_context.user.as_deref() else {
+        return Ok(());
+    };
+    // USER may be "name", "uid", "name:group", or "uid:gid" — the account is
+    // the part before the colon.
+    let account = user.split(':').next().unwrap_or_default().trim();
+    if account.is_empty()
+        || account == "root"
+        || account.chars().all(|c| c.is_ascii_digit())
+    {
+        return Ok(());
+    }
+
+    let quoted = shell_quote(account);
+    let script = format!(
+        "id -u {quoted} >/dev/null 2>&1 || useradd -m {quoted} 2>/dev/null || adduser -D {quoted}"
+    );
+    let result = sandbox
+        .run_command_with_opts("/bin/bash", &["-lc", &script], &ProcessOpts::default())
+        .await;
+    match result {
+        Ok(output) if output.exit_code == 0 => Ok(()),
+        Ok(output) => {
+            warn!(
+                user = account,
+                exit_code = output.exit_code,
+                "template default user is missing and could not be created; \
+                 envd operations that resolve this user will fail at runtime{}",
+                command_output_suffix(&output.stdout, &output.stderr)
+            );
+            Ok(())
+        }
+        Err(error) => {
+            warn!(
+                user = account,
+                error = %format_args!("{error:#}"),
+                "template default user is missing and could not be created; \
+                 envd operations that resolve this user will fail at runtime"
+            );
+            Ok(())
         }
     }
 }
@@ -458,7 +524,7 @@ mod tests {
     use anyhow::{anyhow, Result};
     use async_trait::async_trait;
 
-    use super::{prepare_startup, run_ready_command};
+    use super::{ensure_default_user, prepare_startup, run_ready_command};
     use crate::sandbox::{Executor, ProcessHandle, ProcessOpts, ProcessOutput, SandboxExecutor};
     use crate::snapshot::{CommandContext, StartupCommand};
 
@@ -546,6 +612,115 @@ mod tests {
             startup.context.env_vars.get("BASE").map(String::as_str),
             Some("1")
         );
+    }
+
+    /// Records the shell scripts the runner executes; reports a fixed exit code.
+    struct ScriptRecordingSandbox {
+        scripts: Mutex<Vec<String>>,
+        exit_code: i32,
+    }
+
+    impl ScriptRecordingSandbox {
+        fn with_exit_code(exit_code: i32) -> Self {
+            Self {
+                scripts: Mutex::new(Vec::new()),
+                exit_code,
+            }
+        }
+
+        fn scripts(&self) -> Vec<String> {
+            self.scripts
+                .lock()
+                .expect("scripts mutex should not be poisoned")
+                .clone()
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl SandboxExecutor for ScriptRecordingSandbox {
+        fn executor(&self) -> Result<Executor<'_>> {
+            Err(anyhow!("not used by this test"))
+        }
+
+        async fn run_command_with_opts(
+            &self,
+            _cmd: &str,
+            args: &[&str],
+            _opts: &ProcessOpts,
+        ) -> Result<ProcessOutput> {
+            self.scripts
+                .lock()
+                .expect("scripts mutex should not be poisoned")
+                .push(args.last().unwrap_or(&"").to_string());
+            Ok(ProcessOutput {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: self.exit_code,
+            })
+        }
+
+        async fn start_process(
+            &self,
+            _cmd: &str,
+            _args: &[&str],
+            _opts: &ProcessOpts,
+        ) -> Result<ProcessHandle> {
+            Err(anyhow!("not used by this test"))
+        }
+    }
+
+    fn context_with_user(user: Option<&str>) -> CommandContext {
+        CommandContext::default().with_user(user.map(str::to_string))
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_skips_absent_root_and_numeric_users() {
+        for user in [None, Some("root"), Some("1000"), Some("1000:1000")] {
+            let sandbox = ScriptRecordingSandbox::with_exit_code(0);
+            ensure_default_user(&sandbox, &context_with_user(user))
+                .await
+                .unwrap();
+            assert!(
+                sandbox.scripts().is_empty(),
+                "no provisioning should run for USER {user:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_creates_missing_named_user() {
+        let sandbox = ScriptRecordingSandbox::with_exit_code(0);
+        ensure_default_user(&sandbox, &context_with_user(Some("user")))
+            .await
+            .unwrap();
+        let scripts = sandbox.scripts();
+        assert_eq!(scripts.len(), 1);
+        // shell_quote leaves safe account names bare and quotes the rest.
+        assert!(scripts[0].contains("id -u user"));
+        assert!(scripts[0].contains("useradd -m user"));
+        assert!(scripts[0].contains("adduser -D user"));
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_targets_the_account_before_the_colon() {
+        let sandbox = ScriptRecordingSandbox::with_exit_code(0);
+        ensure_default_user(&sandbox, &context_with_user(Some("app:staff")))
+            .await
+            .unwrap();
+        let scripts = sandbox.scripts();
+        assert_eq!(scripts.len(), 1);
+        assert!(scripts[0].contains("useradd -m app"));
+        assert!(!scripts[0].contains("staff"));
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_failure_warns_but_keeps_the_build() {
+        // An image without useradd/adduser built fine before provisioning
+        // existed; a failed creation must not turn it into a build failure.
+        let sandbox = ScriptRecordingSandbox::with_exit_code(127);
+        ensure_default_user(&sandbox, &context_with_user(Some("user")))
+            .await
+            .expect("provisioning failure should not fail the build");
     }
 
     #[tokio::test]

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -279,6 +279,10 @@ impl TemplateBuildRunner {
 /// worked before this provisioning existed, and only envd calls that resolve
 /// the default user will fail. Executor errors (envd unreachable, sandbox
 /// gone) are not downgraded — they fail the build.
+///
+/// A `USER name:group` value names the account and the group independently
+/// (Docker resolves the two separately and requires no membership), so a
+/// missing named group is provisioned the same way as a missing account.
 async fn ensure_default_user(
     sandbox: &impl SandboxExecutor,
     build_context: &CommandContext,
@@ -286,34 +290,79 @@ async fn ensure_default_user(
     let Some(user) = build_context.user.as_deref() else {
         return Ok(());
     };
-    // USER may be "name", "uid", "name:group", or "uid:gid" — the account is
-    // the part before the colon.
-    let account = user.split(':').next().unwrap_or_default().trim();
-    if account.is_empty()
-        || account == "root"
-        || account.chars().all(|c| c.is_ascii_digit())
-    {
+    // USER may be "name", "uid", "name:group", or "uid:gid".
+    let (account, group) = match user.split_once(':') {
+        Some((account, group)) => (account.trim(), Some(group.trim())),
+        None => (user.trim(), None),
+    };
+
+    // The group first: if a future change binds the account to it (useradd
+    // -g), the group must already exist.
+    if let Some(group) = group {
+        ensure_entity(
+            sandbox,
+            ProvisionEntity {
+                kind: "group",
+                name: group,
+                exists_probe: "getent group",
+                create: "groupadd",
+                create_fallback: "addgroup",
+            },
+        )
+        .await?;
+    }
+    ensure_entity(
+        sandbox,
+        ProvisionEntity {
+            kind: "user",
+            name: account,
+            exists_probe: "id -u",
+            create: "useradd -m",
+            create_fallback: "adduser -D",
+        },
+    )
+    .await
+}
+
+/// One passwd/group entity the template's USER value names.
+struct ProvisionEntity<'a> {
+    kind: &'static str,
+    name: &'a str,
+    exists_probe: &'static str,
+    create: &'static str,
+    create_fallback: &'static str,
+}
+
+async fn ensure_entity(sandbox: &impl SandboxExecutor, entity: ProvisionEntity<'_>) -> Result<()> {
+    let ProvisionEntity {
+        kind,
+        name,
+        exists_probe,
+        create,
+        create_fallback,
+    } = entity;
+    if name.is_empty() || name == "root" || name.chars().all(|c| c.is_ascii_digit()) {
         return Ok(());
     }
-    // Only provision names that are plausibly Unix accounts; anything else
-    // (e.g. a value starting with "-") would be misparsed as options by the
-    // tools below, so leave it alone.
-    let mut chars = account.chars();
+    // Only provision names that are plausibly Unix accounts/groups; anything
+    // else (e.g. a value starting with "-") would be misparsed as options by
+    // the tools below, so leave it alone.
+    let mut chars = name.chars();
     let valid_name = matches!(chars.next(), Some(c) if c.is_ascii_alphanumeric() || c == '_')
         && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-');
     if !valid_name {
         warn!(
-            user = account,
-            "template default user is not a valid account name; leaving it as-is"
+            entity = name,
+            kind, "template default {kind} is not a valid name; leaving it as-is"
         );
         return Ok(());
     }
 
-    let quoted = shell_quote(account);
+    let quoted = shell_quote(name);
     let script = format!(
-        "id -u {quoted} >/dev/null 2>&1 || useradd -m {quoted} 2>/dev/null || adduser -D {quoted}"
+        "{exists_probe} {quoted} >/dev/null 2>&1 || {create} {quoted} 2>/dev/null || {create_fallback} {quoted}"
     );
-    // /bin/sh, not bash: the images most likely to be missing the account
+    // /bin/sh, not bash: the images most likely to be missing the entry
     // (Alpine/BusyBox) are also the ones without bash, and the script is POSIX.
     let result = sandbox
         .run_command_with_opts("/bin/sh", &["-c", &script], &ProcessOpts::default())
@@ -322,19 +371,21 @@ async fn ensure_default_user(
         Ok(output) if output.exit_code == 0 => Ok(()),
         Ok(output) => {
             warn!(
-                user = account,
+                entity = name,
+                kind,
                 exit_code = output.exit_code,
-                "template default user is missing and could not be created; \
-                 envd operations that resolve this user will fail at runtime{}",
+                "template default {kind} is missing and could not be created; \
+                 envd operations that resolve it will fail at runtime{}",
                 command_output_suffix(&output.stdout, &output.stderr)
             );
             Ok(())
         }
-        // A nonzero exit means the image cannot host the account (no
-        // useradd/adduser) — that image built fine before provisioning
-        // existed, so it stays a warning. An executor error is different:
-        // envd unreachable, sandbox gone — those must fail the build.
-        Err(error) => Err(error).context("provision template default user"),
+        // A nonzero exit means the image cannot host the entry (no
+        // useradd/groupadd tooling) — that image built fine before
+        // provisioning existed, so it stays a warning. An executor error is
+        // different: envd unreachable, sandbox gone — those must fail the
+        // build.
+        Err(error) => Err(error).with_context(|| format!("provision template default {kind}")),
     }
 }
 
@@ -714,15 +765,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_user_provisioning_targets_the_account_before_the_colon() {
+    async fn default_user_provisioning_creates_the_named_group_too() {
         let sandbox = ScriptRecordingSandbox::with_exit_code(0);
         ensure_default_user(&sandbox, &context_with_user(Some("app:staff")))
             .await
             .unwrap();
         let scripts = sandbox.scripts();
+        assert_eq!(scripts.len(), 2);
+        // The group is provisioned first so a future account→group binding
+        // would find it, with the same probe-then-create fallbacks.
+        assert!(scripts[0].contains("getent group staff"));
+        assert!(scripts[0].contains("groupadd staff"));
+        assert!(scripts[0].contains("addgroup staff"));
+        assert!(scripts[1].contains("useradd -m app"));
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_leaves_numeric_gids_alone() {
+        let sandbox = ScriptRecordingSandbox::with_exit_code(0);
+        ensure_default_user(&sandbox, &context_with_user(Some("app:1000")))
+            .await
+            .unwrap();
+        let scripts = sandbox.scripts();
         assert_eq!(scripts.len(), 1);
         assert!(scripts[0].contains("useradd -m app"));
-        assert!(!scripts[0].contains("staff"));
+    }
+
+    #[tokio::test]
+    async fn default_user_provisioning_skips_invalid_group_names() {
+        let sandbox = ScriptRecordingSandbox::with_exit_code(0);
+        ensure_default_user(&sandbox, &context_with_user(Some("app:-g")))
+            .await
+            .unwrap();
+        let scripts = sandbox.scripts();
+        assert_eq!(scripts.len(), 1);
+        assert!(scripts[0].contains("useradd -m app"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Background

We work on [miles](https://github.com/radixark/miles), an RL training framework, and are integrating AgentENV as a sandbox backend for agentic RL environments through its E2B-compatible API. Running Dockerfile-defined task suites (Harbor tasks) against an AgentENV server via the stock e2b Python SDK, sandboxes came up but every SDK filesystem call failed with:

```
e2b.exceptions.AuthenticationException: invalid default user: 'user'
```

## Problem

envd resolves SDK operations against the template's default user. E2B Cloud guarantees that account exists through its base images, and the e2b SDK bakes the convention in: `from_dockerfile` injects `USER user` whenever a Dockerfile does not set one (`dockerfile_parser.py`, "Set the user and workdir to the E2B defaults"). Templates built from arbitrary OCI images do not ship that account — `ubuntu:24.04` has no `user` — so the injected default breaks every envd operation that resolves it at runtime.

The chain on the AgentENV side: the template's user metadata lands in `config.common.default_user` (`src/sandbox/firecracker/factory.rs`) and is handed to envd at init; envd then rejects operations because the account does not exist in the guest (`e2b-dev/infra`, `packages/envd/internal/permissions/authenticate.go`).

## Fix

Provision the missing account inside the build sandbox after the build steps finish:

```
id -u <user> || useradd -m <user> || adduser -D <user>
```

covering GNU and BusyBox userlands. Deliberate scoping:

- **Numeric `USER` values are left alone** — Docker allows a UID with no passwd entry.
- **`user:group` forms target the account before the colon.**
- **Failure to create is a warning, not a build failure** — an image without `useradd`/`adduser` built fine before this provisioning existed; only envd calls that resolve the default user will fail, exactly as today.

Alternatives considered: patching envd to fall back to root when the default user is missing (touches the vendored `e2b-dev/infra` build via `tools-image/`, and loosens envd's contract for every deployment), or validating at build submission (breaks previously-working builds). Creating the account aligns AgentENV templates with what E2B-compatible clients already assume; happy to rework toward another layer if you prefer.

## Validation

- `cargo test --lib template` — 35 passed (new: provisioning skips absent/root/numeric users, creates missing named users, targets the account before the colon, and a failed creation warns without failing the build).
- E2E: rebuilt `aenv-server` with this fix and re-ran a previously failing Harbor task (`FROM ubuntu:24.04`, no `USER` instruction, SDK filesystem uploads/downloads) through `harbor run -e e2b` against the patched server: the previously failing trial now passes end-to-end (verifier reward 1.0). Validated together with #66 on the same rebuilt server; each fix addresses an independent failure the task hits in sequence.
