### PR TITLE
fix(orchestrator): treat persistence cleanup failures as operation failures

### DIFF
--- a/src/orchestrator/persistence/file_backed.rs
+++ b/src/orchestrator/persistence/file_backed.rs
@@ -365,8 +365,10 @@ impl SandboxPersister for FileBackedSandboxPersister {
 
     async fn delete_record_and_artifacts(&self, sandbox_id: &SandboxId) -> PersistenceResult<()> {
         debug!(sandbox_id = %sandbox_id, "deleting paused sandbox record and artifacts");
-        self.remove_record(sandbox_id).await?;
+        // Remove artifacts before the record so a failed artifact cleanup cannot
+        // leave a restart-loadable record without its backing files.
         Self::remove_artifact_root(&self.sandbox_artifact_root(sandbox_id)).await?;
+        self.remove_record(sandbox_id).await?;
         Ok(())
     }
 }

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -894,6 +894,28 @@ where
             }
         };
 
+        // Remove durable paused state before detaching/stopping the runtime so a
+        // failed cleanup can restore the previous state while the handle and
+        // proxy route are still intact (including for Running sandboxes).
+        if let Err(err) = self
+            .persister
+            .delete_record_and_artifacts(&sandbox_id)
+            .await
+        {
+            warn!(error = ?err, "failed to delete persisted sandbox state");
+            if let Err(restore_err) = self
+                .store
+                .update_state_if_state(&sandbox_id, previous_state, &[SandboxState::Killing])
+                .await
+            {
+                warn!(
+                    error = ?restore_err,
+                    "failed to restore sandbox state after persistence cleanup failure"
+                );
+            }
+            return Err(OrchestratorError::from(err));
+        }
+
         let (handle, removed_route) = self.detach_sandbox_handle_and_route(&sandbox_id).await;
 
         // If the sandbox is still in memory, attempt to stop it.
@@ -919,30 +941,18 @@ where
             }
         }
 
-        // Remove durable paused state before dropping in-memory metadata so a
-        // failed cleanup cannot resurrect the sandbox after restart. On failure,
-        // restore the pre-delete state so the client can retry.
-        if let Err(err) = self
-            .persister
-            .delete_record_and_artifacts(&sandbox_id)
-            .await
-        {
-            warn!(error = ?err, "failed to delete persisted sandbox state");
-            if let Err(restore_err) = self
-                .store
-                .update_state_if_state(&sandbox_id, previous_state, &[SandboxState::Killing])
-                .await
-            {
+        // Durable state is gone; drop in-memory metadata. Retry once if the
+        // store remove is transiently unavailable.
+        let metadata = match self.store.remove(&sandbox_id).await {
+            Ok(metadata) => metadata,
+            Err(err) => {
                 warn!(
-                    error = ?restore_err,
-                    "failed to restore sandbox state after persistence cleanup failure"
+                    error = ?err,
+                    "failed to remove sandbox metadata after durable cleanup; retrying"
                 );
+                self.store.remove(&sandbox_id).await?
             }
-            return Err(OrchestratorError::from(err));
-        }
-
-        // Now the sandbox is successfully stopped, remove its metadata.
-        let metadata = self.store.remove(&sandbox_id).await?;
+        };
         if let Some(metadata) = metadata {
             self.publish_sandbox_event(
                 SandboxLifecycleEventType::Delete,
@@ -2017,6 +2027,16 @@ where
                 );
                 self.cleanup_failed_launch(&plan, handle, FailedLaunchStage::RunningPersisted)
                     .await;
+                // cleanup_failed_launch already attempted rollback_resuming once.
+                // Retry so a transient failure cannot leave a Resuming marker that
+                // load_all would discard on the next process start.
+                if let Err(rollback_err) = self.persister.rollback_resuming(&sandbox_id).await {
+                    warn!(
+                        error = %format_args!("{rollback_err:#}"),
+                        "failed to restore persisted sandbox record after resume rollback"
+                    );
+                    return Err(OrchestratorError::from(rollback_err));
+                }
                 return Err(OrchestratorError::from(err));
             }
         }
