### PR TITLE
chore(release): bump version to v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,46 @@ on:
       - "v*"
 
 jobs:
+  validate-version:
+    name: Validate release version
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag matches package versions
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python3 - "${RELEASE_TAG#v}" <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          release_version = sys.argv[1]
+          metadata = json.loads(
+              subprocess.check_output(
+                  ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+                  text=True,
+              )
+          )
+          package_versions = {
+              package["name"]: package["version"] for package in metadata["packages"]
+          }
+
+          for package_name in ("agentenv", "aenv"):
+              package_version = package_versions[package_name]
+              if package_version != release_version:
+                  raise SystemExit(
+                      f"{package_name} version {package_version} does not match "
+                      f"release tag v{release_version}"
+                  )
+          PY
+
   build-aenv:
     name: Build aenv (${{ matrix.asset_name }})
+    needs: validate-version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -62,6 +100,7 @@ jobs:
 
   build-server:
     name: Build server (linux-x86_64)
+    needs: validate-version
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aenv"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agentenv"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agentenv-observability",
  "agentenv_http_server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentenv"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 license = "MIT"
 
@@ -26,6 +26,9 @@ members = [
     "storage/ublk",
     "storage/ublk-daemon",
 ]
+
+[workspace.package]
+version = "0.1.1"
 
 [lib]
 path = "src/lib.rs"

--- a/crates/aenv/Cargo.toml
+++ b/crates/aenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aenv"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary

- centralize the product version under `workspace.package` and bump it to 0.1.1
- make the AgentENV server and `aenv` CLI inherit the shared version
- reject release tags that do not match either shipped package version

## Verification

- `cargo fmt --all --check`
- `cargo check -p agentenv -p aenv --locked`
- `cargo run --quiet -p aenv -- --version` outputs `aenv 0.1.1`
- release tag/version validation script passes for `v0.1.1`
- modified GitHub Actions workflow parses as valid YAML

After this PR merges, `v0.1.1` can be tagged on the merge commit to start the existing release workflow.