### PR TITLE
[1/4] feat(snapshot): template build-context archive store (posixfs + oss)

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -165,6 +165,8 @@ p2p_enabled = true
 # bucket = "agentenv-oss-validation"
 # region = "cn-beijing"
 # prefix = "validation/"
+# Configure a seven-day bucket lifecycle expiration rule for
+# "<prefix>/template-build-files/"; AgentENV does not provision this rule.
 # credential_process = ""
 # cache_max_size_gb = 10
 

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -412,6 +412,7 @@ Notes:
 - `credential_process` and static access key settings are mutually exclusive in practice; when `credential_process` is set, the backend ignores static credential fields.
 - `credential_process` should be written as a portable argv-style command line. Avoid `$VAR`, backticks, `$(...)`, pipes, and shell builtins.
 - Although the config section is still named `oss`, the runtime path is implemented via a shared S3-compatible client, so `region` must be configured.
+- Configure a bucket lifecycle expiration rule for `<prefix>/template-build-files/`. AgentENV does not provision or validate this rule. Seven days matches the POSIX cache retention and covers the maximum upload-link TTL; without the rule, abandoned upload grants and cached build archives remain until removed manually.
 
 Other path override:
 

--- a/src/snapshot/image_export/service.rs
+++ b/src/snapshot/image_export/service.rs
@@ -67,6 +67,7 @@ impl SnapshotImageService {
                     let repository = Arc::new(posixfs::PosixFsSnapshotRepository::new(
                         Arc::new(posixfs::PosixFsCatalogStore::new(root.clone())),
                         Arc::new(posixfs::PosixFsArtifactStore::new(root.clone())),
+                        posixfs::PosixFsTemplateBuildFileStore::new(&root),
                     ));
                     (repository, ManagedLayerLocator::PosixFs { root })
                 }
