### PR TITLE
Fix links in README and add documentation for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}
 
+      - name: Prepend documentation links
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          {
+            printf '📖 Documentation for this release: '
+            printf 'https://kvcache-ai.github.io/AgentENV/%s/\n' "$RELEASE_TAG"
+            printf '\n---\n\n'
+            cat CHANGES.md
+          } > CHANGES.md.tmp
+          mv CHANGES.md.tmp CHANGES.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@
     <img src="assets/heading-logo.svg" alt="AgentENV" />
   </picture>
   <p><strong>Running agent environments at scale</strong></p>
+  <p>
+    <a href="https://github.com/kvcache-ai/AgentENV/actions/workflows/coverage.yml">
+      <img src="https://github.com/kvcache-ai/AgentENV/actions/workflows/coverage.yml/badge.svg?branch=main&event=push" alt="Coverage workflow status">
+    </a>
+    <a href="https://github.com/kvcache-ai/AgentENV/blob/coverage-data/coverage/coverage.json">
+      <img src="https://github.com/kvcache-ai/AgentENV/blob/coverage-data/coverage/badge.svg?raw=1" alt="Latest coverage report">
+    </a>
+  </p>
+  <p>
+    📖 Full documentation:
+    <a href="https://kvcache-ai.github.io/AgentENV/latest/">Stable</a> |
+    <a href="https://kvcache-ai.github.io/AgentENV/dev/">Dev</a>
+  </p>
 </div>
-
-[![Coverage workflow status](https://github.com/kvcache-ai/AgentENV/actions/workflows/coverage.yml/badge.svg?branch=main&event=push)](https://github.com/kvcache-ai/AgentENV/actions/workflows/coverage.yml)
-[![Latest coverage report](https://github.com/kvcache-ai/AgentENV/blob/coverage-data/coverage/badge.svg?raw=1)](https://github.com/kvcache-ai/AgentENV/blob/coverage-data/coverage/coverage.json)
-📖 [Full documentation](https://kvcache-ai.github.io/AgentENV/)
 
 AgentENV (AENV) is a platform for running agent environments at scale, powering agentic RL training for **Kimi K3**.
 
@@ -28,7 +37,7 @@ AgentENV (AENV) is a platform for running agent environments at scale, powering 
 - **Linux kernel 6.8+**; the install script additionally requires **Ubuntu 24.04** (see *Quick Start* below for installation options)
 - `/dev/kvm` access for Firecracker microVM execution
 
-If your server does not support standard KVM, see the [PVM deployment guide](https://kvcache-ai.github.io/AgentENV/deployment/pvm.html) before installing.
+If your server does not support standard KVM, see the [PVM deployment guide](https://kvcache-ai.github.io/AgentENV/dev/deployment/pvm.html) before installing.
 
 ---
 
@@ -50,7 +59,7 @@ curl -fsSL https://raw.githubusercontent.com/kvcache-ai/AgentENV/main/scripts/in
 sudo systemctl start aenv
 ```
 
-If this installation fails because standard KVM is unavailable, follow the [PVM deployment guide](https://kvcache-ai.github.io/AgentENV/deployment/pvm.html) instead.
+If this installation fails because standard KVM is unavailable, follow the [PVM deployment guide](https://kvcache-ai.github.io/AgentENV/dev/deployment/pvm.html) instead.
 
 *Option B — Docker*
 
@@ -94,7 +103,7 @@ aenv start ubuntu            # starts a sandbox and attaches an interactive shel
 ## 🗂 Deployment
 
 For Docker Compose / Kubernetes cluster deployment and build-from-source instructions,
-see 📖 [Deployment](https://kvcache-ai.github.io/AgentENV/deployment/manual-compile.html).
+see 📖 [Deployment](https://kvcache-ai.github.io/AgentENV/latest/deployment/manual-compile.html).
 
 ---
 
@@ -102,7 +111,7 @@ see 📖 [Deployment](https://kvcache-ai.github.io/AgentENV/deployment/manual-co
 
 AgentENV exposes an E2B-compatible HTTP API. Point `E2B_API_URL` at your
 server and use the standard E2B Python / TypeScript SDK without any code
-changes. See 📖 [E2B integration](https://kvcache-ai.github.io/AgentENV/integration/e2b.html)
+changes. See 📖 [E2B integration](https://kvcache-ai.github.io/AgentENV/latest/integration/e2b.html)
 for setup details.
 
 ---

--- a/cliff.toml
+++ b/cliff.toml
@@ -2,7 +2,7 @@
 header = ""
 body = """
 {% for group, commits in commits | group_by(attribute="group") %}\
-### {{ group | upper_first }}
+### {{ group | striptags | trim | upper_first }}
 
 {% for commit in commits %}\
 - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
@@ -20,11 +20,11 @@ conventional_commits = true
 filter_unconventional = true
 filter_commits = false
 commit_parsers = [
-    { message = "^feat", group = "Features" },
-    { message = "^fix", group = "Bug Fixes" },
-    { message = "^refactor", group = "Improvements" },
-    { message = "^perf", group = "Performance" },
-    { message = "^docs?", group = "Documentation" },
+    { message = "^feat", group = "<!-- 0 -->Features" },
+    { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+    { message = "^refactor", group = "<!-- 2 -->Improvements" },
+    { message = "^perf", group = "<!-- 3 -->Performance" },
+    { message = "^docs?", group = "<!-- 4 -->Documentation" },
     { message = "^ci", skip = true },
     { message = "^chore", skip = true },
     { message = "^style", skip = true },


### PR DESCRIPTION
## What

- Fix the documentation links in README.
- Add documentation links in release notes.

## Why

- Secondary doc links in README are incorrect.
- Release notes do not have a link pointing to the related doc version.

## Related issue

N/A

## Scope and non-goals

Documentation.

## Design and behavior changes

N/A

## Compatibility and operations

- Public API or generated protocol: N/A
- Configuration or defaults: N/A
- Snapshot manifest, artifact layout, or storage format: N/A
- Upgrade and rollback: N/A
- Host requirements, permissions, ports, or dependencies: N/A

## Validation

- [x] `git-cliff --latest --strip header > CHANGES.md`

Skipped checks and reasons:

Other checks are not applicable.

## Risks and reviewer notes

N/A

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
