### PR TITLE
Fix sandbox lifecycle bugs and improve network policy handling

### DIFF
--- a/src/image/cache/mock.rs
+++ b/src/image/cache/mock.rs
@@ -1,0 +1,54 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::{RuntimeImageOwner, RuntimeImageRefs};
+use crate::sandbox::RuntimeArtifactSet;
+use crate::types::SandboxId;
+
+#[derive(Debug, Default)]
+pub(crate) struct RecordingRuntimeImageRefs {
+    pinned: std::sync::Mutex<Vec<(RuntimeImageOwner, RuntimeArtifactSet)>>,
+    unpinned: std::sync::Mutex<Vec<RuntimeImageOwner>>,
+}
+
+impl RecordingRuntimeImageRefs {
+    pub(crate) fn pinned(&self) -> Vec<(RuntimeImageOwner, RuntimeArtifactSet)> {
+        self.pinned
+            .lock()
+            .expect("pinned refs mutex poisoned")
+            .clone()
+    }
+
+    pub(crate) fn unpinned(&self) -> Vec<RuntimeImageOwner> {
+        self.unpinned
+            .lock()
+            .expect("unpinned refs mutex poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl RuntimeImageRefs for RecordingRuntimeImageRefs {
+    async fn pin(&self, owner: RuntimeImageOwner, artifacts: RuntimeArtifactSet) -> Result<()> {
+        self.pinned
+            .lock()
+            .expect("pinned refs mutex poisoned")
+            .push((owner, artifacts));
+        Ok(())
+    }
+
+    async fn unpin_best_effort(&self, owner: RuntimeImageOwner) {
+        self.unpinned
+            .lock()
+            .expect("unpinned refs mutex poisoned")
+            .push(owner);
+    }
+
+    async fn reconcile_paused(&self, _live_paused: &[SandboxId]) -> Result<()> {
+        Ok(())
+    }
+
+    async fn maintain_running(&self, _running: Vec<(SandboxId, RuntimeArtifactSet)>) -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/image/cache/mod.rs
+++ b/src/image/cache/mod.rs
@@ -4,6 +4,9 @@ mod service;
 mod source_config;
 mod store;
 
+#[cfg(test)]
+mod mock;
+
 pub(crate) use store::{
     local_image_services_from_app_config, local_image_services_from_global_config,
     CachedImageConfig, OverlaybdLayerLocation, OverlaybdLayerStore, RuntimeImageOwner,
@@ -12,6 +15,7 @@ pub(crate) use store::{
 
 #[cfg(test)]
 pub(crate) mod test_support {
+    pub(crate) use super::mock::RecordingRuntimeImageRefs;
     pub(crate) use super::service::ImageCacheService;
     pub(crate) use super::store::test_local_image_services_from_service;
 }

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -1045,6 +1045,27 @@ where
             return Err(error);
         }
 
+        // Allocate persistence space while the running handle and route are
+        // still attached. Allocation does not mutate the backend, so failure
+        // only needs to restore metadata and release the temporary image refs.
+        let artifact_root = match self.persister.allocate_artifact_root(&sandbox_id).await {
+            Ok(artifact_root) => artifact_root,
+            Err(err) => {
+                warn!(error = ?err, "failed to allocate paused sandbox artifact root");
+                self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
+                    .await;
+                let _ = self
+                    .store
+                    .update_state_if_state(
+                        &sandbox_id,
+                        SandboxState::Running,
+                        &[SandboxState::Pausing],
+                    )
+                    .await;
+                return Err(OrchestratorError::from(err));
+            }
+        };
+
         let (handle, removed_proxy_route) = self.detach_sandbox_handle_and_route(&sandbox_id).await;
 
         let Some(handle) = handle else {
@@ -1056,8 +1077,6 @@ where
         };
 
         // Pause the sandbox and capture the paused state for resuming later.
-        let artifact_root = self.persister.allocate_artifact_root(&sandbox_id).await?;
-
         let paused_state_result = {
             let mut sandbox = handle.lock().await;
             sandbox.pause(artifact_root.as_deref()).await

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -218,7 +218,7 @@ where
         Ok(orchestrator)
     }
 
-    async fn run_lifecycle_operation<T>(
+    async fn run_cancellation_safe<T>(
         self: &Arc<Self>,
         operation: &'static str,
         sandbox_id: SandboxId,
@@ -234,14 +234,14 @@ where
                 debug!(
                     sandbox_id = %sandbox_id,
                     operation,
-                    "lifecycle operation completed after caller stopped waiting"
+                    "operation completed after caller stopped waiting"
                 );
             }
         });
 
         rx.await.map_err(|err| {
             OrchestratorError::InternalError(format!(
-                "lifecycle operation task ended before reporting result: {err}"
+                "operation task ended before reporting result: {err}"
             ))
         })?
     }
@@ -322,7 +322,7 @@ where
     ) -> Result<SandboxMetadata> {
         let sandbox_id = SandboxId::new();
         let this = Arc::clone(self);
-        self.run_lifecycle_operation("create", sandbox_id, async move {
+        self.run_cancellation_safe("create", sandbox_id, async move {
             this.create_sandbox_inner(sandbox_id, request).await
         })
         .await
@@ -476,7 +476,7 @@ where
         new_timeout: NewTimeout,
     ) -> Result<Vec<SandboxForkOutcome>> {
         let this = Arc::clone(self);
-        self.run_lifecycle_operation("fork", source_sandbox_id, async move {
+        self.run_cancellation_safe("fork", source_sandbox_id, async move {
             this.fork_sandbox_inner(source_sandbox_id, count, new_timeout)
                 .await
         })
@@ -809,7 +809,7 @@ where
     /// races where an ongoing operation might overwrite the `Killing` state.
     pub async fn delete_sandbox(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         let this = Arc::clone(self);
-        self.run_lifecycle_operation("delete", sandbox_id, async move {
+        self.run_cancellation_safe("delete", sandbox_id, async move {
             this.delete_sandbox_inner(sandbox_id).await
         })
         .await
@@ -977,7 +977,7 @@ where
     /// returns the outcome rather than duplicating the work.
     pub async fn pause_sandbox(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         let this = Arc::clone(self);
-        self.run_lifecycle_operation("pause", sandbox_id, async move {
+        self.run_cancellation_safe("pause", sandbox_id, async move {
             this.pause_sandbox_inner(sandbox_id).await
         })
         .await
@@ -1208,7 +1208,7 @@ where
         timeout: NewTimeout,
     ) -> Result<SandboxMetadata> {
         let this = Arc::clone(self);
-        self.run_lifecycle_operation("resume", sandbox_id, async move {
+        self.run_cancellation_safe("resume", sandbox_id, async move {
             this.resume_sandbox_inner(sandbox_id, timeout).await
         })
         .await
@@ -1330,7 +1330,7 @@ where
         sandbox_id: SandboxId,
     ) -> Result<SnapshotCaptureResult> {
         let this = Arc::clone(self);
-        self.run_lifecycle_operation("snapshot", sandbox_id, async move {
+        self.run_cancellation_safe("snapshot", sandbox_id, async move {
             this.capture_snapshot_inner(sandbox_id).await
         })
         .await
@@ -1444,8 +1444,25 @@ where
         })
     }
 
-    #[tracing::instrument(skip(self, network_policy), fields(sandbox_id = %sandbox_id))]
     pub async fn replace_sandbox_network_policy(
+        self: &Arc<Self>,
+        sandbox_id: SandboxId,
+        network_policy: SandboxNetworkPolicy,
+    ) -> Result<()> {
+        let this = Arc::clone(self);
+        self.run_cancellation_safe("update_network", sandbox_id, async move {
+            this.replace_sandbox_network_policy_inner(sandbox_id, network_policy)
+                .await
+        })
+        .await
+    }
+
+    #[tracing::instrument(
+        name = "replace_sandbox_network_policy",
+        skip(self, network_policy),
+        fields(sandbox_id = %sandbox_id))
+    ]
+    async fn replace_sandbox_network_policy_inner(
         &self,
         sandbox_id: SandboxId,
         network_policy: SandboxNetworkPolicy,
@@ -1499,8 +1516,25 @@ where
     /// On hook failure the sandbox keeps its previous params and the
     /// metadata store is left untouched. Returns the new full params (`None`
     /// means empty params).
-    #[tracing::instrument(skip(self, patch), fields(sandbox_id = %sandbox_id))]
     pub async fn patch_sandbox_custom_extension_params(
+        self: &Arc<Self>,
+        sandbox_id: SandboxId,
+        patch: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Option<CustomExtensionParams>> {
+        let this = Arc::clone(self);
+        self.run_cancellation_safe("patch_custom_extension_params", sandbox_id, async move {
+            this.patch_sandbox_custom_extension_params_inner(sandbox_id, patch)
+                .await
+        })
+        .await
+    }
+
+    #[tracing::instrument(
+        name = "patch_sandbox_custom_extension_params",
+        skip(self, patch),
+        fields(sandbox_id = %sandbox_id))
+    ]
+    async fn patch_sandbox_custom_extension_params_inner(
         &self,
         sandbox_id: SandboxId,
         patch: serde_json::Map<String, serde_json::Value>,

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -19,9 +19,11 @@ use super::super::types::SandboxLaunchSource;
 use super::*;
 use crate::cfg::ResolvedImageCacheConfig;
 use crate::image::cache::test_support::{
-    test_local_image_services_from_service, ImageCacheService,
+    test_local_image_services_from_service, ImageCacheService, RecordingRuntimeImageRefs,
 };
-use crate::image::cache::{local_image_services_from_global_config, RuntimeImageRefs};
+use crate::image::cache::{
+    local_image_services_from_global_config, RuntimeImageOwner, RuntimeImageRefs,
+};
 use crate::sandbox::mock::{
     MockAction, MockBackendFactory, MockBehavior, MockOperation, MockSandboxBackend, MockSnapshot,
 };
@@ -1692,6 +1694,110 @@ async fn pause_persistence_failure_rolls_back_to_running() -> Result<()> {
         created.resources.memory_mib,
     )
     .await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn pause_artifact_root_allocation_failure_restores_running_for_retry() -> Result<()> {
+    setup();
+    let persister = RecordingPersister::default();
+    persister.fail_next(RecordingCall::AllocateArtifactRoot);
+    let runtime_artifacts =
+        RuntimeArtifactSet::from_overlaybd_image_configs(vec![PathBuf::from("runtime/image.json")]);
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.set_runtime_info(SandboxRuntimeInfo {
+        runtime_artifacts: runtime_artifacts.clone(),
+        ..Default::default()
+    });
+    let mut orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::with_behavior(behavior),
+        persister.clone(),
+    );
+    let image_refs = Arc::new(RecordingRuntimeImageRefs::default());
+    Arc::get_mut(&mut orchestrator)
+        .expect("orchestrator should be uniquely owned")
+        .image_refs = image_refs.clone();
+
+    let created = orchestrator
+        .create_sandbox(create_request(Some(60), &[("team", "pause-allocate-fail")]))
+        .await?;
+    let sandbox_id = created.id;
+
+    let err = orchestrator
+        .pause_sandbox(sandbox_id)
+        .await
+        .expect_err("pause should fail when artifact-root allocation fails");
+    assert!(matches!(
+        err,
+        OrchestratorError::SandboxPersistenceFailed(_)
+    ));
+
+    let running = orchestrator
+        .get_sandbox(&sandbox_id)
+        .await?
+        .expect("metadata should remain after allocation failure");
+    assert_eq!(running.state, SandboxState::Running);
+    assert!(running.paused_state.is_none());
+    assert!(
+        orchestrator
+            .sandboxes
+            .read()
+            .await
+            .contains_key(&sandbox_id),
+        "allocation failure must not detach the runtime handle"
+    );
+    assert_proxy_ready(&orchestrator, &sandbox_id).await?;
+    assert_metrics_values(
+        &orchestrator,
+        1,
+        0,
+        1,
+        0,
+        created.resources.cpu_count,
+        created.resources.memory_mib,
+    )
+    .await;
+    assert_eq!(
+        image_refs.pinned(),
+        vec![
+            (
+                RuntimeImageOwner::StartingSandbox(sandbox_id),
+                RuntimeArtifactSet::empty(),
+            ),
+            (
+                RuntimeImageOwner::PausedSandbox(sandbox_id),
+                runtime_artifacts.clone(),
+            ),
+        ]
+    );
+    assert_eq!(
+        image_refs.unpinned(),
+        vec![
+            RuntimeImageOwner::StartingSandbox(sandbox_id),
+            RuntimeImageOwner::PausedSandbox(sandbox_id),
+        ]
+    );
+    assert_eq!(persister.calls(), vec![RecordingCall::AllocateArtifactRoot]);
+
+    orchestrator.pause_sandbox(sandbox_id).await?;
+    let paused = orchestrator
+        .get_sandbox(&sandbox_id)
+        .await?
+        .expect("metadata should remain after retry");
+    assert_eq!(paused.state, SandboxState::Paused);
+    assert!(paused.paused_state.is_some());
+    assert_proxy_paused(&orchestrator, &sandbox_id).await?;
+    assert_eq!(
+        persister.calls(),
+        vec![
+            RecordingCall::AllocateArtifactRoot,
+            RecordingCall::AllocateArtifactRoot,
+            RecordingCall::PersistPaused,
+        ]
+    );
+
+    orchestrator.delete_sandbox(sandbox_id).await?;
     Ok(())
 }
 

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -1211,9 +1211,12 @@ impl FirecrackerSandbox {
         // valid DNS server IP in the 8th field. See that method for format details.
         let ip_config = slot.build_ip_boot_arg();
         let netns = slot.namespace_path();
-        slot.set_egress_policy(config.common.network_policy.as_ref())
-            .context("Failed to configure sandbox egress policy")?;
         self.network_slot = Some(slot);
+        self.network_slot
+            .as_ref()
+            .expect("network slot was just assigned")
+            .set_egress_policy(config.common.network_policy.as_ref())
+            .context("Failed to configure sandbox egress policy")?;
         boot_args = Some(match boot_args.take() {
             Some(existing) => format!("{existing} {ip_config}"),
             None => ip_config,

--- a/src/sandbox/network/iptables_util.rs
+++ b/src/sandbox/network/iptables_util.rs
@@ -200,13 +200,6 @@ fn is_missing_iptables_rule_error(error: &str) -> bool {
         || contains_ci("rule does not exist")
 }
 
-pub(super) fn flush_table_chain(table: &'static str, chain: &'static str) -> Result<()> {
-    apply_iptables_commands(
-        &[IptablesRestoreCommand::FlushChain { table, chain }],
-        OpenFailurePolicy::ReturnErr,
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sandbox/network/policy.rs
+++ b/src/sandbox/network/policy.rs
@@ -5,9 +5,7 @@ use std::{
     net::{IpAddr, Ipv4Addr},
 };
 
-use super::iptables_util::{
-    apply_iptables_commands, flush_table_chain, IptablesRestoreCommand, OpenFailurePolicy,
-};
+use super::iptables_util::{apply_iptables_commands, IptablesRestoreCommand, OpenFailurePolicy};
 use crate::cfg::network::normalize_dns_name;
 
 pub const ALL_INTERNET_TRAFFIC_CIDR: &str = "0.0.0.0/0";
@@ -117,8 +115,7 @@ pub(super) fn set_namespace_egress_policy(policy: Option<&SandboxNetworkPolicy>)
         );
     }
 
-    let commands = build_user_egress_commands(policy);
-    flush_table_chain("filter", USER_EGRESS_CHAIN)?;
+    let commands = build_user_egress_commands(policy, true);
     apply_iptables_commands(&commands, OpenFailurePolicy::ReturnErr)
 }
 
@@ -197,8 +194,18 @@ fn build_static_egress_commands(
     commands
 }
 
-fn build_user_egress_commands(policy: &SandboxNetworkPolicy) -> Vec<IptablesRestoreCommand> {
-    let mut commands = Vec::new();
+fn build_user_egress_commands(
+    policy: &SandboxNetworkPolicy,
+    replace: bool,
+) -> Vec<IptablesRestoreCommand> {
+    let mut commands = if replace {
+        vec![IptablesRestoreCommand::FlushChain {
+            table: "filter",
+            chain: USER_EGRESS_CHAIN,
+        }]
+    } else {
+        Vec::new()
+    };
 
     for cidr in policy.egress.allowed_cidrs.iter().map(String::as_str) {
         commands.push(append_user_egress_command(format!(
@@ -344,7 +351,7 @@ mod tests {
             },
         };
 
-        let commands = build_user_egress_commands(&policy);
+        let commands = build_user_egress_commands(&policy, false);
 
         let allow_pos = commands
             .iter()
@@ -359,6 +366,49 @@ mod tests {
             })
             .unwrap();
         assert!(allow_pos < deny_pos);
+    }
+
+    #[test]
+    fn build_policy_replacement_flushes_before_installing_rules() {
+        let policy = SandboxNetworkPolicy {
+            base_policy: BaseSandboxNetworkPolicy::Deny,
+            egress: SandboxNetworkEgressPolicy {
+                allowed_cidrs: vec!["8.8.8.8/32".to_string()],
+                denied_cidrs: vec!["203.0.113.0/24".to_string()],
+                allowed_domains: Vec::new(),
+            },
+        };
+
+        let commands = build_user_egress_commands(&policy, true);
+
+        assert!(matches!(
+            commands.first(),
+            Some(IptablesRestoreCommand::FlushChain {
+                table: "filter",
+                chain: USER_EGRESS_CHAIN,
+            })
+        ));
+        assert_eq!(
+            commands.iter().filter_map(append_rule).collect::<Vec<_>>(),
+            [
+                "-i tap0 -o vpeer -d 8.8.8.8/32 -j ACCEPT",
+                "-i tap0 -o vpeer -d 203.0.113.0/24 -j REJECT",
+                "-i tap0 -o vpeer -d 0.0.0.0/0 -j REJECT",
+            ]
+        );
+    }
+
+    #[test]
+    fn build_default_policy_replacement_only_flushes_user_chain() {
+        let commands = build_user_egress_commands(&SandboxNetworkPolicy::default(), true);
+
+        assert!(matches!(
+            commands.as_slice(),
+            [IptablesRestoreCommand::FlushChain {
+                table: "filter",
+                chain: USER_EGRESS_CHAIN,
+            }]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

Fixes three sandbox lifecycle bugs (network-slot leak on egress-policy failure, unhandled artifact-root allocation error during pause, and cancellation-unsafe network/custom-extension updates) and makes egress policy replacement atomic via a single `iptables-restore` transaction.

## Why

Several lifecycle paths left the sandbox in an inconsistent state on failure or cancellation:
- A failed `set_egress_policy` call dropped the network slot before it was attached to `self.network_slot`, leaking the underlying network resources.
- `allocate_artifact_root` failure during pause occurred after the handle/route were already detached, with no rollback of image refs or sandbox state.
- `replace_sandbox_network_policy` and `patch_sandbox_custom_extension_params` were not wrapped in the cancellation-safe execution path used by other lifecycle operations (create/fork/delete/pause/resume/snapshot), so a client disconnecting mid-request could leave the update half-applied.
- Egress policy updates flushed the `USER_EGRESS_CHAIN` and installed new rules as two separate `iptables-restore` invocations, leaving a brief window with inconsistent (or no) egress rules.

## Related issue

Closes #42
Closes #99

## Scope and non-goals

Included: sandbox network-slot leak fix, pause artifact-root allocation error handling, cancellation-safety for network policy/custom extension param updates, atomic egress policy replacement.
Excluded: no serialization for concurrent network policy/custom extension param updates.

## Design and behavior changes

- `FirecrackerSandbox`: `network_slot` is now assigned to `self.network_slot` **before** `set_egress_policy` is invoked, so a failed call still leaves the slot reachable by the normal cleanup path instead of being dropped in place.
- `OrchestratorService::pause_sandbox_inner`: `allocate_artifact_root` is now called **before** detaching the sandbox handle/route (while it does not mutate the backend). On allocation failure, image refs for `RuntimeImageOwner::PausedSandbox` are released and the state machine is rolled back from `Pausing` to `Running`.
- `run_lifecycle_operation` renamed to `run_cancellation_safe`; `replace_sandbox_network_policy` and `patch_sandbox_custom_extension_params` are now split into public wrapper + `_inner` implementation and routed through `run_cancellation_safe`, so a caller cancelling the request no longer aborts the update mid-flight — the background task still runs to completion.
- `build_user_egress_commands` now takes a `replace: bool` flag; when replacing, a `FlushChain` command is prepended to the same command batch sent to `apply_iptables_commands`, so flush + rule installation happen as a single atomic `iptables-restore` transaction. The standalone `flush_table_chain` helper was removed as it's no longer needed.

## Compatibility and operations

- Public API or generated protocol: N/A — no API surface changes.
- Configuration or defaults: N/A — no config changes.
- Snapshot manifest, artifact layout, or storage format: N/A — no format changes.
- Upgrade and rollback: No special steps; purely internal lifecycle/network behavior fixes.
- Host requirements, permissions, ports, or dependencies: N/A — no new host requirements.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```shell
make test-agent # All passed
```

Skipped checks and reasons:
- `services/` unchanged, so `make -C services test` skipped.

## Risks and reviewer notes

- Concurrent network policy/custom extension param updates are deliberately NOT serialized so that the orchestrator is kept simple.
- In-memory metadata update failures are deliberately IGNORED due to its rareness and the difficulty to implement a fully transactional architecture.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.