@@ -447,6 +448,7 @@ mod tests {
         let repository = posixfs::PosixFsSnapshotRepository::new(
             Arc::new(posixfs::PosixFsCatalogStore::new(root.clone())),
             Arc::new(posixfs::PosixFsArtifactStore::new(root.clone())),
+            posixfs::PosixFsTemplateBuildFileStore::new(&root),
         );
         let uncommitted =
             SnapshotRecord::template_waiting(SnapshotId::generate(), None, Default::default());

--- a/src/snapshot/manager.rs
+++ b/src/snapshot/manager.rs
@@ -84,6 +84,14 @@ impl SnapshotManager {
         self.repository.create(record).await
     }
 
+    /// Returns the shared build-context archive store, when the configured
+    /// repository backend provides one.
+    pub fn template_build_files(
+        &self,
+    ) -> Option<Arc<dyn crate::snapshot::repository::TemplateBuildFileStore>> {
+        self.repository.template_build_files()
+    }
+
     #[tracing::instrument(skip(self, metadata, manifest), fields(snapshot_id = %metadata.id))]
     pub async fn publish(
         &self,

--- a/src/snapshot/repository/backends/oss/build_files.rs
+++ b/src/snapshot/repository/backends/oss/build_files.rs
@@ -1,0 +1,169 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::client::OssClient;
+use crate::snapshot::repository::build_files::{
+    generate_upload_token, is_valid_build_files_hash, is_valid_upload_token,
+    TemplateBuildFileStore, TemplateBuildUploadGrant,
+};
+use crate::snapshot::repository::{RepositoryError, RepositoryResult};
+
+const BUILD_FILES_PREFIX: &str = "template-build-files";
+
+/// Build-context archive store backed by the OSS repository bucket.
+///
+/// Layout: `template-build-files/{hash}.tar` plus durable bearer grants under
+/// `template-build-files/upload-grants/`. Retention is delegated to bucket
+/// lifecycle rules; archives are cache entries the SDK re-uploads when absent.
+pub(crate) struct OssTemplateBuildFileStore {
+    client: Arc<OssClient>,
+}
+
+impl OssTemplateBuildFileStore {
+    pub(crate) fn new(client: Arc<OssClient>) -> Arc<Self> {
+        Arc::new(Self { client })
+    }
+
+    fn archive_key(hash: &str) -> RepositoryResult<String> {
+        if !is_valid_build_files_hash(hash) {
+            return Err(RepositoryError::InvalidRequest {
+                reason: format!("invalid build files hash '{hash}'"),
+            });
+        }
+        Ok(format!("{BUILD_FILES_PREFIX}/{hash}.tar"))
+    }
+
+    fn grant_key(token: &str) -> Option<String> {
+        is_valid_upload_token(token)
+            .then(|| format!("{BUILD_FILES_PREFIX}/upload-grants/{token}.json"))
+    }
+
+    /// Reads a grant record, mapping an absent object to `None`.
+    async fn read_grant(&self, key: &str) -> RepositoryResult<Option<TemplateBuildUploadGrant>> {
+        let bytes = match self.client.get_bytes(key).await {
+            Ok(bytes) => bytes,
+            Err(error) if OssClient::is_not_found_error(&error) => return Ok(None),
+            Err(error) => return Err(RepositoryError::backend("read upload grant", error)),
+        };
+        serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|error| RepositoryError::backend("parse upload grant", error))
+    }
+}
+
+#[async_trait]
+impl TemplateBuildFileStore for OssTemplateBuildFileStore {
+    async fn exists(&self, hash: &str) -> RepositoryResult<bool> {
+        let key = Self::archive_key(hash)?;
+        self.client
+            .exists(&key)
+            .await
+            .map_err(|error| RepositoryError::backend("check build archive", error))
+    }
+
+    async fn import(&self, hash: &str, staged: &Path) -> RepositoryResult<()> {
+        let key = Self::archive_key(hash)?;
+        // Archives are immutable so a repeat upload cannot change what an
+        // in-flight build reads. This fast path is not atomic against a
+        // concurrent import: the loser's bytes are dropped, and since the hash
+        // is a caller-supplied cache key rather than a verified digest, which
+        // racing upload wins is undefined — first-write-wins stability, not
+        // content authenticity.
+        if self
+            .client
+            .exists(&key)
+            .await
+            .map_err(|error| RepositoryError::backend("check build archive", error))?
+        {
+            return Ok(());
+        }
+        self.client
+            .put_file(&key, staged)
+            .await
+            .map_err(|error| RepositoryError::backend("upload build archive", error))
+    }
+
+    async fn materialize(
+        &self,
+        hash: &str,
+        scratch_dir: &Path,
+    ) -> RepositoryResult<Option<PathBuf>> {
+        let key = Self::archive_key(hash)?;
+        let dest = scratch_dir.join(format!("{hash}.tar"));
+        match self.client.get_to_file(&key, &dest).await {
+            Ok(_) => Ok(Some(dest)),
+            Err(error) if OssClient::is_not_found_error(&error) => Ok(None),
+            Err(error) => Err(RepositoryError::backend("download build archive", error)),
+        }
+    }
+
+    async fn create_upload_grant(
+        &self,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+    ) -> RepositoryResult<String> {
+        let token = generate_upload_token();
+        let key = Self::grant_key(&token).expect("generated token is valid");
+        let grant = serde_json::to_vec(&TemplateBuildUploadGrant::new(
+            template_id,
+            hash,
+            expires_unix,
+        ))
+        .map_err(|error| RepositoryError::backend("serialize upload grant", error))?;
+        self.client
+            .put_bytes(&key, grant)
+            .await
+            .map_err(|error| RepositoryError::backend("write upload grant", error))?;
+        Ok(token)
+    }
+
+    async fn verify_upload_grant(
+        &self,
+        token: &str,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+        now_unix: i64,
+    ) -> RepositoryResult<bool> {
+        let Some(key) = Self::grant_key(token) else {
+            return Ok(false);
+        };
+        // Deliberately does not delete the object: verification must leave the
+        // upload URL usable for a retry.
+        let Some(grant) = self.read_grant(&key).await? else {
+            return Ok(false);
+        };
+        Ok(grant.authorizes(template_id, hash, expires_unix, now_unix))
+    }
+
+    async fn claim_upload_grant(
+        &self,
+        token: &str,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+        now_unix: i64,
+    ) -> RepositoryResult<bool> {
+        let Some(key) = Self::grant_key(token) else {
+            return Ok(false);
+        };
+        let Some(grant) = self.read_grant(&key).await? else {
+            return Ok(false);
+        };
+        if !grant.authorizes(template_id, hash, expires_unix, now_unix) {
+            return Ok(false);
+        }
+        // Consume the grant so the upload URL cannot be replayed. S3-compatible
+        // stores offer no conditional delete, so simultaneous replays of one
+        // token can both observe the grant; archives are immutable, which is
+        // what keeps that from mattering.
+        self.client
+            .delete(&key)
+            .await
+            .map_err(|error| RepositoryError::backend("consume upload grant", error))?;
+        Ok(true)
+    }
+}

--- a/src/snapshot/repository/backends/oss/build_files.rs
+++ b/src/snapshot/repository/backends/oss/build_files.rs
@@ -15,8 +15,11 @@ const BUILD_FILES_PREFIX: &str = "template-build-files";
 /// Build-context archive store backed by the OSS repository bucket.
 ///
 /// Layout: `template-build-files/{hash}.tar` plus durable bearer grants under
-/// `template-build-files/upload-grants/`. Retention is delegated to bucket
-/// lifecycle rules; archives are cache entries the SDK re-uploads when absent.
+/// `template-build-files/upload-grants/`. Operators must configure a bucket
+/// lifecycle expiration rule for this prefix; AgentENV does not provision or
+/// validate one. A seven-day expiration matches the POSIX cache retention and
+/// safely covers the maximum supported upload-link TTL. Archives are cache
+/// entries the SDK re-uploads when absent.
 pub(crate) struct OssTemplateBuildFileStore {
     client: Arc<OssClient>,
 }

--- a/src/snapshot/repository/backends/oss/build_files.rs
+++ b/src/snapshot/repository/backends/oss/build_files.rs
@@ -65,12 +65,10 @@ impl TemplateBuildFileStore for OssTemplateBuildFileStore {
 
     async fn import(&self, hash: &str, staged: &Path) -> RepositoryResult<()> {
         let key = Self::archive_key(hash)?;
-        // Archives are immutable so a repeat upload cannot change what an
-        // in-flight build reads. This fast path is not atomic against a
-        // concurrent import: the loser's bytes are dropped, and since the hash
-        // is a caller-supplied cache key rather than a verified digest, which
-        // racing upload wins is undefined — first-write-wins stability, not
-        // content authenticity.
+        // This is a bandwidth-saving fast path, not an atomic check-and-create:
+        // concurrent uploads may both complete. Each object publication is
+        // atomic, and the upload protocol treats repeated uploads for one hash
+        // as equivalent build input.
         if self
             .client
             .exists(&key)
@@ -156,10 +154,10 @@ impl TemplateBuildFileStore for OssTemplateBuildFileStore {
         if !grant.authorizes(template_id, hash, expires_unix, now_unix) {
             return Ok(false);
         }
-        // Consume the grant so the upload URL cannot be replayed. S3-compatible
-        // stores offer no conditional delete, so simultaneous replays of one
-        // token can both observe the grant; archives are immutable, which is
-        // what keeps that from mattering.
+        // Consume the grant so the upload URL cannot normally be replayed.
+        // S3-compatible stores offer no conditional delete, so simultaneous
+        // replays of one token can both observe the grant and publish the same
+        // logical build input.
         self.client
             .delete(&key)
             .await

--- a/src/snapshot/repository/backends/oss/mod.rs
+++ b/src/snapshot/repository/backends/oss/mod.rs
@@ -1,3 +1,4 @@
+mod build_files;
 mod client;
 mod config;
 mod layout;

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -42,6 +42,7 @@ pub(crate) struct OssSnapshotRepository {
     client: Arc<OssClient>,
     snapshot_image_storage: SnapshotImageStoragePolicy,
     acr_exporter: AcrDiskImageExporter,
+    build_files: Arc<super::build_files::OssTemplateBuildFileStore>,
 }
 
 const MAX_ALIAS_BIND_ATTEMPTS: usize = 5;
@@ -51,10 +52,12 @@ impl OssSnapshotRepository {
         client: Arc<OssClient>,
         snapshot_image_storage: SnapshotImageStoragePolicy,
     ) -> Self {
+        let build_files = super::build_files::OssTemplateBuildFileStore::new(Arc::clone(&client));
         Self {
             client,
             snapshot_image_storage,
             acr_exporter: AcrDiskImageExporter::new(),
+            build_files,
         }
     }
 
@@ -148,6 +151,15 @@ fn fallback_to_object_storage_would_mix_sources(
 
 #[async_trait]
 impl SnapshotRepository for OssSnapshotRepository {
+    fn template_build_files(
+        &self,
+    ) -> Option<Arc<dyn crate::snapshot::repository::TemplateBuildFileStore>> {
+        Some(Arc::clone(&self.build_files)
+            as Arc<
+                dyn crate::snapshot::repository::TemplateBuildFileStore,
+            >)
+    }
+
     async fn create(&self, record: SnapshotRecord) -> RepositoryResult<SnapshotRecord> {
         if !matches!(record.source, SnapshotSource::Template { .. }) {
             return Err(RepositoryError::InvalidRequest {

--- a/src/snapshot/repository/backends/posixfs/backend.rs
+++ b/src/snapshot/repository/backends/posixfs/backend.rs
@@ -7,11 +7,13 @@ use tokio::task;
 
 use super::super::shared_runtime_cache_root;
 use super::artifacts::{CollectedBuiltArtifacts, PosixFsArtifactStore};
+use super::build_files::PosixFsTemplateBuildFileStore;
 use super::catalog::PosixFsCatalogStore;
 use super::runtime::PosixFsRuntimeResolver;
 use crate::image::cache::{local_image_services_from_global_config, OverlaybdLayerStore};
 use crate::sandbox::FirecrackerSnapshotManifest;
 use crate::snapshot::artifact_cache::LocalArtifactCache;
+use crate::snapshot::repository::build_files::TemplateBuildFileStore;
 use crate::snapshot::repository::interfaces::{SnapshotRepository, SnapshotRuntimeResolver};
 use crate::snapshot::repository::{RepositoryError, RepositoryResult, SnapshotListFilter};
 use crate::snapshot::types::{
@@ -72,9 +74,11 @@ impl PosixFsBackend {
         let runtime_cache_root = runtime_cache_root.unwrap_or_else(|| cache_root.join("runtime"));
         let catalog_store = Arc::new(PosixFsCatalogStore::new(root.clone()));
         let artifact_store = Arc::new(PosixFsArtifactStore::new(root.clone()));
+        let build_files = PosixFsTemplateBuildFileStore::new(&root);
         let repository: Arc<dyn SnapshotRepository> = Arc::new(PosixFsSnapshotRepository::new(
             catalog_store,
             artifact_store,
+            build_files,
         ));
         let runtime_resolver: Arc<dyn SnapshotRuntimeResolver> = Arc::new(
             PosixFsRuntimeResolver::new(root, runtime_cache_root, store, cache),
@@ -111,16 +115,19 @@ impl PosixFsBackend {
 pub(crate) struct PosixFsSnapshotRepository {
     catalog_store: Arc<PosixFsCatalogStore>,
     artifact_store: Arc<PosixFsArtifactStore>,
+    build_files: Arc<PosixFsTemplateBuildFileStore>,
 }
 
 impl PosixFsSnapshotRepository {
     pub(crate) fn new(
         catalog_store: Arc<PosixFsCatalogStore>,
         artifact_store: Arc<PosixFsArtifactStore>,
+        build_files: Arc<PosixFsTemplateBuildFileStore>,
     ) -> Self {
         Self {
             catalog_store,
             artifact_store,
+            build_files,
         }
     }
 
@@ -236,6 +243,10 @@ impl SnapshotRepository for PosixFsSnapshotRepository {
             repository.create_sync(record)
         })
         .await
+    }
+
+    fn template_build_files(&self) -> Option<Arc<dyn TemplateBuildFileStore>> {
+        Some(Arc::clone(&self.build_files) as Arc<dyn TemplateBuildFileStore>)
     }
 
     async fn publish(
@@ -400,6 +411,7 @@ mod tests {
         PosixFsSnapshotRepository::new(
             Arc::new(PosixFsCatalogStore::new(root.to_path_buf())),
             Arc::new(PosixFsArtifactStore::new(root.to_path_buf())),
+            super::super::build_files::PosixFsTemplateBuildFileStore::new(root),
         )
     }
 

--- a/src/snapshot/repository/backends/posixfs/build_files.rs
+++ b/src/snapshot/repository/backends/posixfs/build_files.rs
@@ -1,0 +1,726 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use async_trait::async_trait;
+use tokio::task;
+use tracing::{debug, warn};
+
+use crate::snapshot::repository::build_files::{
+    generate_upload_token, is_valid_build_files_hash, is_valid_upload_token,
+    TemplateBuildFileStore, TemplateBuildUploadGrant,
+};
+use crate::snapshot::repository::{RepositoryError, RepositoryResult};
+
+/// How long imported build-context archives and upload grants are retained.
+/// Archives are cache entries keyed by content hash; the SDK re-uploads any
+/// archive that has been pruned, so expiry only costs one extra upload.
+/// Grants expire after `template_build.files_url_ttl_secs` anyway, so this
+/// only bounds how long the spent grant files linger on disk.
+const BUILD_FILE_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+const GRANTS_DIR_NAME: &str = "upload-grants";
+
+/// Build-context archive store rooted on the shared POSIX repository.
+///
+/// Layout: `{repository_root}/template-build-files/{hash}.tar` plus durable
+/// upload grants under `upload-grants/`. Both live on the shared filesystem,
+/// so every node observes the same archives and verifies the same upload URLs.
+pub(crate) struct PosixFsTemplateBuildFileStore {
+    root: PathBuf,
+}
+
+impl PosixFsTemplateBuildFileStore {
+    pub(crate) fn new(repository_root: &Path) -> Arc<Self> {
+        Arc::new(Self {
+            root: repository_root.join("template-build-files"),
+        })
+    }
+
+    fn archive_path(&self, hash: &str) -> RepositoryResult<PathBuf> {
+        if !is_valid_build_files_hash(hash) {
+            return Err(RepositoryError::InvalidRequest {
+                reason: format!("invalid build files hash '{hash}'"),
+            });
+        }
+        Ok(self.root.join(format!("{hash}.tar")))
+    }
+
+    fn ensure_root(root: &Path) -> RepositoryResult<()> {
+        fs::create_dir_all(root).map_err(|error| {
+            RepositoryError::backend(
+                format!("create template build files dir '{}'", root.display()),
+                error,
+            )
+        })
+    }
+
+    /// Removes archives whose modification time is older than the retention
+    /// window. Runs opportunistically on import and scans a bounded number of
+    /// entries per call; failures only log.
+    fn prune_expired(root: &Path) {
+        let cutoff = SystemTime::now() - BUILD_FILE_RETENTION;
+        Self::prune_dir_older_than(root, "tar", cutoff);
+    }
+
+    /// Removes upload grants that have passed their own `expires_unix`. Runs
+    /// opportunistically whenever a new grant is written, so the grants
+    /// directory stays bounded by upload-link traffic; the scan is bounded per
+    /// call and drains the backlog over successive requests, and failures only
+    /// log.
+    ///
+    /// Pruning by the record rather than by mtime keeps grants alive for
+    /// exactly their TTL even when `template_build.files_url_ttl_secs` is
+    /// configured beyond the retention window.
+    fn prune_expired_grants(root: &Path) {
+        let cutoff = SystemTime::now() - BUILD_FILE_RETENTION;
+        let now_unix = chrono::Utc::now().timestamp();
+        Self::prune_dir(&Self::grants_dir(root), "json", |path, modified| {
+            match fs::read(path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<TemplateBuildUploadGrant>(&bytes).ok())
+            {
+                Some(grant) => grant.expires_unix < now_unix,
+                // Unparseable leftovers fall back to the mtime rule.
+                None => modified.is_some_and(|modified| modified < cutoff),
+            }
+        });
+    }
+
+    fn prune_dir_older_than(dir: &Path, extension: &str, cutoff: SystemTime) {
+        Self::prune_dir(dir, extension, |_, modified| {
+            modified.is_some_and(|modified| modified < cutoff)
+        });
+    }
+
+    /// Pruning is opportunistic and bounded: at most `MAX_PRUNE_SCAN` matching
+    /// entries are inspected per call, so the cost a request pays stays
+    /// constant no matter how many records the directory holds. Anything left
+    /// over is reclaimed by later calls.
+    fn prune_dir(
+        dir: &Path,
+        extension: &str,
+        is_expired: impl Fn(&Path, Option<SystemTime>) -> bool,
+    ) {
+        const MAX_PRUNE_SCAN: usize = 256;
+
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        let mut scanned: usize = 0;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_none_or(|ext| ext != extension) {
+                continue;
+            }
+            if scanned >= MAX_PRUNE_SCAN {
+                break;
+            }
+            scanned += 1;
+            let modified = entry
+                .metadata()
+                .and_then(|metadata| metadata.modified())
+                .ok();
+            if is_expired(&path, modified) {
+                if let Err(error) = fs::remove_file(&path) {
+                    warn!(
+                        path = %path.display(),
+                        error = %error,
+                        "failed to prune expired template build file"
+                    );
+                } else {
+                    debug!(path = %path.display(), "pruned expired template build file");
+                }
+            }
+        }
+    }
+
+    fn grants_dir(root: &Path) -> PathBuf {
+        root.join(GRANTS_DIR_NAME)
+    }
+
+    fn grant_path(root: &Path, token: &str) -> Option<PathBuf> {
+        is_valid_upload_token(token).then(|| Self::grants_dir(root).join(format!("{token}.json")))
+    }
+
+    /// Reads a grant record, mapping an absent file to `None`.
+    fn read_grant(path: &Path) -> RepositoryResult<Option<TemplateBuildUploadGrant>> {
+        let bytes = match fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(RepositoryError::backend("read upload grant", error)),
+        };
+        serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|error| RepositoryError::backend("parse upload grant", error))
+    }
+
+    /// Best-effort mtime refresh, so retention means "unused for the window"
+    /// and an archive a build is still reading stays outside the prune
+    /// horizon. Read-only repository mounts must keep working, so failures
+    /// only log.
+    fn touch(path: &Path) {
+        let refreshed = fs::File::options()
+            .write(true)
+            .open(path)
+            .and_then(|file| file.set_times(fs::FileTimes::new().set_modified(SystemTime::now())));
+        if let Err(error) = refreshed {
+            debug!(
+                path = %path.display(),
+                error = %error,
+                "failed to refresh build archive mtime"
+            );
+        }
+    }
+
+    fn write_grant(
+        root: &Path,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+    ) -> RepositoryResult<String> {
+        let grants_dir = Self::grants_dir(root);
+        fs::create_dir_all(&grants_dir).map_err(|error| {
+            RepositoryError::backend(
+                format!("create upload grants dir '{}'", grants_dir.display()),
+                error,
+            )
+        })?;
+        Self::prune_expired_grants(root);
+        let bytes = serde_json::to_vec(&TemplateBuildUploadGrant::new(
+            template_id,
+            hash,
+            expires_unix,
+        ))
+        .map_err(|error| RepositoryError::backend("serialize upload grant", error))?;
+
+        for _ in 0..3 {
+            let token = generate_upload_token();
+            let path = Self::grant_path(root, &token).expect("generated token is valid");
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(mut file) => {
+                    file.write_all(&bytes)
+                        .and_then(|()| file.sync_all())
+                        .map_err(|error| {
+                            let _ = fs::remove_file(&path);
+                            RepositoryError::backend("write upload grant", error)
+                        })?;
+                    return Ok(token);
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(RepositoryError::backend("create upload grant", error)),
+            }
+        }
+        Err(RepositoryError::Backend {
+            message: "failed to allocate a unique upload grant token".to_string(),
+            source: None,
+        })
+    }
+}
+
+#[async_trait]
+impl TemplateBuildFileStore for PosixFsTemplateBuildFileStore {
+    async fn exists(&self, hash: &str) -> RepositoryResult<bool> {
+        let path = self.archive_path(hash)?;
+        task::spawn_blocking(move || -> RepositoryResult<bool> {
+            match fs::metadata(&path) {
+                Ok(_) => Ok(true),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+                Err(error) => Err(RepositoryError::backend(
+                    format!("stat build archive '{}'", path.display()),
+                    error,
+                )),
+            }
+        })
+        .await
+        .map_err(|error| RepositoryError::backend("join build file exists task", error))?
+    }
+
+    async fn import(&self, hash: &str, staged: &Path) -> RepositoryResult<()> {
+        let final_path = self.archive_path(hash)?;
+        let root = self.root.clone();
+        let staged = staged.to_path_buf();
+        task::spawn_blocking(move || -> RepositoryResult<()> {
+            // Archives are immutable: the hash addresses the content, so a
+            // repeat upload cannot change what an in-flight build reads.
+            if final_path.exists() {
+                return Ok(());
+            }
+            Self::ensure_root(&root)?;
+            Self::prune_expired(&root);
+            // Copy into the store filesystem first (the staged file usually
+            // lives on node-local tmp), then link it into place within the
+            // store directory so readers only ever observe complete archives.
+            let store_staged = root.join(format!(".import-{}.tmp", uuid::Uuid::new_v4()));
+            fs::copy(&staged, &store_staged).map_err(|error| {
+                let _ = fs::remove_file(&store_staged);
+                RepositoryError::backend("copy build archive into store", error)
+            })?;
+            // The archive is only ever published once, so its data must reach
+            // stable storage before the name does: a directory entry that
+            // outlives the bytes would pin a truncated archive forever behind
+            // the `exists` fast path.
+            fs::File::open(&store_staged)
+                .and_then(|file| file.sync_all())
+                .map_err(|error| {
+                    let _ = fs::remove_file(&store_staged);
+                    RepositoryError::backend("sync build archive", error)
+                })?;
+            // Link rather than rename so a concurrent import cannot replace an
+            // archive a running build is already reading: the first writer
+            // wins and everyone else observes `AlreadyExists`.
+            let published = match fs::hard_link(&store_staged, &final_path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+                Err(error) => Err(RepositoryError::backend("publish build archive", error)),
+            };
+            if published.is_ok() {
+                // Best effort: filesystems that reject a directory fsync must
+                // keep working, and a lost entry only costs one re-upload.
+                if let Err(error) = fs::File::open(&root).and_then(|dir| dir.sync_all()) {
+                    debug!(
+                        path = %root.display(),
+                        error = %error,
+                        "failed to sync build archive store directory"
+                    );
+                }
+            }
+            let _ = fs::remove_file(&store_staged);
+            published
+        })
+        .await
+        .map_err(|error| RepositoryError::backend("join build file import task", error))?
+    }
+
+    async fn materialize(
+        &self,
+        hash: &str,
+        _scratch_dir: &Path,
+    ) -> RepositoryResult<Option<PathBuf>> {
+        let path = self.archive_path(hash)?;
+        task::spawn_blocking(move || -> RepositoryResult<Option<PathBuf>> {
+            match fs::metadata(&path) {
+                Ok(_) => {
+                    Self::touch(&path);
+                    Ok(Some(path))
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(error) => Err(RepositoryError::backend(
+                    format!("stat build archive '{}'", path.display()),
+                    error,
+                )),
+            }
+        })
+        .await
+        .map_err(|error| RepositoryError::backend("join build file materialize task", error))?
+    }
+
+    async fn create_upload_grant(
+        &self,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+    ) -> RepositoryResult<String> {
+        let root = self.root.clone();
+        let template_id = template_id.to_string();
+        let hash = hash.to_string();
+        task::spawn_blocking(move || Self::write_grant(&root, &template_id, &hash, expires_unix))
+            .await
+            .map_err(|error| RepositoryError::backend("join create upload grant task", error))?
+    }
+
+    async fn verify_upload_grant(
+        &self,
+        token: &str,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+        now_unix: i64,
+    ) -> RepositoryResult<bool> {
+        let Some(path) = Self::grant_path(&self.root, token) else {
+            return Ok(false);
+        };
+        let template_id = template_id.to_string();
+        let hash = hash.to_string();
+        task::spawn_blocking(move || -> RepositoryResult<bool> {
+            // Reads only: the grant file must survive so an upload that fails
+            // before the archive is stored can be retried with the same URL.
+            let Some(grant) = Self::read_grant(&path)? else {
+                return Ok(false);
+            };
+            Ok(grant.authorizes(&template_id, &hash, expires_unix, now_unix))
+        })
+        .await
+        .map_err(|error| RepositoryError::backend("join verify upload grant task", error))?
+    }
+
+    async fn claim_upload_grant(
+        &self,
+        token: &str,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+        now_unix: i64,
+    ) -> RepositoryResult<bool> {
+        let Some(path) = Self::grant_path(&self.root, token) else {
+            return Ok(false);
+        };
+        let template_id = template_id.to_string();
+        let hash = hash.to_string();
+        task::spawn_blocking(move || -> RepositoryResult<bool> {
+            let Some(grant) = Self::read_grant(&path)? else {
+                return Ok(false);
+            };
+            if !grant.authorizes(&template_id, &hash, expires_unix, now_unix) {
+                return Ok(false);
+            }
+            // Consume the grant. `remove_file` succeeds for exactly one
+            // caller, so it is the claim: concurrent replays of the same
+            // token lose the race and are rejected.
+            match fs::remove_file(&path) {
+                Ok(()) => Ok(true),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+                Err(error) => Err(RepositoryError::backend("consume upload grant", error)),
+            }
+        })
+        .await
+        .map_err(|error| RepositoryError::backend("join claim upload grant task", error))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const HASH: &str = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+    fn staged_file(dir: &Path, contents: &[u8]) -> PathBuf {
+        let path = dir.join("staged.tar");
+        fs::write(&path, contents).expect("write staged file");
+        path
+    }
+
+    #[tokio::test]
+    async fn import_then_exists_and_materialize() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+
+        assert!(!store.exists(HASH).await.expect("exists should work"));
+        assert_eq!(
+            store
+                .materialize(HASH, tempdir.path())
+                .await
+                .expect("materialize should work"),
+            None
+        );
+
+        let staged = staged_file(tempdir.path(), b"tar-bytes");
+        store
+            .import(HASH, &staged)
+            .await
+            .expect("import should work");
+
+        assert!(store.exists(HASH).await.expect("exists should work"));
+        let materialized = store
+            .materialize(HASH, tempdir.path())
+            .await
+            .expect("materialize should work")
+            .expect("archive should exist");
+        assert_eq!(
+            fs::read(materialized).expect("read materialized"),
+            b"tar-bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn import_rejects_invalid_hash() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+        let staged = staged_file(tempdir.path(), b"tar-bytes");
+
+        let err = store
+            .import("../escape", &staged)
+            .await
+            .expect_err("invalid hash should fail");
+        assert!(matches!(err, RepositoryError::InvalidRequest { .. }));
+    }
+
+    #[tokio::test]
+    async fn writing_a_grant_prunes_expired_grant_files() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+
+        let fresh_token = store
+            .create_upload_grant("template", HASH, i64::MAX)
+            .await
+            .expect("fresh grant should be created");
+
+        // Plant a grant file that predates the retention window.
+        let grants_dir = tempdir
+            .path()
+            .join("template-build-files")
+            .join("upload-grants");
+        let stale_path = grants_dir.join(format!("{}.json", generate_upload_token()));
+        fs::write(&stale_path, b"{}").expect("write stale grant");
+        let stale_mtime = SystemTime::now() - BUILD_FILE_RETENTION - Duration::from_secs(60);
+        let stale_file = fs::File::options()
+            .write(true)
+            .open(&stale_path)
+            .expect("open stale grant");
+        stale_file
+            .set_times(fs::FileTimes::new().set_modified(stale_mtime))
+            .expect("set stale mtime");
+        drop(stale_file);
+
+        store
+            .create_upload_grant("template", HASH, i64::MAX)
+            .await
+            .expect("new grant should be created");
+
+        assert!(!stale_path.exists(), "expired grant file should be pruned");
+        assert!(
+            store
+                .claim_upload_grant(&fresh_token, "template", HASH, i64::MAX, 0)
+                .await
+                .expect("validation should work"),
+            "unexpired grants must survive pruning"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_grant_is_shared_across_instances() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let first = PosixFsTemplateBuildFileStore::new(tempdir.path());
+        let second = PosixFsTemplateBuildFileStore::new(tempdir.path());
+
+        // A mismatched or expired claim leaves the grant usable.
+        let token = first
+            .create_upload_grant("template", HASH, 1000)
+            .await
+            .expect("grant should be created");
+        assert!(!second
+            .claim_upload_grant(&token, "other", HASH, 1000, 999)
+            .await
+            .expect("mismatched grant should be rejected"));
+        assert!(!second
+            .claim_upload_grant(&token, "template", HASH, 1000, 1001)
+            .await
+            .expect("expired grant should be rejected"));
+        assert!(second
+            .claim_upload_grant(&token, "template", HASH, 1000, 999)
+            .await
+            .expect("grant issued by another instance should claim"));
+    }
+
+    #[tokio::test]
+    async fn upload_grant_is_single_use() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+        let token = store
+            .create_upload_grant("template", HASH, 1000)
+            .await
+            .expect("grant should be created");
+
+        assert!(store
+            .claim_upload_grant(&token, "template", HASH, 1000, 999)
+            .await
+            .expect("first claim should succeed"));
+        assert!(
+            !store
+                .claim_upload_grant(&token, "template", HASH, 1000, 999)
+                .await
+                .expect("replay should be rejected"),
+            "an upload URL must not be replayable"
+        );
+    }
+
+    #[tokio::test]
+    async fn archives_are_immutable_once_stored() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+
+        let first = staged_file(tempdir.path(), b"original");
+        store.import(HASH, &first).await.expect("first import");
+
+        let replacement = tempdir.path().join("replacement.tar");
+        fs::write(&replacement, b"replaced").expect("write replacement");
+        store
+            .import(HASH, &replacement)
+            .await
+            .expect("repeat import should be accepted");
+
+        // Two imports racing for a hash neither has stored yet must both
+        // succeed; the loser's hard link hits AlreadyExists and is dropped.
+        // A fresh hash keeps both calls off the exists() fast path.
+        const FRESH_HASH: &str = "f00ff00ff00ff00ff00ff00ff00ff00f";
+        let concurrent = tempdir.path().join("concurrent.tar");
+        fs::write(&concurrent, b"concurrent").expect("write concurrent");
+        let (left, right) = tokio::join!(
+            store.import(FRESH_HASH, &replacement),
+            store.import(FRESH_HASH, &concurrent)
+        );
+        left.expect("concurrent import should be accepted");
+        right.expect("concurrent import should be accepted");
+        let winner = store
+            .materialize(FRESH_HASH, tempdir.path())
+            .await
+            .expect("materialize should work")
+            .expect("archive should exist");
+        let winner_bytes = fs::read(winner).expect("read winner");
+        assert!(
+            winner_bytes == b"replaced" || winner_bytes == b"concurrent",
+            "stored bytes must come from one of the racing imports"
+        );
+
+        let materialized = store
+            .materialize(HASH, tempdir.path())
+            .await
+            .expect("materialize should work")
+            .expect("archive should exist");
+        assert_eq!(
+            fs::read(materialized).expect("read materialized"),
+            b"original",
+            "a stored archive must never be replaced underneath a build"
+        );
+
+        let leftovers = fs::read_dir(tempdir.path().join("template-build-files"))
+            .expect("read store dir")
+            .flatten()
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with(".import-"))
+            .count();
+        assert_eq!(leftovers, 0, "import must not leak staging files");
+    }
+
+    #[tokio::test]
+    async fn materialize_refreshes_the_archive_mtime() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+
+        let staged = staged_file(tempdir.path(), b"tar-bytes");
+        store.import(HASH, &staged).await.expect("import");
+
+        let archive = tempdir
+            .path()
+            .join("template-build-files")
+            .join(format!("{HASH}.tar"));
+        let stale = SystemTime::now() - BUILD_FILE_RETENTION - Duration::from_secs(60);
+        let file = fs::File::options()
+            .write(true)
+            .open(&archive)
+            .expect("open archive");
+        file.set_times(fs::FileTimes::new().set_modified(stale))
+            .expect("set stale mtime");
+        drop(file);
+
+        store
+            .materialize(HASH, tempdir.path())
+            .await
+            .expect("materialize should work")
+            .expect("archive should exist");
+
+        let modified = fs::metadata(&archive)
+            .and_then(|metadata| metadata.modified())
+            .expect("read archive mtime");
+        assert!(
+            modified > stale,
+            "materializing an archive must keep it outside the prune horizon"
+        );
+    }
+
+    #[tokio::test]
+    async fn verifying_a_grant_does_not_consume_it() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+        let token = store
+            .create_upload_grant("template", HASH, 1000)
+            .await
+            .expect("grant should be created");
+
+        for _ in 0..2 {
+            assert!(
+                store
+                    .verify_upload_grant(&token, "template", HASH, 1000, 999)
+                    .await
+                    .expect("verification should work"),
+                "verification must not consume the grant"
+            );
+        }
+        assert!(!store
+            .verify_upload_grant(&token, "other", HASH, 1000, 999)
+            .await
+            .expect("mismatched grant should be rejected"));
+
+        // An upload that failed after verification can still be retried.
+        assert!(store
+            .claim_upload_grant(&token, "template", HASH, 1000, 999)
+            .await
+            .expect("claim should succeed"));
+        assert!(
+            !store
+                .verify_upload_grant(&token, "template", HASH, 1000, 999)
+                .await
+                .expect("verification should work"),
+            "a consumed grant must no longer verify"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_claims_pick_a_single_winner() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+        let token = store
+            .create_upload_grant("template", HASH, 1000)
+            .await
+            .expect("grant should be created");
+
+        let (left, right) = tokio::join!(
+            store.claim_upload_grant(&token, "template", HASH, 1000, 999),
+            store.claim_upload_grant(&token, "template", HASH, 1000, 999)
+        );
+        let claims = [
+            left.expect("claim should work"),
+            right.expect("claim should work"),
+        ];
+        assert_eq!(
+            claims.iter().filter(|claimed| **claimed).count(),
+            1,
+            "exactly one concurrent claim may win"
+        );
+    }
+
+    #[tokio::test]
+    async fn grants_are_pruned_once_their_own_expiry_passes() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+
+        // Expired long ago in grant terms, but freshly written on disk, so the
+        // mtime rule alone would keep it for the whole retention window.
+        let expired_token = store
+            .create_upload_grant("template", HASH, 1000)
+            .await
+            .expect("grant should be created");
+        let expired_path = tempdir
+            .path()
+            .join("template-build-files")
+            .join("upload-grants")
+            .join(format!("{expired_token}.json"));
+        assert!(expired_path.exists());
+
+        store
+            .create_upload_grant("template", HASH, i64::MAX)
+            .await
+            .expect("new grant should be created");
+
+        assert!(
+            !expired_path.exists(),
+            "a grant past its own expiry should be pruned"
+        );
+    }
+}

--- a/src/snapshot/repository/backends/posixfs/build_files.rs
+++ b/src/snapshot/repository/backends/posixfs/build_files.rs
@@ -58,6 +58,24 @@ impl PosixFsTemplateBuildFileStore {
         })
     }
 
+    /// Checks whether the canonical archive path names a regular file without
+    /// following a final-component symlink. Unexpected object types indicate a
+    /// corrupt repository entry rather than a cache miss.
+    fn archive_exists(path: &Path) -> RepositoryResult<bool> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => Ok(true),
+            Ok(_) => Err(RepositoryError::Backend {
+                message: format!("build archive '{}' is not a regular file", path.display()),
+                source: None,
+            }),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(RepositoryError::backend(
+                format!("stat build archive '{}'", path.display()),
+                error,
+            )),
+        }
+    }
+
     /// Removes archives whose modification time is older than the retention
     /// window. Runs opportunistically on import and scans a bounded number of
     /// entries per call; failures only log.
@@ -242,18 +260,9 @@ impl PosixFsTemplateBuildFileStore {
 impl TemplateBuildFileStore for PosixFsTemplateBuildFileStore {
     async fn exists(&self, hash: &str) -> RepositoryResult<bool> {
         let path = self.archive_path(hash)?;
-        task::spawn_blocking(move || -> RepositoryResult<bool> {
-            match fs::metadata(&path) {
-                Ok(_) => Ok(true),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-                Err(error) => Err(RepositoryError::backend(
-                    format!("stat build archive '{}'", path.display()),
-                    error,
-                )),
-            }
-        })
-        .await
-        .map_err(|error| RepositoryError::backend("join build file exists task", error))?
+        task::spawn_blocking(move || Self::archive_exists(&path))
+            .await
+            .map_err(|error| RepositoryError::backend("join build file exists task", error))?
     }
 
     async fn import(&self, hash: &str, staged: &Path) -> RepositoryResult<()> {
@@ -263,7 +272,7 @@ impl TemplateBuildFileStore for PosixFsTemplateBuildFileStore {
         task::spawn_blocking(move || -> RepositoryResult<()> {
             // Archives are immutable: the hash addresses the content, so a
             // repeat upload cannot change what an in-flight build reads.
-            if final_path.exists() {
+            if Self::archive_exists(&final_path)? {
                 return Ok(());
             }
             Self::ensure_root(&root)?;
@@ -291,7 +300,13 @@ impl TemplateBuildFileStore for PosixFsTemplateBuildFileStore {
             // wins and everyone else observes `AlreadyExists`.
             let published = match fs::hard_link(&store_staged, &final_path) {
                 Ok(()) => Ok(()),
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    match Self::archive_exists(&final_path) {
+                        Ok(true) => Ok(()),
+                        Ok(false) => Err(RepositoryError::backend("publish build archive", error)),
+                        Err(error) => Err(error),
+                    }
+                }
                 Err(error) => Err(RepositoryError::backend("publish build archive", error)),
             };
             if published.is_ok() {
@@ -319,17 +334,11 @@ impl TemplateBuildFileStore for PosixFsTemplateBuildFileStore {
     ) -> RepositoryResult<Option<PathBuf>> {
         let path = self.archive_path(hash)?;
         task::spawn_blocking(move || -> RepositoryResult<Option<PathBuf>> {
-            match fs::metadata(&path) {
-                Ok(_) => {
-                    Self::touch(&path);
-                    Ok(Some(path))
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-                Err(error) => Err(RepositoryError::backend(
-                    format!("stat build archive '{}'", path.display()),
-                    error,
-                )),
+            if !Self::archive_exists(&path)? {
+                return Ok(None);
             }
+            Self::touch(&path);
+            Ok(Some(path))
         })
         .await
         .map_err(|error| RepositoryError::backend("join build file materialize task", error))?
@@ -464,6 +473,60 @@ mod tests {
             .await
             .expect_err("invalid hash should fail");
         assert!(matches!(err, RepositoryError::InvalidRequest { .. }));
+    }
+
+    #[tokio::test]
+    async fn rejects_directory_at_archive_path() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+        let archive = tempdir
+            .path()
+            .join("template-build-files")
+            .join(format!("{HASH}.tar"));
+        fs::create_dir_all(&archive).expect("create archive directory");
+        let staged = staged_file(tempdir.path(), b"tar-bytes");
+
+        assert!(matches!(
+            store.exists(HASH).await,
+            Err(RepositoryError::Backend { .. })
+        ));
+        assert!(matches!(
+            store.import(HASH, &staged).await,
+            Err(RepositoryError::Backend { .. })
+        ));
+        assert!(matches!(
+            store.materialize(HASH, tempdir.path()).await,
+            Err(RepositoryError::Backend { .. })
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_symlink_at_archive_path() {
+        use std::os::unix::fs::symlink;
+
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+        let store_dir = tempdir.path().join("template-build-files");
+        fs::create_dir_all(&store_dir).expect("create store directory");
+        let target = tempdir.path().join("target.tar");
+        fs::write(&target, b"redirected").expect("write symlink target");
+        let archive = store_dir.join(format!("{HASH}.tar"));
+        symlink(&target, &archive).expect("create archive symlink");
+        let staged = staged_file(tempdir.path(), b"tar-bytes");
+
+        assert!(matches!(
+            store.exists(HASH).await,
+            Err(RepositoryError::Backend { .. })
+        ));
+        assert!(matches!(
+            store.import(HASH, &staged).await,
+            Err(RepositoryError::Backend { .. })
+        ));
+        assert!(matches!(
+            store.materialize(HASH, tempdir.path()).await,
+            Err(RepositoryError::Backend { .. })
+        ));
     }
 
     #[tokio::test]

--- a/src/snapshot/repository/backends/posixfs/build_files.rs
+++ b/src/snapshot/repository/backends/posixfs/build_files.rs
@@ -213,6 +213,18 @@ impl PosixFsTemplateBuildFileStore {
                             let _ = fs::remove_file(&path);
                             RepositoryError::backend("write upload grant", error)
                         })?;
+                    drop(file);
+                    // Make the new directory entry durable where supported.
+                    // Some shared filesystems reject directory fsync; losing a
+                    // grant after a host crash only requires requesting a fresh
+                    // upload URL, so keep that case best-effort.
+                    if let Err(error) = fs::File::open(&grants_dir).and_then(|dir| dir.sync_all()) {
+                        debug!(
+                            path = %grants_dir.display(),
+                            error = %error,
+                            "failed to sync upload grants directory"
+                        );
+                    }
                     return Ok(token);
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,

--- a/src/snapshot/repository/backends/posixfs/build_files.rs
+++ b/src/snapshot/repository/backends/posixfs/build_files.rs
@@ -14,7 +14,8 @@ use crate::snapshot::repository::build_files::{
 };
 use crate::snapshot::repository::{RepositoryError, RepositoryResult};
 
-/// How long imported build-context archives and upload grants are retained.
+/// Target retention window for build-context archives and upload grants.
+/// Cleanup is opportunistic and does not provide a strict storage bound.
 /// Archives are cache entries keyed by content hash; the SDK re-uploads any
 /// archive that has been pruned, so expiry only costs one extra upload.
 /// Grants expire after `template_build.files_url_ttl_secs` anyway, so this
@@ -67,9 +68,9 @@ impl PosixFsTemplateBuildFileStore {
 
     /// Removes upload grants that have passed their own `expires_unix`. Runs
     /// opportunistically whenever a new grant is written, so the grants
-    /// directory stays bounded by upload-link traffic; the scan is bounded per
-    /// call and drains the backlog over successive requests, and failures only
-    /// log.
+    /// directory receives regular best-effort cleanup. The scan is bounded per
+    /// call, does not guarantee that every entry is eventually visited, and
+    /// failures only log.
     ///
     /// Pruning by the record rather than by mtime keeps grants alive for
     /// exactly their TTL even when `template_build.files_url_ttl_secs` is
@@ -97,8 +98,9 @@ impl PosixFsTemplateBuildFileStore {
 
     /// Pruning is opportunistic and bounded: at most `MAX_PRUNE_SCAN` matching
     /// entries are inspected per call, so the cost a request pays stays
-    /// constant no matter how many records the directory holds. Anything left
-    /// over is reclaimed by later calls.
+    /// constant no matter how many records the directory holds. Later calls
+    /// may reclaim additional entries, but this is not a strict retention or
+    /// fairness guarantee.
     fn prune_dir(
         dir: &Path,
         extension: &str,
@@ -157,10 +159,10 @@ impl PosixFsTemplateBuildFileStore {
             .map_err(|error| RepositoryError::backend("parse upload grant", error))
     }
 
-    /// Best-effort mtime refresh, so retention means "unused for the window"
-    /// and an archive a build is still reading stays outside the prune
-    /// horizon. Read-only repository mounts must keep working, so failures
-    /// only log.
+    /// Best-effort mtime refresh, so recently materialized archives normally
+    /// stay outside the prune horizon. This is not a lease against a concurrent
+    /// prune. Read-only repository mounts must keep working, so failures only
+    /// log.
     fn touch(path: &Path) {
         let refreshed = fs::File::options()
             .write(true)

--- a/src/snapshot/repository/backends/posixfs/build_files.rs
+++ b/src/snapshot/repository/backends/posixfs/build_files.rs
@@ -76,12 +76,18 @@ impl PosixFsTemplateBuildFileStore {
         }
     }
 
-    /// Removes archives whose modification time is older than the retention
-    /// window. Runs opportunistically on import and scans a bounded number of
-    /// entries per call; failures only log.
+    /// Removes archives and abandoned import staging files whose modification
+    /// time is older than the retention window. Runs opportunistically on
+    /// import and scans a bounded number of entries per call; failures only
+    /// log.
     fn prune_expired(root: &Path) {
         let cutoff = SystemTime::now() - BUILD_FILE_RETENTION;
         Self::prune_dir_older_than(root, "tar", cutoff);
+        Self::prune_dir(root, "tmp", |path, modified| {
+            path.file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with(".import-"))
+                && modified.is_some_and(|modified| modified < cutoff)
+        });
     }
 
     /// Removes upload grants that have passed their own `expires_unix`. Runs
@@ -673,6 +679,32 @@ mod tests {
             .filter(|entry| entry.file_name().to_string_lossy().starts_with(".import-"))
             .count();
         assert_eq!(leftovers, 0, "import must not leak staging files");
+    }
+
+    #[tokio::test]
+    async fn import_prunes_expired_staging_files() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = PosixFsTemplateBuildFileStore::new(tempdir.path());
+        let store_dir = tempdir.path().join("template-build-files");
+        fs::create_dir_all(&store_dir).expect("create store dir");
+        let abandoned = store_dir.join(".import-abandoned.tmp");
+        fs::write(&abandoned, b"partial archive").expect("write abandoned import");
+        let stale = SystemTime::now() - BUILD_FILE_RETENTION - Duration::from_secs(60);
+        let file = fs::File::options()
+            .write(true)
+            .open(&abandoned)
+            .expect("open abandoned import");
+        file.set_times(fs::FileTimes::new().set_modified(stale))
+            .expect("set abandoned import mtime");
+        drop(file);
+
+        let staged = staged_file(tempdir.path(), b"tar-bytes");
+        store.import(HASH, &staged).await.expect("import");
+
+        assert!(
+            !abandoned.exists(),
+            "expired import staging files should be pruned"
+        );
     }
 
     #[tokio::test]

--- a/src/snapshot/repository/backends/posixfs/mod.rs
+++ b/src/snapshot/repository/backends/posixfs/mod.rs
@@ -1,5 +1,6 @@
 mod artifacts;
 mod backend;
+mod build_files;
 mod catalog;
 mod layout;
 mod runtime;
@@ -7,5 +8,6 @@ mod runtime;
 pub(crate) use artifacts::PosixFsArtifactStore;
 pub(crate) use backend::PosixFsSnapshotRepository;
 pub use backend::{PosixFsBackend, PosixFsBackendConfig};
+pub(crate) use build_files::PosixFsTemplateBuildFileStore;
 pub(crate) use catalog::PosixFsCatalogStore;
 pub(crate) use layout::PosixFsSnapshotArtifactLayout;

--- a/src/snapshot/repository/build_files.rs
+++ b/src/snapshot/repository/build_files.rs
@@ -1,0 +1,197 @@
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+use super::errors::RepositoryResult;
+
+/// Number of random bytes in an upload bearer token.
+pub const UPLOAD_TOKEN_LEN: usize = 32;
+
+/// Durable authorization record for one build-context upload URL.
+///
+/// Grants live in the same shared repository as build archives. That makes a
+/// URL issued by one node verifiable by any other node without coordinating a
+/// deployment-wide in-memory signing secret.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TemplateBuildUploadGrant {
+    pub template_id: String,
+    pub hash: String,
+    pub expires_unix: i64,
+}
+
+impl TemplateBuildUploadGrant {
+    pub fn new(template_id: &str, hash: &str, expires_unix: i64) -> Self {
+        Self {
+            template_id: template_id.to_string(),
+            hash: hash.to_string(),
+            expires_unix,
+        }
+    }
+
+    pub fn authorizes(
+        &self,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+        now_unix: i64,
+    ) -> bool {
+        now_unix <= expires_unix
+            && self.expires_unix == expires_unix
+            && self.template_id == template_id
+            && self.hash == hash
+    }
+}
+
+/// Durable store for template build-context archives.
+///
+/// The E2B SDK resolves every `COPY` step through
+/// `GET /templates/{templateID}/files/{hash}` and then `PUT`s a tar archive of
+/// the matching context files to the returned URL. This store owns those
+/// archives, addressed by the SDK-computed content hash, so that:
+///
+/// - any node can answer the upload-link request (`exists`),
+/// - any node can accept the upload (`import`), and
+/// - the node that runs the build can read the archive back (`materialize`).
+///
+/// Implementations must place the archives in storage shared by all nodes of
+/// the deployment, mirroring the visibility rules of committed snapshots.
+#[async_trait]
+pub trait TemplateBuildFileStore: Send + Sync {
+    /// Returns whether an archive for `hash` is already stored.
+    async fn exists(&self, hash: &str) -> RepositoryResult<bool>;
+
+    /// Imports a fully written local file as the archive for `hash`.
+    ///
+    /// Implementations must publish atomically: concurrent readers never
+    /// observe a partially imported archive. `hash` is the cache key supplied
+    /// by the authenticated caller, not a digest the store verifies, so
+    /// immutability here means first-write-wins stability rather than content
+    /// authenticity: importing a hash that is already stored keeps the stored
+    /// archive, so an in-flight build can never observe its build context
+    /// change underneath it.
+    async fn import(&self, hash: &str, staged: &Path) -> RepositoryResult<()>;
+
+    /// Materializes the archive for `hash` as a node-local file.
+    ///
+    /// `scratch_dir` is a caller-owned directory the implementation may use
+    /// for downloads; implementations backed by a shared filesystem may return
+    /// the shared path directly. Callers must treat the returned file as
+    /// read-only. Returns `None` when no archive is stored for `hash`.
+    async fn materialize(
+        &self,
+        hash: &str,
+        scratch_dir: &Path,
+    ) -> RepositoryResult<Option<PathBuf>>;
+
+    /// Creates a durable bearer grant for one upload URL and returns its
+    /// URL-safe token.
+    async fn create_upload_grant(
+        &self,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+    ) -> RepositoryResult<String>;
+
+    /// Verifies a durable bearer grant without consuming it, returning
+    /// whether it authorizes this upload.
+    ///
+    /// Verification never removes the grant, so a request that fails before
+    /// the archive is stored can be retried with the same upload URL. Callers
+    /// must `claim_upload_grant` after publishing the archive, so a failed
+    /// publication leaves the URL retryable.
+    async fn verify_upload_grant(
+        &self,
+        token: &str,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+        now_unix: i64,
+    ) -> RepositoryResult<bool>;
+
+    /// Claims a durable bearer grant, returning whether it authorized this
+    /// upload.
+    ///
+    /// Grants are single-use: a successful claim consumes the grant, so an
+    /// upload URL cannot be replayed within its TTL. Implementations must
+    /// make the claim itself the atomic step wherever the backend offers an
+    /// atomic primitive (a POSIX filesystem does, via rename/unlink), so
+    /// concurrent requests carrying the same token cannot both succeed.
+    /// S3-compatible backends have no conditional delete and therefore
+    /// degrade to best-effort single-use within the grant TTL; archive
+    /// immutability is what keeps a lost race from mattering: both uploads are
+    /// bound to the same (template_id, hash), and `import` is first-write-wins,
+    /// so neither can change an archive that is already stored — which upload
+    /// wins a first store is undefined.
+    async fn claim_upload_grant(
+        &self,
+        token: &str,
+        template_id: &str,
+        hash: &str,
+        expires_unix: i64,
+        now_unix: i64,
+    ) -> RepositoryResult<bool>;
+}
+
+/// Returns whether `hash` is acceptable as a build-file content hash.
+///
+/// The E2B SDK sends a lowercase hex SHA-256, but the value is treated as an
+/// opaque cache key; this only enforces a path- and URL-safe shape.
+pub fn is_valid_build_files_hash(hash: &str) -> bool {
+    (16..=128).contains(&hash.len()) && hash.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Generates a cryptographically random URL-safe upload bearer token.
+pub fn generate_upload_token() -> String {
+    let mut token = [0u8; UPLOAD_TOKEN_LEN];
+    rand::fill(&mut token);
+    URL_SAFE_NO_PAD.encode(token)
+}
+
+/// Returns whether `token` has the exact shape generated for upload grants.
+pub fn is_valid_upload_token(token: &str) -> bool {
+    URL_SAFE_NO_PAD
+        .decode(token)
+        .is_ok_and(|decoded| decoded.len() == UPLOAD_TOKEN_LEN)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_validation_accepts_sha256_hex() {
+        assert!(is_valid_build_files_hash(
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+        ));
+        assert!(is_valid_build_files_hash("ABCDEF0123456789"));
+    }
+
+    #[test]
+    fn hash_validation_rejects_path_unsafe_values() {
+        assert!(!is_valid_build_files_hash(""));
+        assert!(!is_valid_build_files_hash("short"));
+        assert!(!is_valid_build_files_hash("../../../../etc/passwd"));
+        assert!(!is_valid_build_files_hash("deadbeef/deadbeef"));
+        assert!(!is_valid_build_files_hash(&"a".repeat(129)));
+    }
+
+    #[test]
+    fn upload_token_has_expected_shape() {
+        let token = generate_upload_token();
+        assert!(is_valid_upload_token(&token));
+        assert!(!is_valid_upload_token("not-a-valid-token"));
+    }
+
+    #[test]
+    fn upload_grant_is_bound_to_request_and_expiry() {
+        let grant = TemplateBuildUploadGrant::new("tmpl", "aabbccddeeff0011", 1000);
+        assert!(grant.authorizes("tmpl", "aabbccddeeff0011", 1000, 999));
+        assert!(!grant.authorizes("tmpl", "aabbccddeeff0011", 1000, 1001));
+        assert!(!grant.authorizes("other", "aabbccddeeff0011", 1000, 999));
+        assert!(!grant.authorizes("tmpl", "aabbccddeeff0012", 1000, 999));
+        assert!(!grant.authorizes("tmpl", "aabbccddeeff0011", 2000, 999));
+    }
+}

--- a/src/snapshot/repository/build_files.rs
+++ b/src/snapshot/repository/build_files.rs
@@ -38,7 +38,7 @@ impl TemplateBuildUploadGrant {
         expires_unix: i64,
         now_unix: i64,
     ) -> bool {
-        now_unix <= expires_unix
+        now_unix < expires_unix
             && self.expires_unix == expires_unix
             && self.template_id == template_id
             && self.hash == hash
@@ -65,13 +65,12 @@ pub trait TemplateBuildFileStore: Send + Sync {
 
     /// Imports a fully written local file as the archive for `hash`.
     ///
-    /// Implementations must publish atomically: concurrent readers never
-    /// observe a partially imported archive. `hash` is the cache key supplied
-    /// by the authenticated caller, not a digest the store verifies, so
-    /// immutability here means first-write-wins stability rather than content
-    /// authenticity: importing a hash that is already stored keeps the stored
-    /// archive, so an in-flight build can never observe its build context
-    /// change underneath it.
+    /// Implementations must publish each upload atomically: concurrent readers
+    /// may observe either the previous complete archive or the newly imported
+    /// complete archive, but never a partially imported archive. `hash` is the
+    /// SDK-supplied cache key rather than a digest the store verifies, so the
+    /// protocol assumes repeated uploads for one hash describe equivalent
+    /// build input; the store does not provide content authenticity.
     async fn import(&self, hash: &str, staged: &Path) -> RepositoryResult<()>;
 
     /// Materializes the archive for `hash` as a node-local file.
@@ -120,11 +119,10 @@ pub trait TemplateBuildFileStore: Send + Sync {
     /// atomic primitive (a POSIX filesystem does, via rename/unlink), so
     /// concurrent requests carrying the same token cannot both succeed.
     /// S3-compatible backends have no conditional delete and therefore
-    /// degrade to best-effort single-use within the grant TTL; archive
-    /// immutability is what keeps a lost race from mattering: both uploads are
-    /// bound to the same (template_id, hash), and `import` is first-write-wins,
-    /// so neither can change an archive that is already stored — which upload
-    /// wins a first store is undefined.
+    /// degrade to best-effort single-use within the grant TTL. Simultaneous
+    /// requests can both publish, but each grant is bound to the same
+    /// (template_id, hash), and the upload protocol requires repeated uploads
+    /// for one hash to describe equivalent build input.
     async fn claim_upload_grant(
         &self,
         token: &str,
@@ -189,6 +187,7 @@ mod tests {
     fn upload_grant_is_bound_to_request_and_expiry() {
         let grant = TemplateBuildUploadGrant::new("tmpl", "aabbccddeeff0011", 1000);
         assert!(grant.authorizes("tmpl", "aabbccddeeff0011", 1000, 999));
+        assert!(!grant.authorizes("tmpl", "aabbccddeeff0011", 1000, 1000));
         assert!(!grant.authorizes("tmpl", "aabbccddeeff0011", 1000, 1001));
         assert!(!grant.authorizes("other", "aabbccddeeff0011", 1000, 999));
         assert!(!grant.authorizes("tmpl", "aabbccddeeff0012", 1000, 999));

--- a/src/snapshot/repository/build_files.rs
+++ b/src/snapshot/repository/build_files.rs
@@ -113,16 +113,22 @@ pub trait TemplateBuildFileStore: Send + Sync {
     /// Claims a durable bearer grant, returning whether it authorized this
     /// upload.
     ///
-    /// Grants are single-use: a successful claim consumes the grant, so an
-    /// upload URL cannot be replayed within its TTL. Implementations must
-    /// make the claim itself the atomic step wherever the backend offers an
-    /// atomic primitive (a POSIX filesystem does, via rename/unlink), so
-    /// concurrent requests carrying the same token cannot both succeed.
+    /// A successful claim consumes the grant, so later requests cannot reuse
+    /// it. Implementations must make the claim itself atomic wherever the
+    /// backend offers an atomic primitive (a POSIX filesystem does, via
+    /// unlink), so concurrent requests carrying the same token cannot both
+    /// report a successful claim.
+    ///
+    /// Claiming is deliberately not a pre-publication reservation: callers
+    /// verify first so failed staging or publication remains retryable, then
+    /// claim after publication. Simultaneous holders of the same bearer token
+    /// can therefore race publication before one claim succeeds. Possession of
+    /// the token already authorizes publication for its bound
+    /// (template_id, hash); this protocol does not add content authenticity,
+    /// and repeated uploads for one hash must describe equivalent build input.
+    ///
     /// S3-compatible backends have no conditional delete and therefore
-    /// degrade to best-effort single-use within the grant TTL. Simultaneous
-    /// requests can both publish, but each grant is bound to the same
-    /// (template_id, hash), and the upload protocol requires repeated uploads
-    /// for one hash to describe equivalent build input.
+    /// degrade the claim itself to best-effort single-use within the grant TTL.
     async fn claim_upload_grant(
         &self,
         token: &str,

--- a/src/snapshot/repository/interfaces.rs
+++ b/src/snapshot/repository/interfaces.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use super::build_files::TemplateBuildFileStore;
 use super::errors::RepositoryResult;
 use crate::sandbox::FirecrackerSnapshotManifest;
 use crate::snapshot::types::{
@@ -173,6 +174,15 @@ pub trait SnapshotRepository: Send + Sync {
         id: &SnapshotId,
         reason: TemplateBuildErrorReason,
     ) -> RepositoryResult<()>;
+
+    /// Returns the shared store for template build-context archives.
+    ///
+    /// Returns `None` when this backend does not support build-context
+    /// uploads; the template files API then reports the capability as
+    /// unavailable instead of failing at build time.
+    fn template_build_files(&self) -> Option<Arc<dyn TemplateBuildFileStore>> {
+        None
+    }
 }
 
 #[async_trait]

--- a/src/snapshot/repository/mod.rs
+++ b/src/snapshot/repository/mod.rs
@@ -1,6 +1,8 @@
 pub mod backends;
+pub mod build_files;
 pub mod errors;
 pub mod interfaces;
 
+pub use build_files::TemplateBuildFileStore;
 pub use errors::{RepositoryError, RepositoryResult};
 pub use interfaces::{SnapshotListFilter, SnapshotRepository, SnapshotRuntimeResolver};


### PR DESCRIPTION
## What

Add repository-backed template build-context archive storage for POSIX and OSS deployments, including immutable content-addressed archives, single-use upload grants, bounded pruning, and a `SnapshotManager` accessor.

This is the first layer of the active COPY/ADD stack, replayed directly onto current main at `00ba6cb`. The alias-rebuild work in #70 is intentionally not a dependency and is parked pending the planned alias-system refactor.

| Layer | PR | Branch | Scope |
|---|---|---|---|
| **1/4** | **#71** | **`e2b-build/03-build-file-store`** | **Build-context archive store** |
| 2/4 | #72 | `e2b-build/04-upload-api` | Upload API and configuration |
| 3/4 | #73 | `e2b-build/05-copy-plan` | Host-side COPY planning |
| 4/4 | #74 | `e2b-build/06-copy-exec` | COPY/ADD execution, E2E, and documentation |

## Why

The E2B SDK uploads build-context archives separately from the template build request. This layer provides the shared repository primitive needed to accept those uploads on one node and consume them during a later build, including clustered deployments backed by the OSS repository.

Related: #28. The original PR remains the full concept/reference discussion.

## Scope and non-goals

This layer contains only the storage interfaces, POSIX/OSS implementations, repository wiring, accessors, and focused storage tests. It does not expose an HTTP upload surface or execute COPY/ADD steps. Existing-alias rebuild remains unsupported.

Exact layer diff: [00ba6cb...e2b-build/03-build-file-store](https://github.com/JoyboyBrian/AgentENV/compare/00ba6cb...e2b-build/03-build-file-store)

## Design

- `TemplateBuildFileStore` abstracts archive lookup, import, materialization, upload-grant issue/verify/claim, and pruning.
- POSIX publication uses staging, fsync, and no-clobber hard links for first-write-wins behavior.
- OSS stores the same logical archive and grant records under repository object keys.
- Snapshot repositories may return no build-file store; the POSIX and OSS backends wire concrete implementations.
- The rebase includes the minimal constructor updates required by current main's image-export repository creation paths.

## Compatibility and operations

- No public API change in this layer.
- No new configuration or host dependency.
- Committed snapshot manifests are unchanged; the repository gains additive build-context archive/grant data.
- Old repositories remain readable, and unreferenced archives can be pruned.

## Validation

The rewritten stack was validated on Linux against the #74 tip:

```text
cargo fmt --all -- --check
cargo test --locked -p agentenv --lib template::
# 68 passed, 0 failed
cargo clippy --locked -p agentenv --lib -- -D warnings
make agentenv-server
# regeneration produced no intended generated-code diff
```

This layer includes focused tests for immutable import, first-write-wins publication, grants/claims, pruning, mtime refresh, and failure cleanup. GitHub CI validates this cumulative branch independently.

## Reviewer notes

The main review surfaces are single-use grant behavior, no-clobber publication, and bounded cleanup. #70 is not required to merge this stack.
