### PR TITLE
feat: add openEuler support to Linux distro detection

### DIFF
--- a/src/setup/overlaybd.rs
+++ b/src/setup/overlaybd.rs
@@ -136,8 +136,14 @@ fn configured_overlaybd_release(
         // so it runs fine on other glibc-based distros. Fall back to the
         // oldest published Ubuntu build (lowest glibc requirement) for known
         // RPM-family distros so the CLI tools install without a native asset.
-        "tencentos" | "centos" | "centos-stream" | "rhel" | "redhat"
-        | "redhatenterpriseserver" | "openeuler" | "openEuler" => {
+        "tencentos"
+        | "centos"
+        | "centos-stream"
+        | "rhel"
+        | "redhat"
+        | "redhatenterpriseserver"
+        | "openeuler"
+        | "openEuler" => {
             format!("ubuntu1.{}.{}", FALLBACK_UBUNTU_VERSION, target.arch)
         }
         other => bail!(
@@ -577,7 +583,14 @@ mod tests {
             ),
         };
 
-        for os_id in ["centos", "centos-stream", "tencentos", "rhel", "openeuler", "openEuler"] {
+        for os_id in [
+            "centos",
+            "centos-stream",
+            "tencentos",
+            "rhel",
+            "openeuler",
+            "openEuler",
+        ] {
             let release = configured_overlaybd_release(
                 &config,
                 &OverlaybdReleaseTarget {

--- a/src/setup/overlaybd.rs
+++ b/src/setup/overlaybd.rs
@@ -136,7 +136,8 @@ fn configured_overlaybd_release(
         // so it runs fine on other glibc-based distros. Fall back to the
         // oldest published Ubuntu build (lowest glibc requirement) for known
         // RPM-family distros so the CLI tools install without a native asset.
-        "tencentos" | "centos" | "centos-stream" | "rhel" | "redhat" | "redhatenterpriseserver" => {
+        "tencentos" | "centos" | "centos-stream" | "rhel" | "redhat"
+        | "redhatenterpriseserver" | "openeuler" | "openEuler" => {
             format!("ubuntu1.{}.{}", FALLBACK_UBUNTU_VERSION, target.arch)
         }
         other => bail!(
@@ -576,7 +577,7 @@ mod tests {
             ),
         };
 
-        for os_id in ["centos", "centos-stream", "tencentos", "rhel"] {
+        for os_id in ["centos", "centos-stream", "tencentos", "rhel", "openeuler", "openEuler"] {
             let release = configured_overlaybd_release(
                 &config,
                 &OverlaybdReleaseTarget {

--- a/src/setup/packages.rs
+++ b/src/setup/packages.rs
@@ -258,7 +258,9 @@ fn distro_from_id(id: &str) -> Option<Distro> {
     match id {
         "ubuntu" => Some(Distro::Ubuntu),
         "debian" => Some(Distro::Debian),
-        "centos" | "centos-stream" | "tencentos" | "openeuler" | "openEuler" => Some(Distro::Centos),
+        "centos" | "centos-stream" | "tencentos" | "openeuler" | "openEuler" => {
+            Some(Distro::Centos)
+        }
         "rhel" | "redhat" | "redhatenterpriseserver" => Some(Distro::Rhel),
         "arch" | "manjaro" => Some(Distro::Arch),
         _ => None,

--- a/src/setup/packages.rs
+++ b/src/setup/packages.rs
@@ -258,7 +258,7 @@ fn distro_from_id(id: &str) -> Option<Distro> {
     match id {
         "ubuntu" => Some(Distro::Ubuntu),
         "debian" => Some(Distro::Debian),
-        "centos" | "centos-stream" | "tencentos" => Some(Distro::Centos),
+        "centos" | "centos-stream" | "tencentos" | "openeuler" | "openEuler" => Some(Distro::Centos),
         "rhel" | "redhat" | "redhatenterpriseserver" => Some(Distro::Rhel),
         "arch" | "manjaro" => Some(Distro::Arch),
         _ => None,


### PR DESCRIPTION


## What

Add openEuler support to AgentENV's Linux distribution detection so --setup-only works on openEuler hosts.

## Why

openEuler is a glibc-based RPM-family Linux distro widely used on ARM (Kunpeng) servers in China. The upstream ARM64 support (#86) covers Ubuntu/Debian but fails on openEuler with two errors:

1. --setup-only fails with unsupported Linux distribution — distro_from_id in src/setup/packages.rs does not recognize openEuler, so the runtime package list cannot be resolved.
2. overlaybd provisioning fails with unsupported overlaybd release target — configured_overlaybd_release in src/setup/overlaybd.rs does not map openEuler to the RPM-family fallback.


## Related issue

No issue filed


## Scope and non-goals

Included:

- openEuler (ID=openEuler, lowercased to openeuler by the parser) recognized as RPM-family in src/setup/packages.rs
- openEuler mapped to the existing Ubuntu 22.04 overlaybd fallback in src/setup/overlaybd.rs
- Test coverage for both code paths

Excluded:

- No changes to dependency URLs, manifests, or tooling (upstream aenv-deps release already provides aarch64 binaries)
- No changes to tools-image/ build, network mirrors, or documentation
- No changes to non-RPM distributions


## Design and behavior changes

openEuler already matches the existing RPM-family pattern used by centos/rhel/tencentos:

- src/setup/packages.rs: distro_from_id maps openeuler/openEuler to Distro::Centos, reusing the existing dnf/yum package-manager detection and the libaio runtime package list.
- src/setup/overlaybd.rs: configured_overlaybd_release maps openEuler to ubuntu1.22.04.{arch} — the oldest published Ubuntu overlaybd asset, chosen because it bundles its own shared libraries and runs on any glibc-based distro (same reasoning as the existing tencentos/centos/rhel fallback).


## Compatibility and operations



- Public API or generated protocol: N/A
- Configuration or defaults: N/A
- Snapshot manifest, artifact layout, or storage format: N/A
- Upgrade and rollback: N/A — additive recognition of a previously-unsupported OS
- Host requirements, permissions, ports, or dependencies: openEuler hosts additionally need dpkg (to extract the overlaybd .deb)


## Validation

<!-- Check only commands you actually ran. Add focused tests and exact commands below. -->

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text

```

Skipped checks and reasons:

## Risks and reviewer notes

<!-- Identify correctness, security, compatibility, resource, and operational risks. Point reviewers to the most important files or commits. -->

## Checklist

- [ ] The PR contains one coherent change and no unrelated formatting or refactoring.
- [ ] New behavior is covered by tests, or I explained why testing is impractical.
- [ ] Logs and examples contain no credentials, tokens, or private registry information.
- [ ] I did not manually edit generated code without updating its source and regenerating it.
