### PR TITLE
ci: publish multi-platform tools image

### DIFF
--- a/.github/workflows/publish-tools-image.yml
+++ b/.github/workflows/publish-tools-image.yml
@@ -1,0 +1,122 @@
+name: Publish Tools Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tools_version:
+        description: Immutable SemVer tag for the tools drive
+        required: true
+        default: "0.1.0"
+        type: string
+      envd_ref:
+        description: e2b-dev/infra ref used to build envd
+        required: true
+        default: "2026.17"
+        type: string
+
+jobs:
+  validate:
+    name: Validate publication
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set lowercase owner
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version and immutable tag
+        env:
+          TOOLS_VERSION: ${{ inputs.tools_version }}
+        run: |
+          make -C tools-image check-tools-version TOOLS_VERSION="$TOOLS_VERSION"
+          image="ghcr.io/$OWNER/agentenv-tools:$TOOLS_VERSION"
+          if docker buildx imagetools inspect "$image" >/dev/null 2>&1; then
+            echo "Refusing to overwrite published tools drive $image." >&2
+            exit 1
+          fi
+
+  publish-images:
+    name: Publish ${{ matrix.platform }} image
+    needs: validate
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux/amd64
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set lowercase owner
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push architecture image
+        uses: docker/build-push-action@v7
+        with:
+          context: tools-image
+          platforms: ${{ matrix.platform }}
+          target: artifact
+          build-args: |
+            TOOLS_VERSION=${{ inputs.tools_version }}
+            ENVD_REF=${{ inputs.envd_ref }}
+            ENVD_UPSTREAM_REPO=https://github.com/e2b-dev/infra.git
+          tags: ghcr.io/${{ env.OWNER }}/agentenv-tools:${{ inputs.tools_version }}-${{ matrix.arch }}
+          push: true
+
+  publish-manifest:
+    name: Publish multi-platform manifest
+    needs: publish-images
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+      - name: Set lowercase owner
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest
+        env:
+          TOOLS_VERSION: ${{ inputs.tools_version }}
+        run: |
+          repository="ghcr.io/$OWNER/agentenv-tools"
+          docker buildx imagetools create \
+            --tag "$repository:$TOOLS_VERSION" \
+            "$repository:$TOOLS_VERSION-amd64" \
+            "$repository:$TOOLS_VERSION-arm64"

--- a/tests/integration/snapshot.rs
+++ b/tests/integration/snapshot.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use agentenv::cfg::ConfigManager;
 use agentenv::sandbox::{
     CapturedSandboxSnapshot, FirecrackerSandbox, SandboxBackend, SandboxExecutor,
     SandboxLaunchConfig,
@@ -21,7 +22,9 @@ fn sample_runtime_versions() -> SnapshotRuntimeVersions {
         kernel_version: "kernel".to_string(),
         firecracker_version: "fc".to_string(),
         envd_version: "envd".to_string(),
-        tools_drive_version: "0.1.0".to_string(),
+        tools_drive_version: ConfigManager::global_config()
+            .resolved_tools_version()
+            .to_string(),
     }
 }
 

--- a/tests/integration/snapshot_attached_drive.rs
+++ b/tests/integration/snapshot_attached_drive.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::common;
 
