### PR TITLE
perf(p2p): parallelize catalog peer lookups

### DIFF
--- a/src/p2p/iroh/transport.rs
+++ b/src/p2p/iroh/transport.rs
@@ -829,15 +829,25 @@ mod tests {
             }
         });
 
-        first_started.notified().await;
-        second_finished.notified().await;
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            first_started.notified().await;
+            second_finished.notified().await;
+        })
+        .await
+        .expect("initial buffered lookups should complete");
         assert!(
             !lookup.is_finished(),
             "a lower-priority result must wait for earlier candidates"
         );
 
         release_first.notify_one();
-        assert_eq!(lookup.await.expect("lookup task"), Some("first"));
+        assert_eq!(
+            tokio::time::timeout(TEST_TIMEOUT, lookup)
+                .await
+                .expect("ordered lookup should complete")
+                .expect("lookup task"),
+            Some("first")
+        );
     }
 
     #[tokio::test]
@@ -873,10 +883,20 @@ mod tests {
             }
         });
 
-        first_window_ready.wait().await;
+        tokio::time::timeout(TEST_TIMEOUT, first_window_ready.wait())
+            .await
+            .expect("initial concurrency window should fill");
         assert_eq!(current.load(Ordering::SeqCst), 4);
-        release_first_window.wait().await;
-        assert_eq!(lookup.await.expect("lookup task"), None);
+        tokio::time::timeout(TEST_TIMEOUT, release_first_window.wait())
+            .await
+            .expect("initial concurrency window should be released");
+        assert_eq!(
+            tokio::time::timeout(TEST_TIMEOUT, lookup)
+                .await
+                .expect("bounded lookup should complete")
+                .expect("lookup task"),
+            None
+        );
         assert_eq!(maximum.load(Ordering::SeqCst), 4);
     }
 

