### PR TITLE
build: forward proxy settings into the container image builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,9 @@ firecracker_client = { version = "1.15.1", path = "thirdparty/firecracker-client
 envd = { version = "0.1.0", path = "thirdparty/envd" }
 custom_extension_client = { version = "0.1.0", path = "src/custom_extension_api/generated" }
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.13", features = ["json", "stream"] }
+# `socks` lets dependency downloads honour socks5:// values in the standard
+# proxy environment variables; without it reqwest silently ignores them.
+reqwest = { version = "0.13", features = ["json", "stream", "socks"] }
 opendal = { version = "0.55.0", features = ["services-s3"] }
 object-store-operator = { path = "crates/object-store-operator" }
 hyper = { version = "1", features = ["full"] }

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,23 @@ K8S_GATEWAY_IMAGE ?= agentenv-gateway:latest
 K8S_SCHEDULER_IMAGE ?= agentenv-scheduler:latest
 K3S_CTR ?= sudo k3s ctr
 
+# Optional build-time proxy for the image builds. The `--setup-only` layer of
+# Dockerfile.agentenv downloads regctl, firecracker, the kernel, the overlaybd
+# package and the ghcr.io tools image, which is the slowest part of a cold
+# build behind a restricted network. Export HTTPS_PROXY (socks5:// is
+# supported) before `make k8s-build` and it is forwarded to every stage.
+HTTP_PROXY ?= $(http_proxy)
+HTTPS_PROXY ?= $(https_proxy)
+ALL_PROXY ?= $(all_proxy)
+NO_PROXY ?= $(no_proxy)
+# Both cases are passed because Go and Rust HTTP clients differ in which
+# spelling they look up.
+DOCKER_PROXY_ARGS := \
+	$(if $(HTTP_PROXY),--build-arg HTTP_PROXY="$(HTTP_PROXY)" --build-arg http_proxy="$(HTTP_PROXY)",) \
+	$(if $(HTTPS_PROXY),--build-arg HTTPS_PROXY="$(HTTPS_PROXY)" --build-arg https_proxy="$(HTTPS_PROXY)",) \
+	$(if $(ALL_PROXY),--build-arg ALL_PROXY="$(ALL_PROXY)" --build-arg all_proxy="$(ALL_PROXY)",) \
+	$(if $(NO_PROXY),--build-arg NO_PROXY="$(NO_PROXY)" --build-arg no_proxy="$(NO_PROXY)",)
+
 # aenv home path.
 AENV_HOME_PATH ?= /var/lib/aenv
 export AENV_HOME_PATH
@@ -234,9 +251,9 @@ deploy-ps:
 	$(DOCKER_COMPOSE) -f $(DEPLOY_COMPOSE_FILE) ps
 
 k8s-build:
-	$(DOCKER) build $(if $(APT_MIRROR_BASE),--build-arg APT_MIRROR_BASE="$(APT_MIRROR_BASE)",) -f deploy/docker/Dockerfile.agentenv -t $(K8S_RUNTIME_IMAGE) .
-	$(DOCKER) build -f deploy/docker/Dockerfile.gateway -t $(K8S_GATEWAY_IMAGE) .
-	$(DOCKER) build -f deploy/docker/Dockerfile.scheduler -t $(K8S_SCHEDULER_IMAGE) .
+	$(DOCKER) build $(if $(APT_MIRROR_BASE),--build-arg APT_MIRROR_BASE="$(APT_MIRROR_BASE)",) $(DOCKER_PROXY_ARGS) -f deploy/docker/Dockerfile.agentenv -t $(K8S_RUNTIME_IMAGE) .
+	$(DOCKER) build $(DOCKER_PROXY_ARGS) -f deploy/docker/Dockerfile.gateway -t $(K8S_GATEWAY_IMAGE) .
+	$(DOCKER) build $(DOCKER_PROXY_ARGS) -f deploy/docker/Dockerfile.scheduler -t $(K8S_SCHEDULER_IMAGE) .
 
 k8s-redeploy:
 	$(KUBECTL) rollout restart deploy/agentenv-gateway -n $(K8S_NAMESPACE)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -84,6 +84,12 @@ services:
       dockerfile: deploy/docker/Dockerfile.agentenv
       args:
         APT_MIRROR_BASE: ${APT_MIRROR_BASE:-}
+        # Forwarded from the caller's shell so the `--setup-only` dependency
+        # downloads can use a proxy; empty values are ignored by BuildKit.
+        HTTP_PROXY: ${HTTP_PROXY:-${http_proxy:-}}
+        HTTPS_PROXY: ${HTTPS_PROXY:-${https_proxy:-}}
+        ALL_PROXY: ${ALL_PROXY:-${all_proxy:-}}
+        NO_PROXY: ${NO_PROXY:-${no_proxy:-}}
     container_name: agentenv-a
     environment:
       <<: *agentenv-environment

--- a/deploy/docker/Dockerfile.agentenv
+++ b/deploy/docker/Dockerfile.agentenv
@@ -1,7 +1,13 @@
 # syntax=docker/dockerfile:1.7
 
 FROM rust:1-bookworm AS chef
-
+# HTTP_PROXY/HTTPS_PROXY/ALL_PROXY/NO_PROXY are predefined BuildKit build args:
+# passing them with `--build-arg` makes them available to every stage's `RUN`
+# without an `ARG` declaration, and keeps them out of the image environment,
+# `docker history`, and the layer cache key. `make k8s-build` forwards whatever
+# is exported in the caller's shell. Declaring them here instead would scope
+# them to this stage only, leaving the `--setup-only` dependency downloads in
+# `deps-stage` on a direct connection.
 WORKDIR /build
 ENV CARGO_TARGET_DIR=/build/target
 ENV RUSTUP_TOOLCHAIN=${RUST_VERSION}


### PR DESCRIPTION
## What

Forward the caller's proxy environment into the container image builds from both `make k8s-build` and docker compose, and enable reqwest's `socks` feature.

## Why

The `--setup-only` layer of `Dockerfile.agentenv` downloads regctl, firecracker, the kernel, the overlaybd package and the ghcr.io tools image. Behind a restricted network that is by far the slowest part of a cold build, and there was no way to point it at a proxy short of editing the Dockerfile.

The `socks` feature is needed because reqwest reads the standard proxy environment variables but **silently ignores** `socks5://` values when the feature is off. A build that appears to honour `HTTPS_PROXY` then goes direct and hangs, with no diagnostic.

## Related issue

None; build-time developer experience.

## Scope and non-goals

Included: proxy passthrough in the Makefile, docker compose and a Dockerfile comment, plus the reqwest feature.

Explicitly excluded, because they were part of the same internal change but are site-specific:
- Retargeting the k8s image names at a private registry, and adding `--push` to `k8s-build`.
- Defaulting `APT_MIRROR_BASE` to a regional mirror. It stays empty.

## Design and behavior changes

`DOCKER_PROXY_ARGS` is assembled from `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `NO_PROXY`, each defaulting to its lowercase counterpart. Both spellings are passed through because Go and Rust HTTP clients differ in which they look up. Unset variables expand to nothing, so with no proxy exported the build commands are byte-for-byte what they are today.

These four are predefined BuildKit build args. Passing them with `--build-arg` makes them available to every stage's `RUN` without an `ARG` declaration, and keeps them out of the image environment, `docker history`, and the layer cache key — which matters because a proxy URL often carries credentials. The Dockerfile comment records this, since declaring `ARG` explicitly would scope them to a single stage and leave the `deps-stage` downloads on a direct connection, which is the opposite of the intent.

`docker-compose.yml` forwards the same four to the agentenv build.

## Compatibility and operations

- Public API or generated protocol: N/A.
- Configuration or defaults: no defaults change. Behavior is identical unless a proxy variable is exported.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: N/A, build-time only.
- Host requirements, permissions, ports, or dependencies: `socks` pulls in reqwest's SOCKS support; `Cargo.lock` needs no update and `cargo metadata --locked` still passes.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile

$ cargo metadata --locked --format-version 1
LOCKED OK   (Cargo.lock unchanged by the added feature)

$ make -n k8s-build                       # no proxy exported
docker build      -f deploy/docker/Dockerfile.agentenv -t agentenv-runtime:latest .
docker build     -f deploy/docker/Dockerfile.gateway -t agentenv-gateway:latest .
docker build     -f deploy/docker/Dockerfile.scheduler -t agentenv-scheduler:latest .

$ HTTPS_PROXY=socks5://127.0.0.1:1080 make -n k8s-build
docker build   --build-arg HTTPS_PROXY="socks5://127.0.0.1:1080" --build-arg https_proxy="socks5://127.0.0.1:1080"   -f deploy/docker/Dockerfile.agentenv -t agentenv-runtime:latest .
...

$ python3 -c "import yaml; yaml.safe_load(open('deploy/docker-compose.yml'))"
YAML OK
```

Skipped checks and reasons:

- `make test-unit` not run: the only Rust change is a Cargo feature flag, covered by a full `--all-targets` clippy build.
- A real proxied `make k8s-build` was not executed here; the passthrough is verified with `make -n` in both the proxy and no-proxy cases, and the equivalent change has been used to build these images behind a SOCKS proxy internally.

## Risks and reviewer notes

The no-proxy path is the one to check, since it affects everyone: `make -n` output above confirms the commands are unchanged apart from whitespace when no variable is exported.

Second point for review: proxy URLs frequently embed credentials. Using the predefined BuildKit args rather than declaring `ARG` keeps them out of the image and out of `docker history`; if maintainers would rather not accept proxy values through the Makefile at all, the compose and Dockerfile parts still stand on their own.

Most important file: `Makefile`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
