### PR TITLE
[1/6] fix(api): return the JSON error envelope for unmatched routes

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -224,7 +224,18 @@ where
     I: AsRef<ApiImpl> + Send + Sync,
 {
     if !has_routing_header(request.headers()) {
-        return StatusCode::NOT_FOUND.into_response();
+        // Unmatched control-plane route: return the API error envelope so
+        // JSON clients surface "route not found" instead of failing to parse
+        // an empty 404 body.
+        let error = agentenv_http_server::models::Error::new(
+            404,
+            format!(
+                "route not found: {} {}",
+                request.method(),
+                request.uri().path()
+            ),
+        );
+        return (StatusCode::NOT_FOUND, axum::Json(error)).into_response();
     }
     let forward_path = request.uri().path().to_owned();
     with_route_source(
@@ -2120,6 +2131,24 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let content_type = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_owned();
+        assert!(
+            content_type.starts_with("application/json"),
+            "unexpected content-type: {content_type}"
+        );
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["code"], 404);
+        let message = payload["message"].as_str().unwrap();
+        assert!(
+            message.contains("route not found: GET /nonexistent/path"),
+            "unexpected message: {message}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Return the standard JSON API error envelope for unmatched control-plane routes instead of an empty 404 response. The focused proxy test verifies the status, content type, error code, and route-specific message.

| Layer | PR | Branch | Scope |
|---|---|---|---|
| **1/6** | **[#69](https://github.com/kvcache-ai/AgentENV/pull/69)** | **`e2b-build/01-error-envelope`** | **JSON 404 envelope for unmatched routes** |
| 2/6 | [#70](https://github.com/kvcache-ai/AgentENV/pull/70) | `e2b-build/02-alias-rebuild` | Alias rebuild semantics |
| 3/6 | [#71](https://github.com/kvcache-ai/AgentENV/pull/71) | `e2b-build/03-build-file-store` | Build-context archive store |
| 4/6 | [#72](https://github.com/kvcache-ai/AgentENV/pull/72) | `e2b-build/04-upload-api` | Upload API and configuration |
| 5/6 | [#73](https://github.com/kvcache-ai/AgentENV/pull/73) | `e2b-build/05-copy-plan` | Host-side COPY planning |
| 6/6 | [#74](https://github.com/kvcache-ai/AgentENV/pull/74) | `e2b-build/06-copy-exec` | COPY/ADD execution and documentation |

## Why

The maintainer asked that the full change in #28 be split into smaller reviewable PRs. This is layer 1 of that six-PR stack and gives JSON clients a parseable error for unknown API routes.

## Related issue

Related: #28

#28 remains the full reference PR containing the design discussion, prior review history, and two-node E2E evidence.

## Scope and non-goals

This layer changes only `src/api/proxy.rs`: the unmatched-route fallback and its test. It preserves the connection-isolation fix already on `main`. It does not include template storage, upload, COPY planning, or execution changes; those are layers 2–6.

## Design and behavior changes

Requests without sandbox routing headers that miss all control-plane routes now return HTTP 404 with the generated API `Error` JSON model. Proxied sandbox routing and connection-generation isolation are unchanged.

## Compatibility and operations

- Public API or generated protocol: Unmatched routes now have a JSON body; the status remains 404.
- Configuration or defaults: N/A; no configuration changes.
- Snapshot manifest, artifact layout, or storage format: N/A; no storage changes.
- Upgrade and rollback: Compatible response-body improvement; rollback restores the empty 404 body.
- Host requirements, permissions, ports, or dependencies: N/A; no new requirements.

## Validation

- [x] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p agentenv --lib`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
make fmt
cargo clippy --workspace --all-targets --all-features -- -D warnings
TMPDIR=/dev/shm/agentenv-e2b-tests cargo test -p agentenv --lib
```

All listed commands pass in the Linux verification environment. The tmpfs `TMPDIR` avoids a pre-existing `ETXTBSY` from devmachine's shared `/tmp` in an unrelated credential-helper test. The proxy unit test directly covers this layer. The full #28 two-node E2E run is retained as reference evidence, though this response-only layer does not require a multi-node scenario.

Skipped checks and reasons: integration tests, service tests, code generation, docs checks, and benchmarks are outside this layer's scope.

## Risks and reviewer notes

The behavior change is intentionally limited to requests that have no sandbox routing header and miss every control-plane route. Review the single commit on this branch.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