--- a/src/p2p/iroh/transport.rs
+++ b/src/p2p/iroh/transport.rs
@@ -845,21 +845,25 @@ mod tests {
         let current = Arc::new(AtomicUsize::new(0));
         let maximum = Arc::new(AtomicUsize::new(0));
         let first_window_ready = Arc::new(Barrier::new(5));
+        let release_first_window = Arc::new(Barrier::new(5));
 
         let lookup = tokio::spawn({
             let current = current.clone();
             let maximum = maximum.clone();
             let first_window_ready = first_window_ready.clone();
+            let release_first_window = release_first_window.clone();
             async move {
                 first_some_buffered_in_order(0..8, 4, move |candidate| {
                     let current = current.clone();
                     let maximum = maximum.clone();
                     let first_window_ready = first_window_ready.clone();
+                    let release_first_window = release_first_window.clone();
                     async move {
                         let active = current.fetch_add(1, Ordering::SeqCst) + 1;
                         maximum.fetch_max(active, Ordering::SeqCst);
                         if candidate < 4 {
                             first_window_ready.wait().await;
+                            release_first_window.wait().await;
                         }
                         current.fetch_sub(1, Ordering::SeqCst);
                         None::<()>
@@ -871,6 +875,7 @@ mod tests {
 
         first_window_ready.wait().await;
         assert_eq!(current.load(Ordering::SeqCst), 4);
+        release_first_window.wait().await;
         assert_eq!(lookup.await.expect("lookup task"), None);
         assert_eq!(maximum.load(Ordering::SeqCst), 4);
     }

--- a/src/p2p/iroh/transport.rs
+++ b/src/p2p/iroh/transport.rs
@@ -730,12 +730,15 @@ where
     F: FnMut(I) -> Fut,
     Fut: Future<Output = Option<T>>,
 {
-    stream::iter(items)
+    let mut results = stream::iter(items)
         .map(lookup)
-        .buffered(concurrency.max(1))
-        .filter_map(|result| async move { result })
-        .next()
-        .await
+        .buffered(concurrency.max(1));
+    while let Some(result) = results.next().await {
+        if result.is_some() {
+            return result;
+        }
+    }
+    None
 }
 
 fn resolve_remote_local_providers(

--- a/src/p2p/iroh/transport.rs
+++ b/src/p2p/iroh/transport.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::ops::Range;
 use std::path::Path;
@@ -40,6 +41,7 @@ use crate::p2p::types::{
 use crate::p2p::P2pByteStream;
 
 const CATALOG_DB_DIR: &str = "catalog.db";
+const MAX_CONCURRENT_CATALOG_LOOKUPS: usize = 4;
 const ENDPOINT_ADDR_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_STORE_GC_INTERVAL: Duration = Duration::from_mins(5);
 const PUBLISH_TAG_PREFIX: &str = "agentenv:p2p:v1:";
@@ -220,21 +222,19 @@ impl IrohBlobsP2pTransport {
         peers: Vec<P2pPeer>,
         key: &P2pArtifactKey,
     ) -> Option<P2pArtifactDescriptor> {
-        // TODO: parallelize lookups to multiple peers.
-        // No shuffling or prioritization for now since the scheduler should already have done that work for us.
-        for peer in peers {
+        first_some_buffered_in_order(peers, MAX_CONCURRENT_CATALOG_LOOKUPS, |peer| async move {
             if peer.node_id == self.node_id || peer.endpoint == self.local_endpoint {
-                let Some(descriptor) = self.get_local(key).await else {
-                    continue;
-                };
-                trace!("P2P lookup found local descriptor matching peer discovery");
-                return Some(descriptor);
+                let descriptor = self.get_local(key).await;
+                if descriptor.is_some() {
+                    trace!("P2P lookup found local descriptor matching peer discovery");
+                }
+                return descriptor;
             }
             match self.lookup_peer_with_timeout(&peer, key).await {
-                Ok(None) => continue,
+                Ok(None) => None,
                 Ok(Some(descriptor)) => {
                     trace!(peer = %peer.node_id, "P2P lookup found remote descriptor");
-                    return Some(descriptor);
+                    Some(descriptor)
                 }
                 Err(err) => {
                     debug!(
@@ -242,10 +242,11 @@ impl IrohBlobsP2pTransport {
                         error = %err,
                         "P2P artifact catalog lookup failed; trying remaining peers"
                     );
+                    None
                 }
             }
-        }
-        None
+        })
+        .await
     }
 
     async fn get_local(&self, key: &P2pArtifactKey) -> Option<P2pArtifactDescriptor> {
@@ -720,6 +721,23 @@ fn blob_hash_from_descriptor(descriptor: &P2pArtifactDescriptor) -> Result<iroh_
     })
 }
 
+async fn first_some_buffered_in_order<I, F, Fut, T>(
+    items: impl IntoIterator<Item = I>,
+    concurrency: usize,
+    lookup: F,
+) -> Option<T>
+where
+    F: FnMut(I) -> Fut,
+    Fut: Future<Output = Option<T>>,
+{
+    stream::iter(items)
+        .map(lookup)
+        .buffered(concurrency.max(1))
+        .filter_map(|result| async move { result })
+        .next()
+        .await
+}
+
 fn resolve_remote_local_providers(
     mut descriptor: P2pArtifactDescriptor,
     response_peer: &P2pPeer,
@@ -765,6 +783,9 @@ fn gated_gc_config(interval: Duration, pending_gc: Arc<AtomicBool>) -> GcConfig 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use tokio::sync::{Barrier, Notify};
+
     use crate::cfg::P2pConfig;
     use crate::p2p::config::ResolvedP2pConfig;
     use crate::p2p::discovery::P2pPeerDiscovery;
@@ -772,6 +793,86 @@ mod tests {
     use crate::p2p::{NoopP2pPeerDiscovery, P2pPeer, P2pTransportKind, StaticP2pPeerDiscovery};
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    #[tokio::test]
+    async fn buffered_lookup_preserves_candidate_order() {
+        let release_first = Arc::new(Notify::new());
+        let first_started = Arc::new(Notify::new());
+        let second_finished = Arc::new(Notify::new());
+
+        let lookup = tokio::spawn({
+            let release_first = release_first.clone();
+            let first_started = first_started.clone();
+            let second_finished = second_finished.clone();
+            async move {
+                first_some_buffered_in_order([0, 1], 2, move |candidate| {
+                    let release_first = release_first.clone();
+                    let first_started = first_started.clone();
+                    let second_finished = second_finished.clone();
+                    async move {
+                        match candidate {
+                            0 => {
+                                first_started.notify_one();
+                                release_first.notified().await;
+                                Some("first")
+                            }
+                            1 => {
+                                second_finished.notify_one();
+                                Some("second")
+                            }
+                            _ => None,
+                        }
+                    }
+                })
+                .await
+            }
+        });
+
+        first_started.notified().await;
+        second_finished.notified().await;
+        assert!(
+            !lookup.is_finished(),
+            "a lower-priority result must wait for earlier candidates"
+        );
+
+        release_first.notify_one();
+        assert_eq!(lookup.await.expect("lookup task"), Some("first"));
+    }
+
+    #[tokio::test]
+    async fn buffered_lookup_limits_in_flight_candidates() {
+        let current = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let first_window_ready = Arc::new(Barrier::new(5));
+
+        let lookup = tokio::spawn({
+            let current = current.clone();
+            let maximum = maximum.clone();
+            let first_window_ready = first_window_ready.clone();
+            async move {
+                first_some_buffered_in_order(0..8, 4, move |candidate| {
+                    let current = current.clone();
+                    let maximum = maximum.clone();
+                    let first_window_ready = first_window_ready.clone();
+                    async move {
+                        let active = current.fetch_add(1, Ordering::SeqCst) + 1;
+                        maximum.fetch_max(active, Ordering::SeqCst);
+                        if candidate < 4 {
+                            first_window_ready.wait().await;
+                        }
+                        current.fetch_sub(1, Ordering::SeqCst);
+                        None::<()>
+                    }
+                })
+                .await
+            }
+        });
+
+        first_window_ready.wait().await;
+        assert_eq!(current.load(Ordering::SeqCst), 4);
+        assert_eq!(lookup.await.expect("lookup task"), None);
+        assert_eq!(maximum.load(Ordering::SeqCst), 4);
+    }
 
     async fn collect_range_stream(mut stream: P2pByteStream) -> Result<Vec<u8>> {
         let mut out = Vec::new();

--- a/src/p2p/iroh/transport.rs
+++ b/src/p2p/iroh/transport.rs
@@ -730,9 +730,7 @@ where
     F: FnMut(I) -> Fut,
     Fut: Future<Output = Option<T>>,
 {
-    let mut results = stream::iter(items)
-        .map(lookup)
-        .buffered(concurrency.max(1));
+    let mut results = stream::iter(items).map(lookup).buffered(concurrency.max(1));
     while let Some(result) = results.next().await {
         if result.is_some() {
             return result;


### PR DESCRIPTION
## Summary

- run Iroh catalog lookups with a fixed four-peer concurrency window
- preserve scheduler-provided candidate order when selecting a descriptor
- keep misses, timeouts, invalid endpoints, and self/local candidates compatible with the existing fallback behavior
- add deterministic coverage for ordering and the in-flight concurrency bound

## Why

`lookup_peers` currently waits for every candidate serially. With the default
5-second per-peer timeout, stale peers at the front of the discovery result can
make lookup latency grow as `N * lookup_timeout`.

The new ordered buffer starts up to four lookups concurrently but consumes their
results in candidate order. This bounds connection fan-out and reduces timeout
accumulation without changing scheduler priority.

## Lingjun validation

Validation was run on the four-node Lingjun cluster, not on the development
machine.

- `cargo fmt --all -- --check`
- new ordered-buffer tests: 2 passed
- `p2p::iroh::transport::tests`: 14 passed

### Four-node latency experiment

- consumer: lingjun-099 (`192.168.0.42`)
- stale Iroh endpoints: lingjun-100 and lingjun-101
- valid provider: lingjun-102
- lookup timeout: 1000 ms
- candidate order: stale-100, stale-101, valid-102

All endpoints were produced by real `IrohBlobsP2pTransport` instances. The first
two providers were then stopped before measurement; the third continued serving
the published artifact.

| implementation | five lookup samples (ms) | mean (ms) |
|---|---|---:|
| current serial `main` | 2028.327, 2029.424, 2028.062, 2026.525, 2026.695 | 2027.807 |
| ordered concurrency window | 1000.855, 1002.165, 1000.564, 1001.104, 1001.576 | 1001.253 |

The change reduced mean lookup latency by approximately 50.6%; all 10/10
lookups returned the descriptor from lingjun-102.

The branch was subsequently rebased onto v0.1.1 `main`; `git range-diff`
confirmed that all four patch commits remained identical.

Fixes #95