@@ -2097,6 +2117,12 @@ where
                 }
             }
             LaunchPlan::Resume(_) => {
+                // Restore durable lifecycle before flipping in-memory state so a
+                // crash cannot observe Paused metadata with a Resuming record
+                // that load_all would discard.
+                if let Err(err) = self.persister.rollback_resuming(&plan.sandbox_id()).await {
+                    warn!(error = %format_args!("{err:#}"), "failed to restore persisted sandbox record lifecycle during launch rollback");
+                }
                 if let Err(err) = self
                     .store
                     .update_state_if_state(
@@ -2107,9 +2133,6 @@ where
                     .await
                 {
                     warn!(error = %format_args!("{err:#}"), "failed to restore sandbox metadata during launch rollback");
-                }
-                if let Err(err) = self.persister.rollback_resuming(&plan.sandbox_id()).await {
-                    warn!(error = %format_args!("{err:#}"), "failed to restore persisted sandbox record lifecycle during launch rollback");
                 }
             }
         }

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -919,6 +919,28 @@ where
             }
         }
 
+        // Remove durable paused state before dropping in-memory metadata so a
+        // failed cleanup cannot resurrect the sandbox after restart. On failure,
+        // restore the pre-delete state so the client can retry.
+        if let Err(err) = self
+            .persister
+            .delete_record_and_artifacts(&sandbox_id)
+            .await
+        {
+            warn!(error = ?err, "failed to delete persisted sandbox state");
+            if let Err(restore_err) = self
+                .store
+                .update_state_if_state(&sandbox_id, previous_state, &[SandboxState::Killing])
+                .await
+            {
+                warn!(
+                    error = ?restore_err,
+                    "failed to restore sandbox state after persistence cleanup failure"
+                );
+            }
+            return Err(OrchestratorError::from(err));
+        }
+
         // Now the sandbox is successfully stopped, remove its metadata.
         let metadata = self.store.remove(&sandbox_id).await?;
         if let Some(metadata) = metadata {
@@ -927,13 +949,6 @@ where
                 metadata.id,
                 metadata.resources,
             );
-        }
-        if let Err(err) = self
-            .persister
-            .delete_record_and_artifacts(&sandbox_id)
-            .await
-        {
-            warn!(error = ?err, "failed to delete persisted sandbox state");
         }
         self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
             .await;
@@ -1996,7 +2011,13 @@ where
 
         if matches!(plan, LaunchPlan::Resume(_)) {
             if let Err(err) = self.persister.delete_record(&sandbox_id).await {
-                warn!(error = %format_args!("{err:#}"), "failed to delete persisted sandbox record after resume");
+                warn!(
+                    error = %format_args!("{err:#}"),
+                    "failed to delete persisted sandbox record after resume; rolling back"
+                );
+                self.cleanup_failed_launch(&plan, handle, FailedLaunchStage::RunningPersisted)
+                    .await;
+                return Err(OrchestratorError::from(err));
             }
         }
 

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -130,6 +130,7 @@ type StoreHookSlot = StdMutex<Option<StoreHook>>;
 struct ScriptedStoreControl {
     add_actions: StdMutex<VecDeque<StoreAction>>,
     update_if_state_actions: StdMutex<VecDeque<StoreAction>>,
+    remove_actions: StdMutex<VecDeque<StoreAction>>,
     on_add: StoreHookSlot,
 }
 
@@ -145,6 +146,13 @@ impl ScriptedStoreControl {
         self.update_if_state_actions
             .lock()
             .expect("update_if_state actions mutex poisoned")
+            .push_back(action);
+    }
+
+    fn push_remove_action(&self, action: StoreAction) {
+        self.remove_actions
+            .lock()
+            .expect("remove actions mutex poisoned")
             .push_back(action);
     }
 
@@ -238,7 +246,10 @@ impl MetadataStore for ScriptedStore {
         &self,
         sandbox_id: &SandboxId,
     ) -> StdResult<Option<SandboxMetadata>, StoreError> {
-        self.inner.remove(sandbox_id).await
+        match ScriptedStoreControl::take_action(&self.control.remove_actions) {
+            StoreAction::Delegate => self.inner.remove(sandbox_id).await,
+            StoreAction::Fail(err) => Err(err),
+        }
     }
 
     async fn list(&self) -> StdResult<Vec<SandboxMetadata>, StoreError> {
@@ -3238,6 +3249,75 @@ async fn delete_sandbox_fails_when_persisted_state_cannot_be_removed() -> Result
 }
 
 #[tokio::test]