+use agentenv::cfg::ConfigManager;
 use agentenv::sandbox::{
     ExtraDrive, FirecrackerSandbox, FirecrackerSandboxConfig, OverlaybdConfig, SandboxBackend,
     SandboxExecutor, SandboxLaunchConfig,
@@ -178,7 +179,9 @@ async fn publish_sandbox_snapshot_with_attached_drive(
             kernel_version: "test-kernel".to_string(),
             firecracker_version: "test-firecracker".to_string(),
             envd_version: "test-envd".to_string(),
-            tools_drive_version: "0.1.0".to_string(),
+            tools_drive_version: ConfigManager::global_config()
+                .resolved_tools_version()
+                .to_string(),
         },
         image_configs: agentenv::types::ImageConfigs::new(),
         custom_extension_params: None,

--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -18,7 +18,7 @@
 #
 # Build example:
 #
-#   make -C tools-image TOOLS_VERSION=0.1.0 ENVD_REF=2026.16
+#   make -C tools-image TOOLS_VERSION=0.1.0 ENVD_REF=2026.17
 #
 # Important build args:
 #   TOOLS_VERSION        Immutable AgentENV tools drive release version.
@@ -29,8 +29,7 @@
 
 ARG BUSYBOX_IMAGE=busybox:1.37.0-musl
 ARG DEBIAN_VERSION=bookworm
-ARG GO_VERSION=1.25.4
-ARG TARGETPLATFORM=linux/amd64
+ARG GO_VERSION=1.25.9
 ARG TOOLS_VERSION=0.1.0
 
 # ---------------------------------------------------------------------------
@@ -41,7 +40,7 @@ ARG TOOLS_VERSION=0.1.0
 # ---------------------------------------------------------------------------
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${DEBIAN_VERSION} AS envd-builder
 
-ARG ENVD_REF=2026.16
+ARG ENVD_REF=2026.17
 ARG ENVD_UPSTREAM_REPO=https://github.com/e2b-dev/infra.git
 ARG TARGETARCH
 

--- a/tools-image/Makefile
+++ b/tools-image/Makefile
@@ -4,7 +4,7 @@ SHELL := /usr/bin/env bash
 
 REPO_ROOT := ..
 TOOLS_VERSION ?= 0.1.0
-ENVD_REF ?= 2026.16
+ENVD_REF ?= 2026.17
 ENVD_UPSTREAM_REPO ?= https://github.com/e2b-dev/infra.git
 HOST_MACHINE := $(shell uname -m)
 ifeq ($(HOST_MACHINE),x86_64)
@@ -51,7 +51,7 @@ check-publish-image:
 		*/*) ;; \
 		*) \
 			echo "IMAGE must include a registry/repository for publish, got '$(IMAGE)'." >&2; \
-			echo "Example: make publish IMAGE=ghcr.io/zlzgithub-0801/agentenv-tools:$(TOOLS_VERSION)" >&2; \
+			echo "Example: make publish IMAGE=ghcr.io/kvcache-ai/agentenv-tools:$(TOOLS_VERSION)" >&2; \
 			exit 1; \
 		;; \
 	esac

--- a/tools-image/README.md
+++ b/tools-image/README.md
@@ -87,7 +87,7 @@ The build accepts these Make variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TOOLS_VERSION` | `0.1.0` | Immutable SemVer release of the complete tools drive |
-| `ENVD_REF` | `2026.16` | Tag, branch, or fetchable commit to build from the envd upstream repository |
+| `ENVD_REF` | `2026.17` | Tag, branch, or fetchable commit to build from the envd upstream repository |
 | `ENVD_UPSTREAM_REPO` | `https://github.com/e2b-dev/infra.git` | Repository containing `packages/envd` |
 | `ARCH` | host architecture, normalized to `amd64` or `arm64` | Target architecture |
 | `PUBLISH_PLATFORMS` | `linux/amd64,linux/arm64` | Platforms included in the published OCI image |
@@ -99,12 +99,12 @@ The build accepts these Make variables:
 Examples:
 
 ```bash
-make TOOLS_VERSION=0.1.0 ENVD_REF=2026.16 ARCH=amd64
+make TOOLS_VERSION=0.1.0 ENVD_REF=2026.17 ARCH=amd64
 
 make \
   ENVD_UPSTREAM_REPO=https://github.com/e2b-dev/infra.git \
   TOOLS_VERSION=0.1.0 \
-  ENVD_REF=2026.16 \
+  ENVD_REF=2026.17 \
   ARCH=amd64
 ```
 
@@ -119,12 +119,12 @@ tags to prevent concurrent or external publishers from replacing a release.
 ```bash
 make publish \
   TOOLS_VERSION=0.1.0 \
-  ENVD_REF=2026.16 \
-  IMAGE=ghcr.io/zlzgithub-0801/agentenv-tools:0.1.0
+  ENVD_REF=2026.17 \
+  IMAGE=ghcr.io/kvcache-ai/agentenv-tools:0.1.0
 
 make publish \
   TOOLS_VERSION=0.1.0-custom.1 \
-  ENVD_REF=2026.16 \
+  ENVD_REF=2026.17 \
   IMAGE=registry.example.com/custom/agentenv-tools:0.1.0-custom.1
 ```
 


### PR DESCRIPTION
## What

Add a publication workflow for the AgentENV tools image.

## Why

Previously, tools image publication was a manual, local process.
This workflow builds each platform on a native GitHub-hosted runner and publishes a multi-platform image to:
`ghcr.io/<repository-owner>/agentenv-tools:<version>`

## Related issue

<!-- Use "Closes #123" for an issue resolved by this PR. Non-trivial changes should normally have an issue or prior design discussion. -->

Closes #

## Scope and non-goals

### Included:
- A new workflow for building and publishing multi-architecture tools images.
### not included:
- Changes to the AgentENV runtime workflow.

## Design and behavior changes

The `Publish Tools Image` workflow is triggered manually with two inputs:

- `tools_version`: immutable SemVer version for the complete tools drive.
- `envd_ref`: tag, branch, or commit from `e2b-dev/infra`.

The workflow performs three stages:

1. Validate publication
   - Validates `tools_version` using the existing Makefile SemVer check.
   - Checks that the final GHCR tag does not already exist.
2. Build and push architecture images
3. Publish the multi-platform manifest


## Compatibility and operations

<!-- Explain applicable compatibility and deployment impact. Write "N/A" with a reason where appropriate. -->

- Public API or generated protocol: N/A — no API or generated protocol changes.
- Configuration or defaults: The tools producer default remains `0.1.0`; the default envd ref changes to `2026.17`, and the default Go builder changes to `1.25.9`.
- Snapshot manifest, artifact layout, or storage format: N/A — no structural changes.
- Upgrade and rollback: Published version tags are treated as immutable. Rollback is performed by configuring AgentENV to use an earlier tools version.
- Host requirements, permissions, ports, or dependencies: Publication requires GitHub Actions package write access to the repository owner's `agentenv-tools` GHCR package.

## Validation

<!-- Check only commands you actually ran. Add focused tests and exact commands below. -->

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [x] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text

```

Skipped checks and reasons:

- make -C services test: skipped because services/ was not changed.
- Benchmarks: skipped because this change does not affect a runtime hot path or performance-sensitive behavior.

## Risks and reviewer notes

<!-- Identify correctness, security, compatibility, resource, and operational risks. Point reviewers to the most important files or commits. -->

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
