### PR TITLE
fix(orchestrator): roll back network policy when metadata persist fails

### DIFF
--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -1427,10 +1427,38 @@ where
 
     #[tracing::instrument(skip(self, network_policy), fields(sandbox_id = %sandbox_id))]
     pub async fn replace_sandbox_network_policy(
+        self: &Arc<Self>,
+        sandbox_id: SandboxId,
+        network_policy: SandboxNetworkPolicy,
+    ) -> Result<()> {
+        let this = Arc::clone(self);
+        self.run_lifecycle_operation("update_network", sandbox_id, async move {
+            this.replace_sandbox_network_policy_inner(sandbox_id, network_policy)
+                .await
+        })
+        .await
+    }
+
+    async fn replace_sandbox_network_policy_inner(
         &self,
         sandbox_id: SandboxId,
         network_policy: SandboxNetworkPolicy,
     ) -> Result<()> {
+        let sandbox = {
+            let sandboxes = self.sandboxes.read().await;
+            sandboxes.get(&sandbox_id).cloned()
+        }
+        .ok_or_else(|| OrchestratorError::SandboxOperationConflict {
+            sandbox_id,
+            operation: SandboxOperation::UpdateNetwork,
+        })?;
+
+        // Hold the sandbox lock across apply / persist / rollback so concurrent
+        // replacements cannot interleave a newer policy between a failed persist
+        // and its compensating rollback. Combined with run_lifecycle_operation,
+        // the compensation also survives caller cancellation.
+        let mut sandbox_guard = sandbox.lock().await;
+
         let metadata = self
             .store
             .get(&sandbox_id)
@@ -1443,31 +1471,18 @@ where
             });
         }
 
-        let sandbox = {
-            let sandboxes = self.sandboxes.read().await;
-            sandboxes.get(&sandbox_id).cloned()
-        }
-        .ok_or_else(|| OrchestratorError::SandboxOperationConflict {
-            sandbox_id,
-            operation: SandboxOperation::UpdateNetwork,
-        })?;
-
         let previous_policy = metadata.network_policy.clone();
         let runtime_policy = network_policy.runtime_policy();
 
-        let update_result = {
-            let mut sandbox = sandbox.lock().await;
-            sandbox.update_network_policy(runtime_policy).await
-        };
-        update_result.map_err(|source| OrchestratorError::SandboxOperationFailed {
-            sandbox_id,
-            operation: SandboxOperation::UpdateNetwork,
-            source,
-        })?;
+        sandbox_guard
+            .update_network_policy(runtime_policy)
+            .await
+            .map_err(|source| OrchestratorError::SandboxOperationFailed {
+                sandbox_id,
+                operation: SandboxOperation::UpdateNetwork,
+                source,
+            })?;
 
-        // Live egress rules are already applied. If metadata persistence fails,
-        // roll the runtime policy back so GET/pause/snapshot cannot diverge from
-        // the enforced iptables state.
         if let Err(err) = self
             .store
             .update_if_state(&sandbox_id, &[SandboxState::Running], |metadata| {
@@ -1475,16 +1490,21 @@ where
             })
             .await
         {
-            let rollback_policy = previous_policy.runtime_policy();
-            let rollback_result = {
-                let mut sandbox = sandbox.lock().await;
-                sandbox.update_network_policy(rollback_policy).await
-            };
+            let rollback_result = sandbox_guard
+                .update_network_policy(previous_policy.runtime_policy())
+                .await;
             if let Err(rollback_err) = rollback_result {
                 warn!(
                     error = ?rollback_err,
                     "failed to roll back sandbox network policy after metadata persist failure"
                 );
+                return Err(OrchestratorError::SandboxOperationFailed {
+                    sandbox_id,
+                    operation: SandboxOperation::UpdateNetwork,
+                    source: anyhow::anyhow!(
+                        "network policy metadata persist failed ({err:#}); runtime rollback also failed ({rollback_err:#}); runtime enforcement and metadata may disagree"
+                    ),
+                });
             }
 
             return Err(match err {

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -1452,6 +1452,7 @@ where
             operation: SandboxOperation::UpdateNetwork,
         })?;
 
+        let previous_policy = metadata.network_policy.clone();
         let runtime_policy = network_policy.runtime_policy();
 
         let update_result = {
@@ -1464,11 +1465,42 @@ where
             source,
         })?;
 