+async fn delete_running_sandbox_preserves_runtime_when_persist_cleanup_fails() -> Result<()> {
+    setup();
+    let persister = RecordingPersister::default();
+    let orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::new(),
+        persister.clone(),
+    );
+    let created = orchestrator
+        .create_sandbox(create_request(
+            Some(60),
+            &[("team", "delete-running-persist-fail")],
+        ))
+        .await?;
+    persister.clear_calls();
+    persister.fail_next(RecordingCall::DeleteRecordAndArtifacts);
+
+    let err = orchestrator
+        .delete_sandbox(created.id)
+        .await
+        .expect_err("delete must fail before detaching a running sandbox");
+
+    assert!(matches!(
+        err,
+        OrchestratorError::SandboxPersistenceFailed(_)
+    ));
+    let metadata = orchestrator
+        .get_sandbox(&created.id)
+        .await?
+        .expect("running sandbox metadata must remain");
+    assert_eq!(metadata.state, SandboxState::Running);
+    assert_proxy_ready(&orchestrator, &created.id).await?;
+
+    orchestrator.delete_sandbox(created.id).await?;
+    assert!(orchestrator.get_sandbox(&created.id).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_sandbox_retries_metadata_remove_after_durable_cleanup() -> Result<()> {
+    setup();
+    let control = Arc::new(ScriptedStoreControl::default());
+    let persister = RecordingPersister::default();
+    let orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        ScriptedStore::new(Arc::clone(&control)),
+        MockBackendFactory::new(),
+        persister.clone(),
+    );
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[("team", "delete-remove-retry")]))
+        .await?;
+    orchestrator.pause_sandbox(created.id).await?;
+    persister.clear_calls();
+
+    // First metadata remove fails after durable cleanup; retry delegates.
+    control.push_remove_action(StoreAction::Fail(StoreError::Backend {
+        source: anyhow::anyhow!("injected metadata remove failure after durable cleanup"),
+    }));
+
+    orchestrator.delete_sandbox(created.id).await?;
+    assert!(orchestrator.get_sandbox(&created.id).await?.is_none());
+    assert_eq!(
+        persister.calls(),
+        vec![RecordingCall::DeleteRecordAndArtifacts]
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn resume_delete_record_failure_rolls_back_to_paused() -> Result<()> {
     setup();
     let persister = RecordingPersister::default();
@@ -3267,6 +3347,7 @@ async fn resume_delete_record_failure_rolls_back_to_paused() -> Result<()> {
         vec![
             RecordingCall::MarkResuming,
             RecordingCall::DeleteRecord,
+            RecordingCall::RollbackResuming,
             RecordingCall::RollbackResuming
         ]
     );
@@ -3278,6 +3359,64 @@ async fn resume_delete_record_failure_rolls_back_to_paused() -> Result<()> {
     assert!(metadata.paused_state.is_some());
     assert_proxy_paused(&orchestrator, &created.id).await?;
     assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn resume_rollback_resuming_failure_is_surfaced() -> Result<()> {
+    setup();
+    let persister = RecordingPersister::default();
+    let orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::new(),
+        persister.clone(),
+    );
+    let created = orchestrator
+        .create_sandbox(create_request(
+            Some(60),
+            &[("team", "resume-rollback-fail")],
+        ))
+        .await?;
+    orchestrator.pause_sandbox(created.id).await?;
+    persister.clear_calls();
+    persister.fail_next(RecordingCall::DeleteRecord);
+    // cleanup_failed_launch rolls back once; the resume path retries once more.
+    persister.fail_next(RecordingCall::RollbackResuming);
+    persister.fail_next(RecordingCall::RollbackResuming);
+
+    let err = orchestrator
+        .resume_sandbox(created.id, NewTimeout::UseExisting)
+        .await
+        .expect_err("resume must fail when Resuming cannot be rolled back");
+
+    assert!(matches!(
+        err,
+        OrchestratorError::SandboxPersistenceFailed(_)
+    ));
+    assert_eq!(
+        persister.calls(),
+        vec![
+            RecordingCall::MarkResuming,
+            RecordingCall::DeleteRecord,
+            RecordingCall::RollbackResuming,
+            RecordingCall::RollbackResuming
+        ]
+    );
+    let metadata = orchestrator
+        .get_sandbox(&created.id)
+        .await?
+        .expect("metadata should remain after failed resume rollback");
+    // Durable rollback failed, so in-memory state may still be Running from the
+    // aborted resume; the important guarantee is we return a persistence error
+    // instead of reporting success with a Resuming marker.
+    assert!(
+        matches!(
+            metadata.state,
+            SandboxState::Paused | SandboxState::Running | SandboxState::Resuming
+        ),
+        "unexpected state after rollback failure: {:?}",
+        metadata.state
+    );
     Ok(())
 }
 

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -3196,6 +3196,92 @@ async fn resume_marks_resuming_and_deletes_record_after_success() -> Result<()> 
 }
 
 #[tokio::test]
+async fn delete_sandbox_fails_when_persisted_state_cannot_be_removed() -> Result<()> {
+    setup();
+    let persister = RecordingPersister::default();
+    let orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::new(),
+        persister.clone(),
+    );
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[("team", "delete-persist-fail")]))
+        .await?;
+    orchestrator.pause_sandbox(created.id).await?;
+    persister.clear_calls();
+    persister.fail_next(RecordingCall::DeleteRecordAndArtifacts);
+
+    let err = orchestrator
+        .delete_sandbox(created.id)
+        .await
+        .expect_err("delete must fail when durable paused state cannot be removed");
+
+    assert!(matches!(
+        err,
+        OrchestratorError::SandboxPersistenceFailed(_)
+    ));
+    assert_eq!(
+        persister.calls(),
+        vec![RecordingCall::DeleteRecordAndArtifacts]
+    );
+    let metadata = orchestrator
+        .get_sandbox(&created.id)
+        .await?
+        .expect("metadata must remain so delete can be retried");
+    assert_eq!(metadata.state, SandboxState::Paused);
+    assert!(metadata.paused_state.is_some());
+
+    // Retry succeeds once persistence cleanup works again.
+    orchestrator.delete_sandbox(created.id).await?;
+    assert!(orchestrator.get_sandbox(&created.id).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn resume_delete_record_failure_rolls_back_to_paused() -> Result<()> {
+    setup();
+    let persister = RecordingPersister::default();
+    let orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::new(),
+        persister.clone(),
+    );
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[("team", "resume-delete-fail")]))
+        .await?;
+    orchestrator.pause_sandbox(created.id).await?;
+    persister.clear_calls();
+    persister.fail_next(RecordingCall::DeleteRecord);
+
+    let err = orchestrator
+        .resume_sandbox(created.id, NewTimeout::UseExisting)
+        .await
+        .expect_err("resume must fail when the Resuming marker cannot be cleared");
+
+    assert!(matches!(
+        err,
+        OrchestratorError::SandboxPersistenceFailed(_)
+    ));
+    assert_eq!(
+        persister.calls(),
+        vec![
+            RecordingCall::MarkResuming,
+            RecordingCall::DeleteRecord,
+            RecordingCall::RollbackResuming
+        ]
+    );
+    let metadata = orchestrator
+        .get_sandbox(&created.id)
+        .await?
+        .expect("metadata should remain after resume rollback");
+    assert_eq!(metadata.state, SandboxState::Paused);
+    assert!(metadata.paused_state.is_some());
+    assert_proxy_paused(&orchestrator, &created.id).await?;
+    assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn resume_mark_resuming_failure_restores_paused_metadata() -> Result<()> {
     setup();
     let persister = RecordingPersister::default();


### PR DESCRIPTION
## Summary
- Delete reported success even when paused artifacts could not be removed, so sandboxes could resurrect after restart.
- Resume warned and continued when clearing the `Resuming` marker failed, so a crash could discard the paused record.
- Delete now fails and restores a stable state for retry; resume rolls back to `Paused` if record cleanup fails.

## Test plan
- [x] Added `delete_sandbox_fails_when_persisted_state_cannot_be_removed`
- [x] Added `resume_delete_record_failure_rolls_back_to_paused`
- [x] `cargo test -p agentenv --lib resume_marks_resuming`
- [x] `cargo test -p agentenv --lib delete_sandbox_fails_when_persisted`