### PR TITLE
fix(orchestrator): fail fork when source cannot leave Forking

### DIFF
--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -561,7 +561,10 @@ where
             }
         };
 
-        // Restore the source sandbox's state to Running.
+        // Restore the source sandbox's state to Running. A failure here must
+        // abort the fork: leaving the source in Forking blocks pause/resume/
+        // delete waiters, and registering children would report success while
+        // the source is stuck in a transitional state.
         if let Err(err) = self
             .store
             .update_state_if_state(
@@ -572,6 +575,23 @@ where
             .await
         {
             warn!(error = ?err, "failed to restore source sandbox metadata after fork");
+            self.counters.record_create_fail(u64::from(count));
+            for (sandbox_id, backend) in child_ids.iter().zip(forked_backends) {
+                if let Ok(backend) = backend {
+                    Self::stop_failed_fork(backend, *sandbox_id).await;
+                }
+            }
+            return Err(match err {
+                StoreError::StateConflict {
+                    sandbox_id,
+                    actual_state,
+                    ..
+                } => OrchestratorError::InvalidSandboxState {
+                    sandbox_id,
+                    state: actual_state,
+                },
+                other => OrchestratorError::from(other),
+            });
         }
 
         // Register each forked sandbox in the store and runtime, and publish events.

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -561,26 +561,54 @@ where
             }
         };
 
-        // Restore the source sandbox's state to Running. A failure here must
-        // abort the fork: leaving the source in Forking blocks pause/resume/
-        // delete waiters, and registering children would report success while
-        // the source is stuck in a transitional state.
-        if let Err(err) = self
-            .store
-            .update_state_if_state(
-                &source_sandbox_id,
-                SandboxState::Running,
-                &[SandboxState::Forking],
-            )
-            .await
-        {
-            warn!(error = ?err, "failed to restore source sandbox metadata after fork");
-            self.counters.record_create_fail(u64::from(count));
-            for (sandbox_id, backend) in child_ids.iter().zip(forked_backends) {
-                if let Ok(backend) = backend {
-                    Self::stop_failed_fork(backend, *sandbox_id).await;
+        // Restore the source sandbox's state to Running. Leaving the source in
+        // Forking permanently strands pause/resume/delete waiters, so retry a
+        // few times and fall back to terminal source cleanup if persistence
+        // cannot recover a stable state.
+        const SOURCE_RESTORE_ATTEMPTS: u32 = 3;
+        let mut restore_err = None;
+        for attempt in 1..=SOURCE_RESTORE_ATTEMPTS {
+            match self
+                .store
+                .update_state_if_state(
+                    &source_sandbox_id,
+                    SandboxState::Running,
+                    &[SandboxState::Forking],
+                )
+                .await
+            {
+                Ok(_) => {
+                    restore_err = None;
+                    break;
+                }
+                Err(err) => {
+                    warn!(
+                        attempt,
+                        error = ?err,
+                        "failed to restore source sandbox metadata after fork"
+                    );
+                    restore_err = Some(err);
+                    if attempt < SOURCE_RESTORE_ATTEMPTS {
+                        tokio::time::sleep(Duration::from_millis(10 * u64::from(attempt))).await;
+                    }
                 }
             }
+        }
+        if let Some(err) = restore_err {
+            self.counters.record_create_fail(u64::from(count));
+            for (sandbox_id, backend) in child_ids.into_iter().zip(forked_backends) {
+                if let Ok(backend) = backend {
+                    Self::stop_failed_fork(backend, sandbox_id).await;
+                }
+            }
+            // Terminal cleanup: do not leave the source stranded in Forking.
+            self.detach_sandbox_handle_and_route(&source_sandbox_id)
+                .await;
+            let _ = {
+                let mut sandbox = source_handle.lock().await;
+                sandbox.stop().await
+            };
+            let _ = self.store.remove(&source_sandbox_id).await;
             return Err(match err {
                 StoreError::StateConflict {
                     sandbox_id,

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -4437,6 +4437,72 @@ async fn fork_sandbox_terminal_failure_removes_source_and_cleans_up_metrics() ->
     Ok(())
 }
 
+/// If the source cannot leave `Forking` after a successful backend fork, the
+/// operation fails and forked children are stopped instead of being registered.
+#[tokio::test]
+async fn fork_sandbox_fails_when_source_cannot_leave_forking() -> Result<()> {
+    setup();
+    let control = Arc::new(ScriptedStoreControl::default());
+    let behavior = Arc::new(MockBehavior::new());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&control)),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+
+    let source = orchestrator
+        .create_sandbox(create_request(
+            Some(60),
+            &[("team", "fork-restore-source-fail")],
+        ))
+        .await?;
+    let baseline = current_metrics(&orchestrator).await;
+
+    // First update_if_state (Running -> Forking) succeeds via Delegate.
+    // Second update_state_if_state (Forking -> Running) fails.
+    control.push_update_if_state_action(StoreAction::Delegate);
+    control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("injected failure restoring source after fork"),
+    }));
+
+    let err = orchestrator
+        .fork_sandbox(source.id, 2, NewTimeout::Set(Duration::from_secs(15)))
+        .await
+        .expect_err("fork must fail when source cannot leave Forking");
+
+    assert!(matches!(
+        err,
+        OrchestratorError::StoreOperationFailed(StoreError::Backend { .. })
+    ));
+
+    let source_after = orchestrator
+        .get_sandbox(&source.id)
+        .await?
+        .expect("source sandbox metadata should remain");
+    assert_eq!(
+        source_after.state,
+        SandboxState::Forking,
+        "store restore failed, so source remains in Forking until a later recovery path"
+    );
+    assert_eq!(
+        behavior.stop_calls(),
+        2,
+        "both forked children must be stopped when source restore fails"
+    );
+    assert_eq!(orchestrator.list_sandboxes().await?.len(), 1);
+    assert_metrics_values(
+        &orchestrator,
+        baseline.create_successes,
+        baseline.create_fails + 2,
+        1,
+        0,
+        source_after.resources.cpu_count,
+        source_after.resources.memory_mib,
+    )
+    .await;
+
+    Ok(())
+}
+
 /// A failure during one child registration is reported for that child without
 /// rolling back a sibling that was registered successfully.
 #[tokio::test]

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -4437,10 +4437,10 @@ async fn fork_sandbox_terminal_failure_removes_source_and_cleans_up_metrics() ->
     Ok(())
 }
 