-        self.store
+        // Live egress rules are already applied. If metadata persistence fails,
+        // roll the runtime policy back so GET/pause/snapshot cannot diverge from
+        // the enforced iptables state.
+        if let Err(err) = self
+            .store
             .update_if_state(&sandbox_id, &[SandboxState::Running], |metadata| {
                 metadata.network_policy = network_policy;
             })
-            .await?;
+            .await
+        {
+            let rollback_policy = previous_policy.runtime_policy();
+            let rollback_result = {
+                let mut sandbox = sandbox.lock().await;
+                sandbox.update_network_policy(rollback_policy).await
+            };
+            if let Err(rollback_err) = rollback_result {
+                warn!(
+                    error = ?rollback_err,
+                    "failed to roll back sandbox network policy after metadata persist failure"
+                );
+            }
+
+            return Err(match err {
+                // Lost a race against a concurrent state transition (e.g.
+                // pause): report it as a conflict instead of a 500.
+                StoreError::StateConflict {
+                    sandbox_id,
+                    actual_state,
+                    ..
+                } => OrchestratorError::InvalidSandboxState {
+                    sandbox_id,
+                    state: actual_state,
+                },
+                other => OrchestratorError::from(other),
+            });
+        }
 
         Ok(())
     }

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -1260,6 +1260,69 @@ async fn sandbox_network_policy_is_applied_and_persisted() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn sandbox_network_policy_rolls_back_when_metadata_persist_fails() -> Result<()> {
+    setup();
+    let control = Arc::new(ScriptedStoreControl::default());
+    let behavior = Arc::new(MockBehavior::new());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&control)),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+
+    let initial_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Deny,
+        SandboxNetworkEgressPolicy::new(
+            Some(vec!["8.8.8.8".to_string()]),
+            Some(vec!["203.0.113.0/24".to_string()]),
+        )?,
+    );
+    let mut request = create_request(Some(60), &[]);
+    request.network_policy = initial_policy.clone();
+    let created = orchestrator.create_sandbox(request).await?;
+    assert_eq!(created.network_policy, initial_policy);
+
+    let updated_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Allow,
+        SandboxNetworkEgressPolicy::new(None, Some(vec!["198.51.100.0/24".to_string()]))?,
+    );
+
+    // Fail the metadata write that follows the successful live policy apply.
+    control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("injected metadata failure during network policy update"),
+    }));
+
+    let err = orchestrator
+        .replace_sandbox_network_policy(created.id, updated_policy.clone())
+        .await
+        .expect_err("network policy update must fail when metadata cannot persist");
+
+    assert!(matches!(
+        err,
+        OrchestratorError::StoreOperationFailed(StoreError::Backend { .. })
+    ));
+    assert_eq!(
+        behavior.update_network_calls(),
+        2,
+        "runtime policy apply must be followed by a rollback apply"
+    );
+    let applied = behavior.applied_network_policies();
+    assert_eq!(applied.len(), 2);
+    assert_eq!(applied[0], updated_policy.runtime_policy());
+    assert_eq!(applied[1], initial_policy.runtime_policy());
+
+    let metadata = orchestrator
+        .get_sandbox(&created.id)
+        .await?
+        .expect("sandbox metadata should remain");
+    assert_eq!(
+        metadata.network_policy, initial_policy,
+        "failed persist must leave stored policy unchanged"
+    );
+
+    Ok(())
+}
+
 async fn wait_for_state(
     orchestrator: &Arc<TestOrchestrator>,
     sandbox_id: &SandboxId,

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use async_trait::async_trait;
 use serde_json::json;
 use tempfile::TempDir;
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
 use tokio::time::{sleep, Duration};
 use uuid::Uuid;
 
@@ -131,6 +131,9 @@ struct ScriptedStoreControl {
     add_actions: StdMutex<VecDeque<StoreAction>>,
     update_if_state_actions: StdMutex<VecDeque<StoreAction>>,
     on_add: StoreHookSlot,
+    /// Optional one-shot gate: the next `update_if_state` / `update_state_if_state`
+    /// signals `entered` then waits for `release` before continuing.
+    update_gate: StdMutex<Option<(oneshot::Sender<()>, oneshot::Receiver<()>)>>,
 }
 
 impl ScriptedStoreControl {
@@ -150,6 +153,28 @@ impl ScriptedStoreControl {
 
     fn set_on_add(&self, hook: StoreHook) {
         *self.on_add.lock().expect("on_add mutex poisoned") = Some(hook);
+    }
+
+    fn arm_next_update_gate(&self) -> (oneshot::Receiver<()>, oneshot::Sender<()>) {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        *self
+            .update_gate
+            .lock()
+            .expect("update gate mutex poisoned") = Some((entered_tx, release_rx));
+        (entered_rx, release_tx)
+    }
+
+    async fn wait_update_gate(&self) {
+        let gate = self
+            .update_gate
+            .lock()
+            .expect("update gate mutex poisoned")
+            .take();
+        if let Some((entered_tx, release_rx)) = gate {
+            let _ = entered_tx.send(());
+            let _ = release_rx.await;
+        }
     }
 
     fn take_action(queue: &StdMutex<VecDeque<StoreAction>>) -> StoreAction {
@@ -201,6 +226,7 @@ impl MetadataStore for ScriptedStore {
         new_state: SandboxState,
         expected_states: &[SandboxState],
     ) -> StdResult<SandboxState, StoreError> {
+        self.control.wait_update_gate().await;
         match ScriptedStoreControl::take_action(&self.control.update_if_state_actions) {
             StoreAction::Delegate => {
                 self.inner
@@ -220,6 +246,7 @@ impl MetadataStore for ScriptedStore {
     where
         F: FnOnce(&mut SandboxMetadata) + Send,
     {
+        self.control.wait_update_gate().await;
         match ScriptedStoreControl::take_action(&self.control.update_if_state_actions) {
             StoreAction::Delegate => {
                 self.inner
@@ -1318,6 +1345,223 @@ async fn sandbox_network_policy_rolls_back_when_metadata_persist_fails() -> Resu
     assert_eq!(
         metadata.network_policy, initial_policy,
         "failed persist must leave stored policy unchanged"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sandbox_network_policy_surfaces_rollback_failure() -> Result<()> {
+    setup();
+    let control = Arc::new(ScriptedStoreControl::default());
+    let behavior = Arc::new(MockBehavior::new());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&control)),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+
+    let initial_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Deny,
+        SandboxNetworkEgressPolicy::new(
+            Some(vec!["8.8.8.8".to_string()]),
+            Some(vec!["203.0.113.0/24".to_string()]),
+        )?,
+    );
+    let mut request = create_request(Some(60), &[]);
+    request.network_policy = initial_policy.clone();
+    let created = orchestrator.create_sandbox(request).await?;
+
+    let updated_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Allow,
+        SandboxNetworkEgressPolicy::new(None, Some(vec!["198.51.100.0/24".to_string()]))?,
+    );
+
+    behavior.push_action(MockOperation::UpdateNetwork, MockAction::Succeed);
+    behavior.push_action(
+        MockOperation::UpdateNetwork,
+        MockAction::Fail {
+            message: "injected rollback failure".to_string(),
+        },
+    );
+    control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("injected metadata failure during network policy update"),
+    }));
+
+    let err = orchestrator
+        .replace_sandbox_network_policy(created.id, updated_policy.clone())
+        .await
+        .expect_err("double failure must surface enforcement inconsistency");
+
+    match err {
+        OrchestratorError::SandboxOperationFailed {
+            operation: SandboxOperation::UpdateNetwork,
+            source,
+            ..
+        } => {
+            let message = source.to_string();
+            assert!(
+                message.contains("runtime enforcement and metadata may disagree"),
+                "unexpected error message: {message}"
+            );
+            assert!(
+                message.contains("injected rollback failure"),
+                "unexpected error message: {message}"
+            );
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+    assert_eq!(behavior.update_network_calls(), 2);
+    assert_eq!(
+        behavior.applied_network_policies(),
+        vec![updated_policy.runtime_policy()],
+        "failed rollback must not be recorded as applied"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sandbox_network_policy_completes_rollback_after_caller_cancel() -> Result<()> {
+    setup();
+    let control = Arc::new(ScriptedStoreControl::default());
+    let behavior = Arc::new(MockBehavior::new());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&control)),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+
+    let initial_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Deny,
+        SandboxNetworkEgressPolicy::new(
+            Some(vec!["8.8.8.8".to_string()]),
+            Some(vec!["203.0.113.0/24".to_string()]),
+        )?,
+    );
+    let mut request = create_request(Some(60), &[]);
+    request.network_policy = initial_policy.clone();
+    let created = orchestrator.create_sandbox(request).await?;
+    let sandbox_id = created.id;
+
+    let updated_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Allow,
+        SandboxNetworkEgressPolicy::new(None, Some(vec!["198.51.100.0/24".to_string()]))?,
+    );
+
+    let (entered_rx, release_tx) = control.arm_next_update_gate();
+    control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("injected metadata failure during network policy update"),
+    }));
+
+    let orch = Arc::clone(&orchestrator);
+    let replace_task = tokio::spawn(async move {
+        orch.replace_sandbox_network_policy(sandbox_id, updated_policy)
+            .await
+    });
+
+    entered_rx
+        .await
+        .expect("store update should signal that the live policy was already applied");
+    replace_task.abort();
+    let _ = replace_task.await;
+    release_tx
+        .send(())
+        .expect("lifecycle task should still be waiting on the update gate");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while behavior.update_network_calls() < 2 {
+        if std::time::Instant::now() >= deadline {
+            panic!("rollback did not complete after caller cancellation");
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(
+        behavior.applied_network_policies(),
+        vec![
+            SandboxNetworkPolicy::new(
+                BaseSandboxNetworkPolicy::Allow,
+                SandboxNetworkEgressPolicy::new(None, Some(vec!["198.51.100.0/24".to_string()]))?,
+            )
+            .runtime_policy(),
+            initial_policy.runtime_policy(),
+        ]
+    );
+    let metadata = orchestrator
+        .get_sandbox(&sandbox_id)
+        .await?
+        .expect("sandbox metadata should remain");
+    assert_eq!(metadata.network_policy, initial_policy);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sandbox_network_policy_serializes_concurrent_replacements() -> Result<()> {
+    setup();
+    let control = Arc::new(ScriptedStoreControl::default());
+    let behavior = Arc::new(MockBehavior::new());
+    let orchestrator = make_orchestrator_without_background_with_factory(
+        ScriptedStore::new(Arc::clone(&control)),
+        MockBackendFactory::with_behavior(Arc::clone(&behavior)),
+    );
+
+    let initial_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Deny,
+        SandboxNetworkEgressPolicy::new(
+            Some(vec!["8.8.8.8".to_string()]),
+            Some(vec!["203.0.113.0/24".to_string()]),
+        )?,
+    );
+    let mut request = create_request(Some(60), &[]);
+    request.network_policy = initial_policy.clone();
+    let created = orchestrator.create_sandbox(request).await?;
+    let sandbox_id = created.id;
+
+    let failing_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Allow,
+        SandboxNetworkEgressPolicy::new(None, Some(vec!["198.51.100.0/24".to_string()]))?,
+    );
+    let winning_policy = SandboxNetworkPolicy::new(
+        BaseSandboxNetworkPolicy::Deny,
+        SandboxNetworkEgressPolicy::new(
+            Some(vec!["1.1.1.1".to_string()]),
+            Some(vec!["192.0.2.0/24".to_string()]),
+        )?,
+    );
+
+    // Whichever replacement persists first fails once; the other succeeds.
+    // Holding the sandbox lock across apply/persist/rollback keeps runtime and
+    // metadata aligned with the last successful replacement.
+    control.push_update_if_state_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("injected metadata failure during concurrent network update"),
+    }));
+
+    let orch_a = Arc::clone(&orchestrator);
+    let orch_b = Arc::clone(&orchestrator);
+    let failing = failing_policy.clone();
+    let winning = winning_policy.clone();
+    let (a, b) = tokio::join!(
+        async move { orch_a.replace_sandbox_network_policy(sandbox_id, failing).await },
+        async move { orch_b.replace_sandbox_network_policy(sandbox_id, winning).await },
+    );
+
+    assert!(a.is_err() ^ b.is_err(), "exactly one replacement should fail: {a:?} / {b:?}");
+    let expected = if a.is_ok() {
+        failing_policy
+    } else {
+        winning_policy
+    };
+
+    let metadata = orchestrator
+        .get_sandbox(&sandbox_id)
+        .await?
+        .expect("sandbox metadata should remain");
+    assert_eq!(metadata.network_policy, expected);
+    let applied = behavior.applied_network_policies();
+    assert_eq!(
+        applied.last().cloned().flatten(),
+        expected.runtime_policy(),
+        "runtime enforcement must end on the successfully persisted policy: {applied:?}"
     );
 
     Ok(())

--- a/src/sandbox/mock.rs
+++ b/src/sandbox/mock.rs
@@ -345,14 +345,16 @@ impl SandboxBackend for MockSandboxBackend {
         &mut self,
         policy: Option<super::SandboxNetworkPolicy>,
     ) -> Result<()> {
+        let applied_policy = policy.clone();
+        self.behavior
+            .apply_async(MockOperation::UpdateNetwork)
+            .await?;
         self.behavior
             .applied_network_policies
             .lock()
             .expect("mock behavior mutex poisoned")
-            .push(policy);
-        self.behavior
-            .apply_async(MockOperation::UpdateNetwork)
-            .await
+            .push(applied_policy);
+        Ok(())
     }
 
     fn update_custom_extension_params(&mut self, _params: Option<CustomExtensionParams>) {}

--- a/src/sandbox/mock.rs
+++ b/src/sandbox/mock.rs
@@ -24,7 +24,7 @@ use super::backend::{
     SandboxBackendFactory, SandboxCaptureResult, SandboxForkResult, SandboxRuntimeInfo,
 };
 use super::{FreshSandboxBuildSpec, SandboxCaptureError, SandboxLaunchConfig};
-use crate::sandbox::CustomExtensionParams;
+use crate::sandbox::{CustomExtensionParams, SandboxNetworkPolicy};
 
 #[derive(Debug)]
 pub struct MockSnapshot;
@@ -73,6 +73,7 @@ pub struct MockBehavior {
     on_operation: Mutex<HashMap<MockOperation, Arc<dyn Fn() + Send + Sync>>>,
     runtime_info: Mutex<SandboxRuntimeInfo>,
     source_config_paths: Mutex<Vec<std::path::PathBuf>>,
+    applied_network_policies: Mutex<Vec<Option<SandboxNetworkPolicy>>>,
     stop_calls: AtomicUsize,
     update_network_calls: AtomicUsize,
 }
@@ -128,6 +129,13 @@ impl MockBehavior {
 
     pub fn update_network_calls(&self) -> usize {
         self.update_network_calls.load(Ordering::Relaxed)
+    }
+
+    pub fn applied_network_policies(&self) -> Vec<Option<SandboxNetworkPolicy>> {
+        self.applied_network_policies
+            .lock()
+            .expect("mock behavior mutex poisoned")
+            .clone()
     }
 
     fn pop_action(&self, operation: MockOperation) -> MockAction {
@@ -335,8 +343,13 @@ impl SandboxBackend for MockSandboxBackend {
 
     async fn update_network_policy(
         &mut self,
-        _policy: Option<super::SandboxNetworkPolicy>,
+        policy: Option<super::SandboxNetworkPolicy>,
     ) -> Result<()> {
+        self.behavior
+            .applied_network_policies
+            .lock()
+            .expect("mock behavior mutex poisoned")
+            .push(policy);
         self.behavior
             .apply_async(MockOperation::UpdateNetwork)
             .await


### PR DESCRIPTION
## Summary
- Network policy updates applied live iptables/runtime rules before persisting metadata.
- A store failure returned an error while egress rules had already changed, desyncing API metadata from enforced policy.
- On persist failure, roll the runtime policy back to the previous value and map `StateConflict` to 409 like patch-params.

## Test plan
- [x] Added `sandbox_network_policy_rolls_back_when_metadata_persist_fails`
- [x] `cargo test -p agentenv --lib sandbox_network_policy`