### PR TITLE
feat(overlaybd): introduce index() and flatten_with_args() from LSMTFile

### DIFF
--- a/storage/overlaybd/src/lsmt/file/readwrite.rs
+++ b/storage/overlaybd/src/lsmt/file/readwrite.rs
@@ -58,6 +58,10 @@ pub struct LSMTFile {
 }
 
 impl LSMTFile {
+    pub fn index(&self) -> Arc<RwLock<ComboIndex>> {
+        self.index.clone()
+    }
+
     fn rw_layout_from_header(header: &HeaderTrailer) -> Result<RwLayout> {
         let is_sparse_rw = header.is_sparse_rw();
         let is_hybrid_rw = header.is_hybrid_rw();
@@ -478,6 +482,10 @@ impl LSMTFile {
     }
 
     pub async fn flatten(&self, dest_file: Arc<dyn VirtualFile>) -> Result<()> {
+        self.flatten_with_args(CommitArgs::new(dest_file)).await
+    }
+
+    pub async fn flatten_with_args(&self, args: CommitArgs) -> Result<()> {
         let virtual_size = self.virtual_size.load(Ordering::Acquire);
         let query = Segment::new(0, virtual_size.div_ceil(ALIGNMENT) as u32);
         let mut mappings = Vec::new();
@@ -485,8 +493,7 @@ impl LSMTFile {
             let idx = self.index.read().await;
             idx.lookup(query, &mut mappings);
         }
-        let commit_args = CommitArgs::new(dest_file);
-        compact_to(&self.layers, &mappings, virtual_size, commit_args).await
+        compact_to(&self.layers, &mappings, virtual_size, args).await
     }
 
     pub async fn commit_with_args(&self, args: CommitArgs) -> Result<()> {


### PR DESCRIPTION
## What

Expose two new capabilities from the read-write LSMTFile:

  - Add index() to return the shared Arc<RwLock<ComboIndex>>.
  - Add flatten_with_args() to support custom CommitArgs.

The existing flatten() method remains backward-compatible and delegates to flatten_with_args() with default arguments.

## Why

Higher-level callers need access to the combined LSMT index and finer control over flatten operations, including the destination writer, UUID metadata, user tags, and write concurrency.

Previously, these capabilities were only available internally.

## Design and behavior changes

index() clones and returns the internal Arc<RwLock<ComboIndex>>. Callers share the same index instance with LSMTFile and must use the existing lock for synchronization.

flatten_with_args():

  1. Loads the current virtual size.
  2. Acquires an index read lock and resolves mappings for the full logical address range.
  3. Releases the index lock.
  4. Passes the mappings, source layers, virtual size, and caller-provided CommitArgs to compact_to().

The existing method now delegates as follows: `flatten_with_args(CommitArgs::new(dest_file))`.

Existing callers therefore retain the same default metadata and sequential write behavior. Read and write failures continue to propagate from compact_to().

## Compatibility and operations

<!-- Explain applicable compatibility and deployment impact. Write "N/A" with a reason where appropriate. -->

- Public API or generated protocol: Adds public Rust APIs to the OverlayBD crate. No HTTP or generated protocol changes.
- Configuration or defaults: No changes.
- Snapshot manifest, artifact layout, or storage format: No default behavior or format changes.
- Upgrade and rollback: No migration is required. Code using the new methods will no longer compile after rollback.
- Host requirements, permissions, ports, or dependencies: No changes.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
