### PR TITLE
test(image): cover ACR referrer discovery at the regctl boundary

### DIFF
--- a/src/image/resolver.rs
+++ b/src/image/resolver.rs
@@ -677,7 +677,7 @@ mod tests {
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": "sha256:overlaybd",
                     "size": 20,
-                    "artifactType": OVERLAYBD_NATIVE_ARTIFACT_TYPE
+                    "artifactType": "application/vnd.containerd.overlaybd.native.v1+json"
                 }
             ]
         });
@@ -700,13 +700,13 @@ mod tests {
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": "sha256:first",
                     "size": 10,
-                    "artifactType": OVERLAYBD_NATIVE_ARTIFACT_TYPE
+                    "artifactType": "application/vnd.containerd.overlaybd.native.v1+json"
                 },
                 {
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": "sha256:second",
                     "size": 20,
-                    "artifactType": OVERLAYBD_NATIVE_ARTIFACT_TYPE
+                    "artifactType": "application/vnd.containerd.overlaybd.native.v1+json"
                 }
             ]
         });
@@ -748,7 +748,7 @@ mod tests {
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": "sha256:0a21030948e9223e054ab830dd82b0ad85f921df34f11c5bf769bb0ed636d72a",
                     "size": 1234,
-                    "artifactType": ACR_ARTIFACT_STREAMING_ARTIFACT_TYPE,
+                    "artifactType": "application/vnd.azure.artifact.streaming.v1",
                     "annotations": {
                         "streaming.format": "overlaybd",
                         "streaming.version": "v1",
@@ -764,7 +764,58 @@ mod tests {
             Some((
                 "sha256:0a21030948e9223e054ab830dd82b0ad85f921df34f11c5bf769bb0ed636d72a"
                     .to_string(),
-                ACR_ARTIFACT_STREAMING_ARTIFACT_TYPE
+                "application/vnd.azure.artifact.streaming.v1"
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_overlaybd_referrer_selects_first_of_acr_per_platform_referrers() {
+        // Captured from `regctl artifact list --format body` against a real ACR
+        // registry for a multi-arch tag, with the generic
+        // `org.opencontainers.image.*` annotations elided for readability.
+        //
+        // ACR attaches one streaming referrer per platform, all sharing the
+        // same artifactType, so a multi-arch subject legitimately yields
+        // several matches and the "multiple referrers" path is the normal case
+        // rather than an oddity. Selection stays first-match.
+        let body = json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "sha256:1bdbcce5b02202d0c4c204da05e6ffbb8605bb178f441ff2990b9924c046a69f",
+                    "size": 2817,
+                    "artifactType": "application/vnd.azure.artifact.streaming.v1",
+                    "annotations": {
+                        "streaming.format": "overlaybd",
+                        "streaming.version": "v1",
+                        "streaming.platform.os": "linux",
+                        "streaming.platform.arch": "amd64"
+                    }
+                },
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "sha256:3a5ae9547e3ed4d44f435db3ca286f9655e9fcb43ba36b0f5a6cf7da409ce0b8",
+                    "size": 2819,
+                    "artifactType": "application/vnd.azure.artifact.streaming.v1",
+                    "annotations": {
+                        "streaming.format": "overlaybd",
+                        "streaming.version": "v1",
+                        "streaming.platform.os": "linux",
+                        "streaming.platform.arch": "arm64"
+                    }
+                }
+            ]
+        });
+
+        assert_eq!(
+            parse_overlaybd_referrer(&body.to_string()).expect("parse"),
+            Some((
+                "sha256:1bdbcce5b02202d0c4c204da05e6ffbb8605bb178f441ff2990b9924c046a69f"
+                    .to_string(),
+                "application/vnd.azure.artifact.streaming.v1"
             ))
         );
     }
@@ -779,20 +830,23 @@ mod tests {
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": "sha256:acr",
                     "size": 10,
-                    "artifactType": ACR_ARTIFACT_STREAMING_ARTIFACT_TYPE
+                    "artifactType": "application/vnd.azure.artifact.streaming.v1"
                 },
                 {
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": "sha256:native",
                     "size": 20,
-                    "artifactType": OVERLAYBD_NATIVE_ARTIFACT_TYPE
+                    "artifactType": "application/vnd.containerd.overlaybd.native.v1+json"
                 }
             ]
         });
 
         assert_eq!(
             parse_overlaybd_referrer(&body.to_string()).expect("parse"),
-            Some(("sha256:native".to_string(), OVERLAYBD_NATIVE_ARTIFACT_TYPE))
+            Some((
+                "sha256:native".to_string(),
+                "application/vnd.containerd.overlaybd.native.v1+json"
+            ))
         );
     }
 