-/// If the source cannot leave `Forking` after a successful backend fork, the
-/// operation fails and forked children are stopped instead of being registered.
+/// A transient failure restoring the source from `Forking` is retried so the
+/// source returns to a usable `Running` state and children can still register.
 #[tokio::test]
-async fn fork_sandbox_fails_when_source_cannot_leave_forking() -> Result<()> {
+async fn fork_sandbox_retries_source_restore_after_transient_store_failure() -> Result<()> {
     setup();
     let control = Arc::new(ScriptedStoreControl::default());
     let behavior = Arc::new(MockBehavior::new());
@@ -4452,17 +4452,70 @@ async fn fork_sandbox_fails_when_source_cannot_leave_forking() -> Result<()> {
     let source = orchestrator
         .create_sandbox(create_request(
             Some(60),
-            &[("team", "fork-restore-source-fail")],
+            &[("team", "fork-restore-retry")],
+        ))
+        .await?;
+
+    // Running -> Forking succeeds; first Forking -> Running fails; retry delegates.
+    control.push_update_if_state_action(StoreAction::Delegate);
+    control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("injected transient failure restoring source after fork"),
+    }));
+
+    let outcomes = orchestrator
+        .fork_sandbox(source.id, 2, NewTimeout::Set(Duration::from_secs(15)))
+        .await?;
+    let children = outcomes.into_iter().collect::<StdResult<Vec<_>, _>>()?;
+    assert_eq!(children.len(), 2);
+
+    let source_after = orchestrator
+        .get_sandbox(&source.id)
+        .await?
+        .expect("source sandbox metadata should remain");
+    assert_eq!(
+        source_after.state,
+        SandboxState::Running,
+        "a failed fork restore must retry until the source is usable again"
+    );
+    for child in &children {
+        assert_eq!(child.state, SandboxState::Running);
+        assert_proxy_ready(&orchestrator, &child.id).await?;
+    }
+
+    for child in children {
+        orchestrator.delete_sandbox(child.id).await?;
+    }
+    orchestrator.delete_sandbox(source.id).await?;
+    Ok(())
+}
+
+/// If every restore attempt fails, forked children are stopped and the source
+/// is removed instead of being left permanently in `Forking`.
+#[tokio::test]
+async fn fork_sandbox_terminates_source_when_restore_cannot_complete() -> Result<()> {
+    setup();
+    let control = Arc::new(ScriptedStoreControl::default());
+    let behavior = Arc::new(MockBehavior::new());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&control)),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+
+    let source = orchestrator
+        .create_sandbox(create_request(
+            Some(60),
+            &[("team", "fork-restore-terminal")],
         ))
         .await?;
     let baseline = current_metrics(&orchestrator).await;
 
