### PR TITLE
fix(proxy): probe upstream liveness with TCP keepalive

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -89,6 +89,10 @@ const PROXY_CONNECT_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(not(test))]
 const PROXY_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
+const PROXY_TCP_KEEPALIVE: Duration = Duration::from_secs(3);
+const PROXY_TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
+const PROXY_TCP_KEEPALIVE_RETRIES: u32 = 2;
+
 #[cfg(test)]
 const PROXY_RESPONSE_HEADER_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(not(test))]
@@ -123,6 +127,12 @@ pub(crate) fn build_proxy_client() -> ProxyClient {
     // delayed-ACK wait to them.
     connector.set_nodelay(true);
     connector.set_connect_timeout(Some(PROXY_CONNECT_TIMEOUT));
+    // Tearing down a VM never delivers FIN/RST to the host socket, so keepalive
+    // probes are what turn a connection to a sandbox that is already gone into
+    // a prompt error instead of a request that hangs until a higher timeout.
+    connector.set_keepalive(Some(PROXY_TCP_KEEPALIVE));
+    connector.set_keepalive_interval(Some(PROXY_TCP_KEEPALIVE_INTERVAL));
+    connector.set_keepalive_retries(Some(PROXY_TCP_KEEPALIVE_RETRIES));
     // Interaction IPs are reused across sandbox runtime generations. Hyper keys
     // its idle pool by authority, so a pooled connection can retain a stale VM flow.
     Client::builder(TokioExecutor::new())

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -119,6 +119,9 @@ fn auto_resume_min_sandbox_timeout() -> Duration {
 
 pub(crate) fn build_proxy_client() -> ProxyClient {
     let mut connector = HttpConnector::new();
+    // Proxied requests and responses are small, so Nagle only ever adds a
+    // delayed-ACK wait to them.
+    connector.set_nodelay(true);
     connector.set_connect_timeout(Some(PROXY_CONNECT_TIMEOUT));
     // Interaction IPs are reused across sandbox runtime generations. Hyper keys
     // its idle pool by authority, so a pooled connection can retain a stale VM flow.

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -9,6 +9,7 @@ use agentenv::overlaybd::OverlaybdP2pRuntime;
 use agentenv::sandbox::{FirecrackerPool, FirecrackerSandboxFactory, UblkDeviceManager};
 use agentenv::snapshot::SnapshotManager;
 use agentenv::template::TemplateBuilder;
+use axum::serve::ListenerExt;
 use clap::Parser;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
@@ -141,7 +142,14 @@ async fn main() -> anyhow::Result<()> {
     let shutdown_orchestrator = Arc::clone(&orchestrator);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    // envd streams a command's lifecycle as a burst of tiny Connect-RPC frames.
+    // With Nagle left on, the frame after the first one waits for the client's
+    // delayed ACK, adding a ~40ms floor to every short-lived command.
+    let listener = tokio::net::TcpListener::bind(&addr).await?.tap_io(|stream| {
+        if let Err(err) = stream.set_nodelay(true) {
+            warn!(target: "agentenv", error = %err, "failed to set TCP_NODELAY on incoming connection");
+        }
+    });
     info!(target: "agentenv", addr = %addr, "API server listening");
 
     let shutdown_cleanup = tokio::spawn(async move {

--- a/thirdparty/envd/src/transport.rs
+++ b/thirdparty/envd/src/transport.rs
@@ -105,6 +105,14 @@ impl Service<http::Request<TonicBoxBody>> for DualClient {
     }
 }
 
+/// envd exchanges small RPC frames, so Nagle only ever trades latency for a
+/// coalescing win that never materializes here.
+fn nodelay_connector() -> HttpConnector {
+    let mut connector = HttpConnector::new();
+    connector.set_nodelay(true);
+    connector
+}
+
 /// Creates a channel compatible with both HTTP/1.1 and HTTP/2.
 ///
 /// The channel automatically probes the server to determine supported protocol (H2 or H1).
@@ -113,12 +121,12 @@ pub fn new_channel(addr: &str) -> anyhow::Result<Channel> {
 
     let h1 = Client::builder(TokioExecutor::new())
         .http2_only(false)
-        .build(HttpConnector::new());
+        .build(nodelay_connector());
 
     // H2 with Prior Knowledge for cleartext
     let h2 = Client::builder(TokioExecutor::new())
         .http2_only(true)
-        .build(HttpConnector::new());
+        .build(nodelay_connector());
 
     let service = DualClient {
         h1,


### PR DESCRIPTION
## What

Enable TCP keepalive probes on the sandbox proxy's connector: 3 s idle before the first probe, 1 s between probes, 2 retries.

> **Depends on #109.** This branch is stacked on it because both touch `build_proxy_client()`; the diff shown here against `main` therefore also contains #109's commit. Please merge #109 first — this then rebases to a single-commit, three-line change.

## Why

Tearing down a VM never delivers FIN or RST to the host side of a proxied connection. The socket stays open from the host's point of view, so a request addressed to a sandbox that is already gone hangs until some higher-level timeout fires instead of failing immediately.

Keepalive probes are what detect that silence. With the values above the failure surfaces in roughly 5 s, which is a prompt error for a caller and still far above any plausible pause in normal proxied traffic.

## Related issue

None. Small, self-contained reliability fix on an existing code path.

## Scope and non-goals

Included: keepalive parameters on the proxy connector.

Excluded:
- Retry or failover behavior when a probe does detect a dead peer — the request fails, as it should.
- Connection pooling. `pool_max_idle_per_host(0)` already handles the separate problem of interaction IPs being reused across runtime generations.
- Any other connector in the tree.

## Design and behavior changes

Three constants next to the existing `PROXY_CONNECT_TIMEOUT`, applied via `HttpConnector::set_keepalive{,_interval,_retries}`.

Failure mode change: a request to a torn-down sandbox now returns a connection error after ~5 s instead of hanging. Callers that previously relied on a longer timeout to mask this will see the error sooner, which is the intent.

## Compatibility and operations

- Public API or generated protocol: N/A.
- Configuration or defaults: no new config keys. The values are compile-time constants; if maintainers want them tunable I can move them into `[orchestrator]` or a proxy section.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: transparent both ways.
- Host requirements, permissions, ports, or dependencies: `TCP_KEEPIDLE`/`TCP_KEEPINTVL`/`TCP_KEEPCNT` are Linux socket options and AgentENV is Linux-only.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
$ cargo fmt --all -- --check
(clean)

$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile

$ cargo check -p agentenv --all-targets
Finished `dev` profile
```

Skipped checks and reasons:

- `make test-unit` not run. Observing this behavior in a test requires a peer that vanishes without sending FIN/RST, which is not reproducible with an in-process test server; it needs a real VM teardown or an injected netfilter drop.
- No benchmark: this is a failure-mode fix, not a throughput or latency change on the healthy path.

## Risks and reviewer notes

The risk worth reviewing is the aggressiveness of the values. A 3 s idle threshold with 1 s probes means an idle-but-alive sandbox connection sends a probe every second. That is negligible traffic on a host-local link, but if the proxy is ever used across a slower network the numbers deserve revisiting.

The other question is whether ~5 s to detect is the right target. It is well under typical client timeouts while leaving room for a transient stall.

Most important file: `src/api/proxy.rs`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