@@ -822,6 +876,169 @@ mod tests {
         assert_eq!(
             parse_overlaybd_referrer(&body.to_string()).expect("parse"),
             None
+        );
+    }
+
+    #[test]
+    fn overlaybd_referrer_artifact_types_match_published_wire_values() {
+        // These are registry wire values, not internal identifiers: they must
+        // match byte-for-byte what accelerated-container-image and ACR publish.
+        // Asserting the literals here means a typo in the constants fails with
+        // a readable diff instead of only surfacing as a missed referrer.
+        assert_eq!(
+            OVERLAYBD_NATIVE_ARTIFACT_TYPE,
+            "application/vnd.containerd.overlaybd.native.v1+json"
+        );
+        assert_eq!(
+            ACR_ARTIFACT_STREAMING_ARTIFACT_TYPE,
+            "application/vnd.azure.artifact.streaming.v1"
+        );
+        // Preference order is part of the contract: an image carrying both
+        // referrers must resolve to the accelerated-container-image one.
+        assert_eq!(
+            OVERLAYBD_REFERRER_ARTIFACT_TYPES.to_vec(),
+            vec![
+                "application/vnd.containerd.overlaybd.native.v1+json",
+                "application/vnd.azure.artifact.streaming.v1",
+            ]
+        );
+    }
+
+    /// Install a fake `regctl` that records its argv (one entry per line) into
+    /// `<dir>/argv`, replays `stdout`/`stderr`, and exits with `exit_code`.
+    ///
+    /// This covers the half of discovery that fixture-only tests cannot: the
+    /// argv actually handed to `regctl`.
+    #[cfg(unix)]
+    fn fake_regctl(
+        dir: &std::path::Path,
+        stdout: &str,
+        stderr: &str,
+        exit_code: i32,
+    ) -> std::path::PathBuf {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let argv_path = dir.join("argv");
+        let stdout_path = dir.join("stdout");
+        let stderr_path = dir.join("stderr");
+        std::fs::write(&stdout_path, stdout).expect("write stdout fixture");
+        std::fs::write(&stderr_path, stderr).expect("write stderr fixture");
+
+        // Staged write + rename so the binary is never observed half-written or
+        // non-executable, matching how the real dependency installer stages
+        // downloads.
+        let binary = dir.join("regctl");
+        let staged = dir.join("regctl.staged");
+        {
+            let mut file = std::fs::File::create(&staged).expect("create fake regctl");
+            write!(
+                file,
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{argv}'\ncat '{stdout}'\ncat '{stderr}' >&2\nexit {exit_code}\n",
+                argv = argv_path.display(),
+                stdout = stdout_path.display(),
+                stderr = stderr_path.display(),
+            )
+            .expect("write fake regctl");
+            file.sync_all().expect("sync fake regctl");
+        }
+        let mut permissions = std::fs::metadata(&staged).expect("stat").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&staged, permissions).expect("chmod fake regctl");
+        std::fs::rename(&staged, &binary).expect("publish fake regctl");
+        binary
+    }
+
+    #[cfg(unix)]
+    fn recorded_argv(dir: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(dir.join("argv"))
+            .expect("fake regctl did not run")
+            .lines()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn discover_overlaybd_referrer_lists_referrers_unfiltered_and_finds_acr_streaming() {
+        let temp = TempDir::new().expect("tempdir");
+        let subject = "demo.azurecr.io/python:3.11-slim";
+        // Literal referrers index as returned by ACR for an image processed by
+        // `az acr artifact-streaming create`.
+        let body = json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "sha256:0a21030948e9223e054ab830dd82b0ad85f921df34f11c5bf769bb0ed636d72a",
+                    "size": 1234,
+                    "artifactType": "application/vnd.azure.artifact.streaming.v1",
+                    "annotations": {
+                        "streaming.format": "overlaybd",
+                        "streaming.version": "v1",
+                        "streaming.platform.os": "linux",
+                        "streaming.platform.arch": "amd64"
+                    }
+                }
+            ]
+        });
+        let regctl = fake_regctl(temp.path(), &body.to_string(), "", 0);
+
+        let discovered = discover_overlaybd_referrer(&regctl, subject)
+            .await
+            .expect("discover referrer");
+
+        assert_eq!(
+            discovered,
+            Some((
+                "sha256:0a21030948e9223e054ab830dd82b0ad85f921df34f11c5bf769bb0ed636d72a"
+                    .to_string(),
+                "application/vnd.azure.artifact.streaming.v1"
+            ))
+        );
+
+        let argv = recorded_argv(temp.path());
+        // The listing must stay unfiltered. `regctl artifact list` accepts only
+        // one `--filter-artifact-type`, so reintroducing it would pin discovery
+        // to a single artifactType and silently drop ACR referrers while every
+        // parse-level test stayed green.
+        assert!(
+            !argv.iter().any(|arg| arg == "--filter-artifact-type"),
+            "referrers must be listed unfiltered and matched locally, got argv: {argv:?}"
+        );
+        assert_eq!(
+            argv,
+            vec!["artifact", "list", "--format", "body", subject],
+            "unexpected regctl invocation"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn discover_overlaybd_referrer_surfaces_regctl_failure() {
+        let temp = TempDir::new().expect("tempdir");
+        let regctl = fake_regctl(
+            temp.path(),
+            "",
+            "unauthorized: authentication required\n",
+            1,
+        );
+
+        let error = discover_overlaybd_referrer(&regctl, "demo.azurecr.io/python:3.11-slim")
+            .await
+            .expect_err("regctl failure must not be reported as 'no referrer'");
+
+        // A registry error has to fail loudly: swallowing it into `Ok(None)`
+        // would silently downgrade to a local pull-and-convert.
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("regctl artifact list failed"),
+            "unexpected error: {rendered}"
+        );
+        assert!(
+            rendered.contains("unauthorized: authentication required"),
+            "regctl stderr must be preserved: {rendered}"
         );
     }
 