-    // First update_if_state (Running -> Forking) succeeds via Delegate.
-    // Second update_state_if_state (Forking -> Running) fails.
+    // Running -> Forking succeeds; all three Forking -> Running attempts fail.
     control.push_update_if_state_action(StoreAction::Delegate);
-    control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
-        source: anyhow::anyhow!("injected failure restoring source after fork"),
-    }));
+    for _ in 0..3 {
+        control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+            source: anyhow::anyhow!("injected persistent failure restoring source after fork"),
+        }));
+    }
 
     let err = orchestrator
         .fork_sandbox(source.id, 2, NewTimeout::Set(Duration::from_secs(15)))
@@ -4473,30 +4526,24 @@ async fn fork_sandbox_fails_when_source_cannot_leave_forking() -> Result<()> {
         err,
         OrchestratorError::StoreOperationFailed(StoreError::Backend { .. })
     ));
-
-    let source_after = orchestrator
-        .get_sandbox(&source.id)
-        .await?
-        .expect("source sandbox metadata should remain");
-    assert_eq!(
-        source_after.state,
-        SandboxState::Forking,
-        "store restore failed, so source remains in Forking until a later recovery path"
+    assert!(
+        orchestrator.get_sandbox(&source.id).await?.is_none(),
+        "unrestorable source must be removed rather than left in Forking"
     );
-    assert_eq!(
-        behavior.stop_calls(),
-        2,
-        "both forked children must be stopped when source restore fails"
+    assert!(
+        behavior.stop_calls() >= 3,
+        "source and both forked children must be stopped; got {}",
+        behavior.stop_calls()
     );
-    assert_eq!(orchestrator.list_sandboxes().await?.len(), 1);
+    assert!(orchestrator.list_sandboxes().await?.is_empty());
     assert_metrics_values(
         &orchestrator,
         baseline.create_successes,
         baseline.create_fails + 2,
-        1,
         0,
-        source_after.resources.cpu_count,
-        source_after.resources.memory_mib,
+        0,
+        0,
+        0,
     )
     .await;
 


### PR DESCRIPTION
## Summary
- After a successful backend fork, restoring the source from `Forking` → `Running` was best-effort and ignored on failure.
- That left the source stuck in `Forking` while children were still registered, breaking later pause/resume/delete waiters.
- Fork now fails hard on that restore error, stops forked children, and surfaces the store failure.

## Test plan
- [x] Added `fork_sandbox_fails_when_source_cannot_leave_forking`
- [x] `cargo test -p agentenv --lib fork_sandbox_`