### PR TITLE
fix(snapshot): export s3-marked OSS-managed rootfs layers as images

### DIFF
--- a/src/snapshot/image_export/service.rs
+++ b/src/snapshot/image_export/service.rs
@@ -250,6 +250,22 @@ impl SnapshotImageService {
                     .await
             }
             OverlaybdLayerRef::External(external) => {
+                // Committed snapshots record OSS-managed layers without a
+                // local file as external refs carrying the synthetic
+                // managed-layers s3 URL; their bytes live in the
+                // managed-layer store, addressed by digest.
+                if external.repo_blob_url.starts_with("s3://") {
+                    let managed = ManagedLayer {
+                        digest: external.digest.clone(),
+                        size: external.size,
+                        uuid: None,
+                    };
+                    let path = self.materialize_managed_layer(&managed, tempdir).await?;
+                    return self
+                        .regctl
+                        .blob_put(target_repository, layer_digest, &path)
+                        .await;
+                }
                 let source = SourceRegistryRepository::parse(&external.repo_blob_url)?;
                 let source_repository = format!("{}/{}", source.registry, source.repository);
                 if source.registry != target.registry {
@@ -542,6 +558,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn s3_external_layer_exports_from_managed_layer_store() {
+        let dir = TempDir::new().unwrap();
+        let service = posix_service(
+            dir.path().join("repository"),
+            install_fake_regctl(dir.path()),
+        );
+        let layer = external_ref(b"oss managed bytes", "s3://bucket/prefix/managed-layers");
+        let digest = layer_digest_size(&layer).0.to_string();
+        seed_posix_layer(
+            &dir.path().join("repository"),
+            &digest,
+            b"oss managed bytes",
+        );
+        let committed = committed_with_layers(vec![layer]);
+
+        let result = publish(&service, &committed).await.unwrap();
+
+        assert!(!result.reused);
+        assert_eq!(
+            fs::read(blob_path(dir.path(), TARGET_REPOSITORY, &digest)).unwrap(),
+            b"oss managed bytes"
+        );
+        let argv = argv_lines(dir.path());
+        assert!(argv.contains(&format!(
+            "argv:blob put {TARGET_REPOSITORY} --digest {digest}"
+        )));
+    }
+
+    #[tokio::test]
     async fn republish_is_reused_and_conflicting_ref_is_rejected() {
         let dir = TempDir::new().unwrap();
         let service = posix_service(
@@ -634,6 +679,22 @@ mod tests {
             source.image_ref(),
             format!("reg.example/team/app:snapshot-{snapshot_id}")
         );
+
+        // s3-marked OSS-managed layers are not registry sources.
+        committed.rootfs_layers = vec![
+            external_ref(b"a", SRC_URL),
+            external_ref(b"oss", "s3://bucket/prefix/managed-layers"),
+        ];
+        let mixed = resolve_snapshot_image_target(&snapshot_id, &committed, None, None).unwrap();
+        assert_eq!(
+            mixed.image_ref(),
+            format!("reg.example/team/app:snapshot-{snapshot_id}")
+        );
+        committed.rootfs_layers = vec![external_ref(b"oss", "s3://bucket/prefix/managed-layers")];
+        assert!(matches!(
+            resolve_snapshot_image_target(&snapshot_id, &committed, None, None),
+            Err(SnapshotImageTargetError::CannotInfer { .. })
+        ));
 
         for layers in [
             vec![managed_ref(b"managed")],

--- a/src/snapshot/image_export/target.rs
+++ b/src/snapshot/image_export/target.rs
@@ -97,17 +97,21 @@ pub(crate) fn resolve_snapshot_image_target(
         return SnapshotImageTarget::parse(target_repository, tag);
     }
 
-    let (registry, repository) =
-        if let Some(publication) = canonical_rootfs_publication(snapshot_id, committed) {
-            infer_repository_from_blob_urls([publication.repo_blob_url.as_str()])?
-        } else {
-            infer_repository_from_blob_urls(committed.rootfs_layers.iter().filter_map(|layer| {
-                match layer {
-                    OverlaybdLayerRef::External(layer) => Some(layer.repo_blob_url.as_str()),
-                    OverlaybdLayerRef::Managed(_) => None,
-                }
-            }))?
-        };
+    let (registry, repository) = if let Some(publication) =
+        canonical_rootfs_publication(snapshot_id, committed)
+    {
+        infer_repository_from_blob_urls([publication.repo_blob_url.as_str()])?
+    } else {
+        infer_repository_from_blob_urls(committed.rootfs_layers.iter().filter_map(|layer| {
+            match layer {
+                // OSS-managed layers recorded with the synthetic s3 URL
+                // are not registry sources.
+                OverlaybdLayerRef::External(layer) => (!layer.repo_blob_url.starts_with("s3://"))
+                    .then_some(layer.repo_blob_url.as_str()),
+                OverlaybdLayerRef::Managed(_) => None,
+            }
+        }))?
+    };
     let tag = match tag {
         Some(tag) => validated_tag(Some(tag))?.to_string(),
         None => format!("snapshot-{snapshot_id}"),


### PR DESCRIPTION
aenv-snapshot-image rejected committed snapshots whose OSS backend records managed layers without local files as external refs carrying the synthetic managed-layers s3 repoBlobUrl. Treat those refs as managed-layer lookups (bytes addressed by digest in the managed-layer store) and skip them during target registry inference.

## What

<!-- Summarize the change. Keep the PR focused on one problem. -->

## Why

<!-- Explain the user or maintainer problem this solves. -->

## Related issue

<!-- Use "Closes #123" for an issue resolved by this PR. Non-trivial changes should normally have an issue or prior design discussion. -->

Closes #

## Scope and non-goals

<!-- State what is intentionally included and excluded. Call out unrelated refactors. -->

## Design and behavior changes

<!-- Describe important data flow, lifecycle, failure handling, concurrency, or operational changes. Include diagrams for substantial changes. -->

## Compatibility and operations

<!-- Explain applicable compatibility and deployment impact. Write "N/A" with a reason where appropriate. -->

- Public API or generated protocol:
- Configuration or defaults:
- Snapshot manifest, artifact layout, or storage format:
- Upgrade and rollback:
- Host requirements, permissions, ports, or dependencies:

## Validation

<!-- Check only commands you actually ran. Add focused tests and exact commands below. -->

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text

```

Skipped checks and reasons:

## Risks and reviewer notes

<!-- Identify correctness, security, compatibility, resource, and operational risks. Point reviewers to the most important files or commits. -->

## Checklist

- [ ] The PR contains one coherent change and no unrelated formatting or refactoring.
- [ ] New behavior is covered by tests, or I explained why testing is impractical.
- [ ] Logs and examples contain no credentials, tokens, or private registry information.
- [ ] I did not manually edit generated code without updating its source and regenerating it.
