### PR TITLE
fix(install): warn for known affected ublk kernels

### DIFF
--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -16,6 +16,20 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+KERNEL_RELEASE="$(uname -r)"
+case "$KERNEL_RELEASE" in
+    6.18.4|6.18.4[-+]*|6.18.5|6.18.5[-+]*|\
+    6.17.0-1015-azure|6.17.0-1015-azure[-+]*|\
+    6.17.0-1018-azure|6.17.0-1018-azure[-+]*)
+        cat >&2 <<EOF
+warning: Linux kernel ${KERNEL_RELEASE} is known to contain a ublk initialization regression.
+         Creating the first ublk device may hang or panic the host.
+         Upgrade to a fixed vendor kernel (upstream 6.18.6+ for 6.18.y) before running AgentENV.
+         See: https://github.com/kvcache-ai/AgentENV/issues/20
+EOF
+        ;;
+esac
+
 # ---------------------------------------------------------------------------
 # 1. ublk_drv kernel module
 # ---------------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,6 +65,20 @@ if [[ "$OS" != "linux" ]]; then
     exit 1
 fi
 
+KERNEL_RELEASE="$(uname -r)"
+case "$KERNEL_RELEASE" in
+    6.18.4|6.18.4[-+]*|6.18.5|6.18.5[-+]*|\
+    6.17.0-1015-azure|6.17.0-1015-azure[-+]*|\
+    6.17.0-1018-azure|6.17.0-1018-azure[-+]*)
+        cat >&2 <<EOF
+warning: Linux kernel ${KERNEL_RELEASE} is known to contain a ublk initialization regression.
+         Creating the first ublk device may hang or panic the host.
+         Upgrade to a fixed vendor kernel (upstream 6.18.6+ for 6.18.y) before running AgentENV.
+         See: https://github.com/kvcache-ai/AgentENV/issues/20
+EOF
+        ;;
+esac
+
 RELEASE_API="https://api.github.com/repos/${REPO}/releases/latest"
 if [[ "$VIRTUALIZATION_MODE" == "pvm" ]]; then
     TARBALL="aenv-server-${OS}-${ARCH_TAG}-pvm.tar.gz"


### PR DESCRIPTION
## Summary

- warn from `scripts/install.sh` when the running kernel is a known affected ublk release
- emit the same warning before Docker host setup loads and persists `ublk_drv`
- keep installation non-blocking while explaining the hang/panic risk and fixed-kernel guidance

## Scope

This revision follows the maintainer guidance on #20 and replaces the earlier
runtime guard with an installation-only warning. The PR now changes only:

- `scripts/install.sh`
- `scripts/docker-setup.sh`

The delimiter-aware shell patterns cover the known upstream `6.18.4` / `6.18.5`
families and Ubuntu Azure `6.17.0-1015` / `6.17.0-1018`, including `-` and `+`
local-version suffixes without overmatching releases such as `6.18.40`.

## Validation

- `git diff --check`
- GitHub AENV CI, including installer verification

Fixes #20