--- a/src/image/resolver.rs
+++ b/src/image/resolver.rs
@@ -922,12 +922,15 @@ mod tests {
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
 
-        let argv_path = dir.join("argv");
         let stdout_path = dir.join("stdout");
         let stderr_path = dir.join("stderr");
         std::fs::write(&stdout_path, stdout).expect("write stdout fixture");
         std::fs::write(&stderr_path, stderr).expect("write stderr fixture");
 
+        // The script locates its fixtures relative to `$0` rather than
+        // embedding absolute paths, so a TMPDIR containing shell
+        // metacharacters cannot break or inject into the generated script.
+        //
         // Staged write + rename so the binary is never observed half-written or
         // non-executable, matching how the real dependency installer stages
         // downloads.
@@ -937,10 +940,7 @@ mod tests {
             let mut file = std::fs::File::create(&staged).expect("create fake regctl");
             write!(
                 file,
-                "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{argv}'\ncat '{stdout}'\ncat '{stderr}' >&2\nexit {exit_code}\n",
-                argv = argv_path.display(),
-                stdout = stdout_path.display(),
-                stderr = stderr_path.display(),
+                "#!/bin/sh\ndir=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\nprintf '%s\\n' \"$@\" > \"$dir/argv\"\ncat \"$dir/stdout\"\ncat \"$dir/stderr\" >&2\nexit {exit_code}\n",
             )
             .expect("write fake regctl");
             file.sync_all().expect("sync fake regctl");

--- a/src/image/resolver.rs
+++ b/src/image/resolver.rs
@@ -772,13 +772,16 @@ mod tests {
     #[test]
     fn parse_overlaybd_referrer_selects_first_of_acr_per_platform_referrers() {
         // Captured from `regctl artifact list --format body` against a real ACR
-        // registry for a multi-arch tag, with the generic
+        // registry, using a multi-arch *tag* as the subject, with the generic
         // `org.opencontainers.image.*` annotations elided for readability.
         //
-        // ACR attaches one streaming referrer per platform, all sharing the
-        // same artifactType, so a multi-arch subject legitimately yields
-        // several matches and the "multiple referrers" path is the normal case
-        // rather than an oddity. Selection stays first-match.
+        // ACR attaches one streaming referrer per platform, all sharing the same
+        // artifactType, so an index subject yields several matches. The resolver
+        // never passes an index: `resolve_fetched_manifest` hands
+        // `FetchedManifest::selected_image_ref` to discovery, which is already
+        // pinned to the platform-resolved manifest digest, and such a subject
+        // carries exactly one referrer. This multi-match shape is therefore a
+        // defensive lock on first-match selection rather than the common path.
         let body = json!({
             "schemaVersion": 2,
             "mediaType": "application/vnd.oci.image.index.v1+json",


### PR DESCRIPTION
## Summary

Follow-up for code quality on the review feedback in
https://github.com/kvcache-ai/AgentENV/pull/58#pullrequestreview-4805170907.

Both non-blocking suggestions from that review are addressed here. **This PR changes no
production code** — it is test-only.

## 1. Coverage now starts at the regctl boundary, not at the parser

The review noted that coverage started at `parse_overlaybd_referrer`, so reintroducing
`--filter-artifact-type` to the `regctl artifact list` command would leave tests green while
breaking ACR discovery.

`discover_overlaybd_referrer_lists_referrers_unfiltered_and_finds_acr_streaming` installs a fake
`regctl` that records its argv and replays a canned referrers index, then asserts the listing is
unfiltered and that the ACR referrer is returned.

I verified the test actually closes the gap by mutation — reintroducing the flag:

```diff
     .arg("list")
+    .arg("--filter-artifact-type")
+    .arg(OVERLAYBD_NATIVE_ARTIFACT_TYPE)
     .arg("--format")
```

```
test parse_overlaybd_referrer_picks_matching_artifact ... ok
test parse_overlaybd_referrer_keeps_first_matching_artifact ... ok
test parse_overlaybd_referrer_returns_none_without_match ... ok
test parse_overlaybd_referrer_accepts_acr_artifact_streaming ... ok
test parse_overlaybd_referrer_prefers_containerd_native_over_acr_streaming ... ok
test parse_overlaybd_referrer_ignores_unrelated_artifact_types ... ok
test parse_overlaybd_referrer_selects_first_of_acr_per_platform_referrers ... ok
test discover_overlaybd_referrer_lists_referrers_unfiltered_and_finds_acr_streaming ... FAILED

test result: FAILED. 17 passed; 1 failed
```

All seven parse-level tests stay green; only the new test fails. That is exactly the regression
the review described.

The same fake-regctl harness also covers the failure path, which previously had no test: a
registry error must surface as an error rather than `Ok(None)`, since `Ok(None)` would silently
downgrade to a local pull-and-convert.

## 2. Fixtures use literal wire values

Fixtures now use the literal artifactType strings rather than the implementation constants, so an
unintended edit to a constant is caught instead of being mirrored into the fixture.
`overlaybd_referrer_artifact_types_match_published_wire_values` additionally pins both constants
and their preference order, so a typo fails with a readable diff rather than only surfacing as a
missed referrer.

## 3. Fake regctl fixtures are located relative to `$0`

The fake `regctl` script originally interpolated absolute fixture paths into single-quoted shell
literals. `TempDir` is created beneath `TMPDIR`, so a `TMPDIR` containing an apostrophe or newline
would break the generated script rather than fail cleanly.

The script now derives its own directory from `$0` and reaches `argv`, `stdout` and `stderr`
through a quoted shell variable, so no filesystem path is embedded in shell source. This matches
the fully static fake-helper script already used in the ACR client tests
(`snapshot::repository::backends::common::acr::client`). Verified by running the resolver tests
under `TMPDIR="/tmp/it's a dir"`.

## Wire format verified against a real registry

Rather than trusting the fixture, I re-derived it from a live ACR registry with the same command
the code issues:

```
$ regctl artifact list --format body <myregistry>.azurecr.io/streamtest:v1
```

```jsonc
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    { "digest": "sha256:1bdbcce5...", "artifactType": "application/vnd.azure.artifact.streaming.v1",
      "annotations": { "streaming.format": "overlaybd", "streaming.version": "v1",
                       "streaming.platform.os": "linux", "streaming.platform.arch": "amd64" } },
    { "digest": "sha256:3a5ae954...", "artifactType": "application/vnd.azure.artifact.streaming.v1",
      "annotations": { "streaming.format": "overlaybd", "streaming.version": "v1",
                       "streaming.platform.os": "linux", "streaming.platform.arch": "arm64" } }
  ]
}
```

The artifactType literal matches byte-for-byte, so the fixture is faithful.

On platform selection, measured against the same registry:

| subject passed to `regctl artifact list` | referrers returned |
| --- | --- |
| `streamtest:v1` — multi-arch tag, resolves to an index | 2 — `amd64` + `arm64` |
| `streamtest@sha256:c4116d4d…` — the `linux/amd64` child | 1 — `amd64` only |

`resolve_fetched_manifest` passes `fetched.selected_image_ref` into discovery, and `oci_image`
pins that to the platform-resolved manifest digest via
`image_ref_with_digest(&current_ref, &manifest_digest)`. Discovery therefore never receives an
index, and the subject it does receive carries exactly one referrer, for the right architecture.
`parse_overlaybd_referrer_selects_first_of_acr_per_platform_referrers` keeps the two-referrer
payload as a defensive lock on first-match selection.

The discovery path these tests cover was also exercised end to end against a live Premium ACR
registry and an AKS cluster, where a sandbox booted from an ACR artifact-streaming image — though
that exercises the production change from #58 rather than anything in this test-only PR.

## Test results

`cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean.

| | passed | failed |
|---|---|---|
| `origin/main` (8174bd9) | 649 | 3 |
| this branch | 653 | 3 |

The 3 failures are pre-existing and identical on unmodified `main` (`snapshot::p2p::tests::local_overlaybd_layers_*`
and `…::acr::source_image::tests::plans_descriptorless_sparse_overlaybd_delta_for_dense_export`);
they appear environment-specific to my aarch64 container and are unrelated to this change. Net
`+4` tests, no regressions.
