### PR TITLE
fix(overlaybd): isolate runtime and CLI cache directories

### DIFF
--- a/docs/src/internals/persistence-artifact-inventory.md
+++ b/docs/src/internals/persistence-artifact-inventory.md
@@ -15,7 +15,7 @@ This document lists AgentENV artifacts that can remain on disk or in object stor
 | `persisted_sandbox_store_path` | `$AENV_HOME/persisted-sandboxes` | `src/orchestrator/persistence/*` | Durable paused sandbox records and artifacts. |
 | `snapshot_store` | `$AENV_HOME/snapshot-store` | `src/snapshot/repository/*` | Durable committed snapshot repository root. The configured backend uses `<snapshot_store>/repository`. Relative explicit paths are resolved against the config file directory. |
 | `snapshot.local_cache_path` | `$AENV_HOME/snapshot-local-cache` | `src/snapshot/artifact_cache.rs`, runtime resolvers | Node-local cache for materialized runtime artifacts. Relative explicit paths are resolved against the config file directory. |
-| `image.cache.root_dir` | `$AENV_HOME/image-cache` | `src/image/*`, overlaybd runtime | Node-local image cache root. Contains `configs/`, `indexes/`, `commits/`, and `remote-blocks/`. |
+| `image.cache.root_dir` | `$AENV_HOME/image-cache` | `src/image/*`, overlaybd runtime | Node-local image cache root. Contains `configs/`, `indexes/`, `commits/`, and `remote-blocks/`. The offline C++ tools own isolated sibling cache roots: `convert-blocks/` (`overlaybd-apply`) and `resize-blocks/` (`overlaybd-resize`). |
 | `p2p.store_dir` | `$AENV_HOME/p2p/store` | `src/p2p/*`, `src/cfg.rs` | Local store for P2P artifact transport backends. Relative explicit paths are resolved against the config file directory. |
 | `image.cache.remote_blocks` | `<image.cache.root_dir>/remote-blocks` | overlaybd runtime config | Remote block cache root. Overlaybd also stores `premerged-index/` under this cache dir. Its size limit comes from `image.cache.remote_blocks.max_size_gb`. |
 | `ublk.daemon_socket_path` | `$AENV_RUNTIME/ublk-daemon.sock` | `src/sandbox/ublk/*`, `storage/ublk-daemon/*` | Unix socket used for server-to-daemon IPC. |
@@ -34,7 +34,7 @@ Owned by `src/setup/*` and `src/cfg.rs`.
 | Overlaybd tools | `<deps_path>/overlaybd/bin/*`, `<deps_path>/overlaybd/lib/*` | `overlaybd-create`, `overlaybd-apply`, `overlaybd-commit`, `overlaybd-resize`, libraries | OCI-to-overlaybd conversion and packaging | Installed during setup when release metadata does not match. |
 | Overlaybd release metadata | `<deps_path>/overlaybd/tools-release.json` | Installed overlaybd release identifier | Detects whether tools need reinstalling | Rewritten on setup when release changes. |
 | Overlaybd package downloads | `<deps_path>/overlaybd/downloads/*` | Downloaded package archives | Setup cache for overlaybd release packages | Kept after install; no automatic GC. |
-| Generated overlaybd config | `$AENV_HOME/overlaybd/overlaybd-global.json`, `$AENV_HOME/overlaybd/mem-overlaybd-global.json` | Runtime global config, cache path, credentials config | Configures overlaybd runtime and memory snapshot overlaybd access | Rewritten during setup/startup. |
+| Generated overlaybd config | `$AENV_HOME/overlaybd/overlaybd-global.json`, `$AENV_HOME/overlaybd/mem-overlaybd-global.json`, `$AENV_HOME/overlaybd/convert-overlaybd-global.json`, `$AENV_HOME/overlaybd/resize-overlaybd-global.json` | Runtime global config, cache path, credentials config | Configures overlaybd runtime, memory snapshot overlaybd access, and the offline C++ tools (`overlaybd-apply`, `overlaybd-resize`), which get dedicated configs with isolated cacheDirs (`convert-blocks`, `resize-blocks`) and download disabled | Rewritten during setup/startup. |
 | Overlaybd runtime log | `<deps_path>/overlaybd/overlaybd.log` | Overlaybd runtime logs | Debugging | Appended by overlaybd runtime; no automatic GC. |
 
 ## Firecracker Sandbox
@@ -166,6 +166,7 @@ Owned by `storage/overlaybd/*`.
 | Artifact | Location | Contents | Purpose | Lifecycle | Rebuildable |
 | --- | --- | --- | --- | --- | --- |
 | Remote block cache | configured `cacheConfig.cacheDir`, derived from `<image.cache.root_dir>/remote-blocks` | Cached registryfs_v2 block ranges | Speeds remote overlaybd-native layer reads | Managed by overlaybd cache settings. | Yes. |
+| Offline C++ tool block caches | `<image.cache.root_dir>/convert-blocks` (`overlaybd-apply`), `<image.cache.root_dir>/resize-blocks` (`overlaybd-resize`) | C++ file-cache entries for the offline tools | Keeps C++ cache eviction (truncate+unlink of flat cacheDir files) away from the Rust runtime cache's per-entry directories | Owned and evicted by the C++ tools via their dedicated generated global configs; download is disabled in those configs. Never shared with the Rust runtime `remote-blocks` cache. | Yes. |
 | Premerged index cache | `cacheConfig.cacheDir/premerged-index/*.pmidx` | Serialized merged read-only lower index | Speeds opening repeated lower stacks | Written asynchronously on read-only open. Pruned by size limit derived from cache size. | Yes. |
 | Sealed overlaybd commit files | Various owner paths: image cache, snapshot dirs, repository managed layers | Overlaybd layer data and index trailer | Immutable lower layers for block devices and memory images | Lifecycle is owned by the module that stores the file. Overlaybd only defines the format and open/merge behavior. | Depends on owner. |
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -652,6 +652,36 @@ impl AppConfig {
         format!("overlaybd-oci:{version}:agentenv-cache-v1")
     }
 
+    /// Path of the generated overlaybd global config dedicated to the offline
+    /// C++ conversion tools (`overlaybd-apply`). It mirrors the runtime global
+    /// config but points at an isolated cacheDir: the C++ file cache manages
+    /// cacheDir as flat files and evicts (truncate+unlink) whatever it finds,
+    /// which would destroy the Rust runtime cache's per-entry directories if
+    /// both shared `remote-blocks`.
+    pub(crate) fn resolved_overlaybd_convert_global_config_path(&self) -> PathBuf {
+        self.ublk
+            .overlaybd
+            .global_config_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("convert-overlaybd-global.json")
+    }
+
+    /// Path of the generated overlaybd global config dedicated to the offline
+    /// C++ resize tool (`overlaybd-resize`). It mirrors the runtime global
+    /// config but points at an isolated cacheDir: the C++ file cache manages
+    /// cacheDir as flat files and evicts (truncate+unlink) whatever it finds,
+    /// which would destroy the Rust runtime cache's per-entry directories if
+    /// both shared `remote-blocks`.
+    pub(crate) fn resolved_overlaybd_resize_global_config_path(&self) -> PathBuf {
+        self.ublk
+            .overlaybd
+            .global_config_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("resize-overlaybd-global.json")
+    }
+
     /// Resolve the cpu-template-helper binary path derived from deps_path + version.
     /// Returns `None` if the binary does not exist on disk.
     pub fn resolved_cpu_template_helper(&self) -> Option<PathBuf> {
@@ -888,28 +918,45 @@ impl AppConfig {
     }
 
     pub(crate) fn validate_overlaybd_global_config_paths(&self) -> Result<()> {
-        // Shared lexical normalization (no filesystem access) so aliased
-        // spellings of the same file cannot skip validation.
-        let rootfs =
-            overlaybd::config::lexically_normalize_path(&self.ublk.overlaybd.global_config_path);
-        let memory = overlaybd::config::lexically_normalize_path(
-            &self.memory_snapshot.overlaybd_global_config_path,
-        );
-        // Lexical equality catches spelling aliases; canonicalize covers
-        // symlink aliases for paths that already exist.
-        let same = rootfs == memory
-            || match (
-                std::fs::canonicalize(&rootfs),
-                std::fs::canonicalize(&memory),
-            ) {
-                (Ok(rootfs), Ok(memory)) => rootfs == memory,
-                _ => false,
-            };
-        if same {
-            bail!(
-                "ublk.overlaybd.global_config_path and \
-                 memory_snapshot.overlaybd_global_config_path must be different"
-            );
+        let paths = [
+            (
+                "ublk.overlaybd.global_config_path",
+                &self.ublk.overlaybd.global_config_path,
+            ),
+            (
+                "memory_snapshot.overlaybd_global_config_path",
+                &self.memory_snapshot.overlaybd_global_config_path,
+            ),
+            (
+                "derived convert overlaybd global config path",
+                &self.resolved_overlaybd_convert_global_config_path(),
+            ),
+            (
+                "derived resize overlaybd global config path",
+                &self.resolved_overlaybd_resize_global_config_path(),
+            ),
+        ];
+        let normalized =
+            paths.map(|(name, path)| (name, overlaybd::config::lexically_normalize_path(path)));
+        let canonical = normalized
+            .clone()
+            .map(|(name, path)| (name, std::fs::canonicalize(&path).ok()));
+
+        for left in 0..normalized.len() {
+            for right in (left + 1)..normalized.len() {
+                let lexical_alias = normalized[left].1 == normalized[right].1;
+                let canonical_alias =
+                    canonical[left].1.is_some() && canonical[left].1 == canonical[right].1;
+                if lexical_alias || canonical_alias {
+                    bail!(
+                        "{} ({:?}) and {} ({:?}) must be different",
+                        normalized[left].0,
+                        normalized[left].1,
+                        normalized[right].0,
+                        normalized[right].1,
+                    );
+                }
+            }
         }
         Ok(())
     }
@@ -1251,6 +1298,34 @@ mod tests {
         config.memory_snapshot.overlaybd_global_config_path =
             PathBuf::from("/tmp/benv/global.json");
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_rootfs_path_equal_to_derived_resize_path() {
+        let mut config = AppConfig::default();
+        config.ublk.overlaybd.global_config_path =
+            PathBuf::from("/tmp/overlaybd/resize-overlaybd-global.json");
+
+        let err = config.validate().unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("ublk.overlaybd.global_config_path"));
+        assert!(message.contains("derived resize"));
+        assert!(message.contains("must be different"));
+    }
+
+    #[test]
+    fn validate_rejects_memory_path_equal_to_derived_convert_path() {
+        let mut config = AppConfig::default();
+        config.ublk.overlaybd.global_config_path =
+            PathBuf::from("/tmp/overlaybd/overlaybd-global.json");
+        config.memory_snapshot.overlaybd_global_config_path =
+            PathBuf::from("/tmp/overlaybd/convert-overlaybd-global.json");
+
+        let err = config.validate().unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("memory_snapshot.overlaybd_global_config_path"));
+        assert!(message.contains("derived convert"));
+        assert!(message.contains("must be different"));
     }
 
     #[test]

--- a/src/image/resolver.rs
+++ b/src/image/resolver.rs
@@ -55,7 +55,7 @@ pub struct ResolvedBlockImage {
 pub struct ImageResolver {
     store: Arc<dyn SourceImageStore>,
     overlaybd_install_root: PathBuf,
-    overlaybd_global_config: PathBuf,
+    overlaybd_convert_global_config: PathBuf,
     overlaybd_oci_converter_id: String,
     regctl_binary: PathBuf,
     default_image: String,
@@ -71,7 +71,7 @@ impl ImageResolver {
         Self {
             store,
             overlaybd_install_root: config.deps_path.join("overlaybd"),
-            overlaybd_global_config: config.ublk.overlaybd.global_config_path.clone(),
+            overlaybd_convert_global_config: config.resolved_overlaybd_convert_global_config_path(),
             overlaybd_oci_converter_id: config.resolved_overlaybd_oci_converter_id(),
             regctl_binary: config.resolved_regctl_binary(),
             default_image: config.image.resolver.default_image.clone(),
@@ -296,7 +296,7 @@ impl ImageResolver {
             fetched,
             oci_image::OverlaybdConversionEnv {
                 install_root: &self.overlaybd_install_root,
-                global_config: &self.overlaybd_global_config,
+                global_config: &self.overlaybd_convert_global_config,
                 converter_id: &self.overlaybd_oci_converter_id,
                 regctl_binary: &self.regctl_binary,
             },

--- a/src/sandbox/ublk/device.rs
+++ b/src/sandbox/ublk/device.rs
@@ -83,6 +83,8 @@ pub struct UblkDaemonConfig {
     pub daemon_binary: PathBuf,
     pub socket_path: PathBuf,
     pub global_config: PathBuf,
+    /// OverlayBD global config used by the daemon only for overlaybd-resize.
+    pub resize_global_config: PathBuf,
     pub app_config: Option<PathBuf>,
     /// Log file path for the daemon. If `None`, the daemon logs to stderr.
     pub log_file: Option<PathBuf>,
@@ -125,6 +127,7 @@ impl UblkDaemonConfig {
             daemon_binary,
             socket_path: ublk.daemon_socket_path.clone(),
             global_config: ublk.overlaybd.global_config_path.clone(),
+            resize_global_config: config.resolved_overlaybd_resize_global_config_path(),
             app_config: crate::cfg::ConfigManager::global()
                 .config_path()
                 .map(PathBuf::from),
@@ -197,6 +200,7 @@ impl UblkDeviceManager {
                             binary_path: &cfg.daemon_binary,
                             socket_path: cfg.socket_path,
                             global_config: &cfg.global_config,
+                            resize_global_config: &cfg.resize_global_config,
                             app_config: cfg.app_config.as_deref(),
                             log_file: cfg.log_file.as_deref(),
                             metrics_listen_addr: &cfg.metrics_listen_addr,

--- a/src/setup/deps.rs
+++ b/src/setup/deps.rs
@@ -11,7 +11,8 @@ use serde::Deserialize;
 use tracing::{debug, info};
 
 use crate::cfg::{
-    AppConfig, OssBackendConfig, OverlaybdDependencyConfig, SnapshotRepositoryBackendKind,
+    AppConfig, OssBackendConfig, OverlaybdDependencyConfig, ResolvedImageCacheConfig,
+    SnapshotRepositoryBackendKind,
 };
 use crate::digest::FileDigest;
 use crate::virtualization::VirtualizationMode;
@@ -312,16 +313,73 @@ pub(crate) fn write_generated_overlaybd_global_configs(
         .background_download
         .to_overlaybd_download_config();
 
-    for (path, download) in [
-        (&config.ublk.overlaybd.global_config_path, &rootfs_download),
-        (
-            &config.memory_snapshot.overlaybd_global_config_path,
-            &memory_download,
-        ),
-    ] {
-        write_generated_overlaybd_global_config(path, config, p2p_facade_address, download)
-            .with_context(|| format!("write overlaybd global config {}", path.display()))?;
-    }
+    let image_cache = config.image_cache_layout();
+    write_generated_overlaybd_global_config(
+        &config.ublk.overlaybd.global_config_path,
+        config,
+        &image_cache,
+        p2p_facade_address,
+        &rootfs_download,
+    )
+    .with_context(|| {
+        format!(
+            "write overlaybd global config {}",
+            config.ublk.overlaybd.global_config_path.display()
+        )
+    })?;
+
+    let mut memory_cache = image_cache.clone();
+    memory_cache.remote_blocks_dir = image_cache.root_dir.join("memory-blocks");
+    write_generated_overlaybd_global_config(
+        &config.memory_snapshot.overlaybd_global_config_path,
+        config,
+        &memory_cache,
+        p2p_facade_address,
+        &memory_download,
+    )
+    .with_context(|| {
+        format!(
+            "write overlaybd global config {}",
+            config
+                .memory_snapshot
+                .overlaybd_global_config_path
+                .display()
+        )
+    })?;
+
+    // The offline C++ conversion tools (`overlaybd-apply`) get a dedicated
+    // global config with an isolated cacheDir: the C++ file cache treats every
+    // file under cacheDir as a flat cache entry and evicts (truncate+unlink)
+    // them, which destroys the Rust runtime cache's per-entry directories when
+    // both share `remote-blocks`. Background download stays disabled because
+    // conversion only ever opens local layers.
+    let mut convert_cache = image_cache.clone();
+    convert_cache.remote_blocks_dir = image_cache.root_dir.join("convert-blocks");
+    let convert_path = config.resolved_overlaybd_convert_global_config_path();
+    write_generated_overlaybd_global_config(
+        &convert_path,
+        config,
+        &convert_cache,
+        p2p_facade_address,
+        &DownloadConfig::default(),
+    )
+    .with_context(|| format!("write overlaybd global config {}", convert_path.display()))?;
+
+    // The offline C++ resize tool (`overlaybd-resize`) gets a dedicated global
+    // config with an isolated cacheDir for the same reason as the conversion
+    // tools above: the C++ file cache would otherwise evict live entries from
+    // the shared Rust runtime cache. Background download stays disabled.
+    let mut resize_cache = image_cache.clone();
+    resize_cache.remote_blocks_dir = image_cache.root_dir.join("resize-blocks");
+    let resize_path = config.resolved_overlaybd_resize_global_config_path();
+    write_generated_overlaybd_global_config(
+        &resize_path,
+        config,
+        &resize_cache,
+        p2p_facade_address,
+        &DownloadConfig::default(),
+    )
+    .with_context(|| format!("write overlaybd global config {}", resize_path.display()))?;
     Ok(())
 }
 
@@ -588,11 +646,11 @@ fn extract_ext4_from_ghcr(
 fn write_generated_overlaybd_global_config(
     path: &Path,
     app_config: &AppConfig,
+    image_cache: &ResolvedImageCacheConfig,
     p2p_facade_address: Option<&str>,
     download: &DownloadConfig,
 ) -> Result<()> {
     let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let image_cache = app_config.image_cache_layout();
     let log_path = config_dir.join("overlaybd.log");
     let credential_config = match detect_docker_credential_config() {
         Some(credential_path) => {
@@ -1010,6 +1068,100 @@ mod tests {
     }
 
     #[test]
+    fn generated_convert_overlaybd_global_config_uses_isolated_cache_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let rootfs = temp.path().join("overlaybd-global.json");
+        let mem = temp.path().join("mem-overlaybd-global.json");
+        let mut config =
+            app_config_with_overlaybd_global_configs(temp.path(), rootfs.clone(), mem.clone());
+        config.image.cache.root_dir = temp.path().join("image-cache");
+
+        write_generated_overlaybd_global_configs(&config, None).expect("write global configs");
+
+        let convert = temp.path().join("convert-overlaybd-global.json");
+        let convert_value = read_global_config_value(&convert);
+        let rootfs_value = read_global_config_value(&rootfs);
+        let expected_cache_dir = temp.path().join("image-cache").join("convert-blocks");
+        assert_eq!(
+            convert_value["cacheConfig"]["cacheDir"].as_str(),
+            expected_cache_dir.to_str(),
+            "convert tools must use an isolated cacheDir"
+        );
+        assert_ne!(
+            convert_value["cacheConfig"]["cacheDir"], rootfs_value["cacheConfig"]["cacheDir"],
+            "convert tools must not share the runtime remote-blocks cacheDir"
+        );
+        assert_eq!(convert_value["download"]["enable"], false);
+    }
+
+    #[test]
+    fn resolved_overlaybd_resize_global_config_path_is_sibling_of_runtime_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let rootfs = temp.path().join("overlaybd-global.json");
+        let mem = temp.path().join("mem-overlaybd-global.json");
+        let config = app_config_with_overlaybd_global_configs(temp.path(), rootfs, mem);
+
+        assert_eq!(
+            config.resolved_overlaybd_resize_global_config_path(),
+            temp.path().join("resize-overlaybd-global.json")
+        );
+    }
+
+    #[test]
+    fn generated_resize_overlaybd_global_config_uses_isolated_cache_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let rootfs = temp.path().join("overlaybd-global.json");
+        let mem = temp.path().join("mem-overlaybd-global.json");
+        let mut config =
+            app_config_with_overlaybd_global_configs(temp.path(), rootfs.clone(), mem.clone());
+        config.image.cache.root_dir = temp.path().join("image-cache");
+
+        write_generated_overlaybd_global_configs(&config, None).expect("write global configs");
+
+        let resize = temp.path().join("resize-overlaybd-global.json");
+        let resize_value = read_global_config_value(&resize);
+        let rootfs_value = read_global_config_value(&rootfs);
+        let convert_value =
+            read_global_config_value(&temp.path().join("convert-overlaybd-global.json"));
+        let expected_resize_cache_dir = temp.path().join("image-cache").join("resize-blocks");
+        assert_eq!(
+            resize_value["cacheConfig"]["cacheDir"].as_str(),
+            expected_resize_cache_dir.to_str(),
+            "resize tool must use an isolated cacheDir"
+        );
+        assert_ne!(
+            resize_value["cacheConfig"]["cacheDir"], rootfs_value["cacheConfig"]["cacheDir"],
+            "resize tool must not share the runtime remote-blocks cacheDir"
+        );
+        assert_ne!(
+            resize_value["cacheConfig"]["cacheDir"], convert_value["cacheConfig"]["cacheDir"],
+            "resize tool must not share the conversion convert-blocks cacheDir"
+        );
+        assert_eq!(resize_value["download"]["enable"], false);
+
+        // Isolation only changes cache/download ownership: registry, credential
+        // and P2P fields stay identical to the runtime rootfs config.
+        assert_eq!(
+            resize_value["registryFsVersion"],
+            rootfs_value["registryFsVersion"]
+        );
+        assert_eq!(
+            resize_value["credentialConfig"],
+            rootfs_value["credentialConfig"]
+        );
+        assert_eq!(resize_value["p2pConfig"], rootfs_value["p2pConfig"]);
+        assert_eq!(resize_value["ioEngine"], rootfs_value["ioEngine"]);
+        assert_eq!(
+            resize_value["cacheConfig"]["cacheType"],
+            rootfs_value["cacheConfig"]["cacheType"]
+        );
+        assert_eq!(
+            resize_value["cacheConfig"]["cacheSizeGB"],
+            rootfs_value["cacheConfig"]["cacheSizeGB"]
+        );
+    }
+
+    #[test]
     fn generated_memory_overlaybd_global_config_uses_explicit_download_overrides() {
         let temp = tempfile::tempdir().expect("tempdir");
         let rootfs = temp.path().join("overlaybd-global.json");
@@ -1031,6 +1183,49 @@ mod tests {
                 .to_overlaybd_download_config()
         };
         assert_download_json(&read_global_config_value(&mem), &expected_memory);
+    }
+
+    #[test]
+    fn generated_memory_overlaybd_global_config_uses_independent_cache_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let rootfs = temp.path().join("overlaybd-global.json");
+        let mem = temp.path().join("mem-overlaybd-global.json");
+        let mut config =
+            app_config_with_overlaybd_global_configs(temp.path(), rootfs.clone(), mem.clone());
+        config.image.cache.root_dir = temp.path().join("image-cache");
+        config.memory_snapshot.background_download.enable = false;
+        config.memory_snapshot.background_download.block_size = 2 * 1024 * 1024;
+        config.memory_snapshot.background_download.concurrency = 7;
+
+        write_generated_overlaybd_global_configs(&config, None).expect("write global configs");
+
+        let rootfs_value = read_global_config_value(&rootfs);
+        let memory_value = read_global_config_value(&mem);
+        let convert_value =
+            read_global_config_value(&temp.path().join("convert-overlaybd-global.json"));
+        let resize_value =
+            read_global_config_value(&temp.path().join("resize-overlaybd-global.json"));
+        let expected_memory_cache_dir = config.image.cache.root_dir.join("memory-blocks");
+        assert_eq!(
+            memory_value["cacheConfig"]["cacheDir"].as_str(),
+            expected_memory_cache_dir.to_str(),
+            "memory snapshots must use an independent Rust cacheDir"
+        );
+        for other in [&rootfs_value, &convert_value, &resize_value] {
+            assert_ne!(
+                memory_value["cacheConfig"]["cacheDir"], other["cacheConfig"]["cacheDir"],
+                "memory cacheDir must be distinct from every other cacheDir"
+            );
+        }
+        let expected_memory = DownloadConfig {
+            enable: false,
+            block_size: 2 * 1024 * 1024,
+            concurrency: 7,
+            ..MemorySnapshotConfig::default()
+                .background_download
+                .to_overlaybd_download_config()
+        };
+        assert_download_json(&memory_value, &expected_memory);
     }
 
     #[test]

--- a/storage/ublk-daemon/src/client.rs
+++ b/storage/ublk-daemon/src/client.rs
@@ -115,6 +115,7 @@ pub struct UblkDaemonSpawnConfig<'a> {
     pub binary_path: &'a Path,
     pub socket_path: PathBuf,
     pub global_config: &'a Path,
+    pub resize_global_config: &'a Path,
     pub app_config: Option<&'a Path>,
     pub log_file: Option<&'a Path>,
     pub metrics_listen_addr: &'a str,
@@ -150,6 +151,7 @@ impl UblkDaemonClient {
             binary = %config.binary_path.display(),
             socket = %config.socket_path.display(),
             global_config = %config.global_config.display(),
+            resize_global_config = %config.resize_global_config.display(),
             app_config = ?config.app_config,
             log_file = ?config.log_file,
             metrics_listen_addr = config.metrics_listen_addr,
@@ -166,6 +168,8 @@ impl UblkDaemonClient {
             .arg(&config.socket_path)
             .arg("--global-config")
             .arg(config.global_config)
+            .arg("--resize-global-config")
+            .arg(config.resize_global_config)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::inherit());
 

--- a/storage/ublk-daemon/src/main.rs
+++ b/storage/ublk-daemon/src/main.rs
@@ -29,6 +29,10 @@ struct Cli {
     #[arg(long)]
     global_config: PathBuf,
 
+    /// Path to the OverlayBD global config used only by overlaybd-resize.
+    #[arg(long)]
+    resize_global_config: PathBuf,
+
     /// Path to AgentENV TOML config. Pool settings are read from [pool.block].
     #[arg(long)]
     config: Option<PathBuf>,
@@ -294,6 +298,7 @@ fn main() -> Result<()> {
             cli.socket_path.clone(),
             ctrl_ring,
             image_service,
+            cli.resize_global_config.clone(),
             cli.p2p_publish_url.clone(),
         );
         let daemon_config =

--- a/storage/ublk-daemon/src/runtime.rs
+++ b/storage/ublk-daemon/src/runtime.rs
@@ -2,6 +2,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -82,7 +83,7 @@ impl MaterializedOverlaybdRuntime {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) struct MaterializeOverlaybdRuntimeRequest<'a> {
     pub(crate) image_service_cache: &'a ImageServiceCache,
     pub(crate) source_image_config: &'a Path,
@@ -93,6 +94,14 @@ pub(crate) struct MaterializeOverlaybdRuntimeRequest<'a> {
     pub(crate) requested_virtual_size: Option<u64>,
     pub(crate) known_source_virtual_size: Option<u64>,
     pub(crate) resize_tool: Option<&'a ResizeToolSpec>,
+    /// Dedicated OverlayBD global config used only by the overlaybd-resize
+    /// child process (isolated cacheDir, download disabled). The normal
+    /// `global_config` above still drives size resolution and the Rust-side
+    /// reopen/verification.
+    pub(crate) resize_global_config: &'a Path,
+    /// Daemon-wide permit serializing overlaybd-resize child processes, which
+    /// all share the single isolated resize cacheDir.
+    pub(crate) resize_permit: Arc<tokio::sync::Mutex<()>>,
     pub(crate) allow_shrink: bool,
 }
 
@@ -142,6 +151,8 @@ async fn materialize_runtime_contents(
         requested_virtual_size,
         known_source_virtual_size,
         resize_tool,
+        resize_global_config,
+        resize_permit,
         allow_shrink,
     } = request;
 
@@ -214,13 +225,21 @@ async fn materialize_runtime_contents(
                 "overlaybd resize tool is required when virtual size changes".to_string(),
             )
         })?;
+        // Serialize overlaybd-resize children daemon-wide: they all share the
+        // single isolated resize cacheDir. The guard is held only around the
+        // child process and is released on every exit path (normal, non-zero
+        // exit, timeout, spawn/read errors) when it drops below or during
+        // error propagation; verification reopens through the Rust
+        // ImageService with the request's normal global config.
+        let resize_guard = resize_permit.lock().await;
         run_resize_tool(
             tool,
             &runtime_image_config_path,
-            global_config,
+            resize_global_config,
             actual_virtual_size,
         )
         .await?;
+        drop(resize_guard);
         verify_resized_runtime(
             image_service_cache,
             &runtime_image_config_path,
@@ -308,7 +327,7 @@ fn validate_requested_virtual_size(
 async fn run_resize_tool(
     tool: &ResizeToolSpec,
     image_config: &Path,
-    global_config: &Path,
+    resize_global_config: &Path,
     target_size: u64,
 ) -> Result<()> {
     let runtime_dir = image_config
@@ -322,7 +341,7 @@ async fn run_resize_tool(
         .arg("--size")
         .arg((target_size / GIB).to_string())
         .arg("--service_config_path")
-        .arg(global_config)
+        .arg(resize_global_config)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
@@ -654,6 +673,8 @@ mod tests {
             requested_virtual_size: None,
             known_source_virtual_size: None,
             resize_tool: None,
+            resize_global_config: global_config,
+            resize_permit: Arc::new(tokio::sync::Mutex::new(())),
             allow_shrink: false,
         }
     }
@@ -786,6 +807,12 @@ mod tests {
         let runtime = temp.path().join("runtime");
         let observed = temp.path().join("observed");
         let tool_lib = temp.path().join("tool-lib");
+        let resize_global_config = temp.path().join("resize-overlaybd-global.json");
+        fs::write(
+            &resize_global_config,
+            serde_json::to_vec_pretty(&GlobalConfig::default()).unwrap(),
+        )
+        .unwrap();
         let script = fake_resize_tool(
             temp.path(),
             &format!(
@@ -798,12 +825,15 @@ mod tests {
         let resize_tool = ResizeToolSpec {
             binary: script,
             lib_dir: Some(tool_lib.clone()),
-            timeout_secs: 2,
+            timeout_secs: 60,
         };
+        let resize_permit = Arc::new(tokio::sync::Mutex::new(()));
         let mut request = materialize_test_request(&cache, &source, &global_config, &runtime);
         request.requested_virtual_size = Some(2 * GIB);
-        request.known_source_virtual_size = Some(GIB);
+        request.known_source_virtual_size = None;
         request.resize_tool = Some(&resize_tool);
+        request.resize_global_config = &resize_global_config;
+        request.resize_permit = Arc::clone(&resize_permit);
         let materialized = materialize_overlaybd_runtime(request).await.unwrap();
 
         assert_eq!(materialized.actual_virtual_size, 2 * GIB);
@@ -829,13 +859,50 @@ mod tests {
             "{}\n--config\n{}\n--size\n2\n--service_config_path\n{}\n",
             runtime.display(),
             materialized.runtime_image_config_path.display(),
-            global_config.display(),
+            resize_global_config.display(),
         );
         let library_path = observed.strip_prefix(&expected_prefix).unwrap().trim_end();
         assert_eq!(
             std::env::split_paths(OsStr::new(library_path)).next(),
             Some(tool_lib)
         );
+
+        let timeout_tool = ResizeToolSpec {
+            binary: fake_resize_tool(temp.path(), "sleep 30"),
+            lib_dir: None,
+            timeout_secs: 1,
+        };
+        let timed_out_runtime = temp.path().join("runtime-timed-out");
+        let mut timed_out_request =
+            materialize_test_request(&cache, &source, &global_config, &timed_out_runtime);
+        timed_out_request.requested_virtual_size = Some(2 * GIB);
+        timed_out_request.resize_tool = Some(&timeout_tool);
+        timed_out_request.resize_global_config = &resize_global_config;
+        timed_out_request.resize_permit = Arc::clone(&resize_permit);
+        let err = materialize_overlaybd_runtime(timed_out_request)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("timed out after 1 seconds"));
+
+        let second_tool = fake_resize_tool(temp.path(), "exit 0");
+        let second_tool = ResizeToolSpec {
+            binary: second_tool,
+            lib_dir: None,
+            timeout_secs: 2,
+        };
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let _guard = resize_permit.lock().await;
+            run_resize_tool(
+                &second_tool,
+                &materialized.runtime_image_config_path,
+                &resize_global_config,
+                2 * GIB,
+            )
+            .await
+        })
+        .await
+        .expect("resize permit must be released after timeout")
+        .unwrap();
     }
 
     #[tokio::test]

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -263,6 +263,11 @@ pub struct UblkDaemonServer {
     devices: Arc<DashMap<u32, ManagedDevice>>,
     pool_state: Option<Arc<PoolState>>,
     resize_tool: Option<ResizeToolSpec>,
+    resize_global_config: PathBuf,
+    /// Daemon-wide permit serializing overlaybd-resize child processes: they
+    /// all share the single isolated resize cacheDir, so only one may run at
+    /// a time.
+    resize_permit: Arc<Mutex<()>>,
     shutdown: Arc<Notify>,
 }
 
@@ -271,14 +276,22 @@ impl UblkDaemonServer {
         socket_path: PathBuf,
         ctrl_ring: IoRingHandle<io_uring::squeue::Entry128>,
         default_image_service: ImageService,
+        resize_global_config: PathBuf,
     ) -> Self {
-        Self::new_with_p2p_publish_url(socket_path, ctrl_ring, default_image_service, None)
+        Self::new_with_p2p_publish_url(
+            socket_path,
+            ctrl_ring,
+            default_image_service,
+            resize_global_config,
+            None,
+        )
     }
 
     pub fn new_with_p2p_publish_url(
         socket_path: PathBuf,
         ctrl_ring: IoRingHandle<io_uring::squeue::Entry128>,
         default_image_service: ImageService,
+        resize_global_config: PathBuf,
         p2p_publish_url: Option<String>,
     ) -> Self {
         let mut cache = ImageServiceCache::new(p2p_publish_url);
@@ -301,6 +314,8 @@ impl UblkDaemonServer {
             devices: Arc::new(DashMap::new()),
             pool_state: None,
             resize_tool: None,
+            resize_global_config,
+            resize_permit: Arc::new(Mutex::new(())),
             shutdown: Arc::new(Notify::new()),
         }
     }
@@ -367,7 +382,11 @@ impl UblkDaemonServer {
 
         let listener = UnixListener::bind(&self.socket_path)
             .with_context(|| format!("bind daemon socket: {}", self.socket_path.display()))?;
-        tracing::info!(path = %self.socket_path.display(), "ublk daemon listening");
+        tracing::info!(
+            path = %self.socket_path.display(),
+            resize_global_config = %self.resize_global_config.display(),
+            "ublk daemon listening"
+        );
         signal_ready()?;
 
         // Note: spawned connection handlers may outlive the accept loop when
@@ -384,6 +403,8 @@ impl UblkDaemonServer {
                     let image_service_cache = Arc::clone(&self.image_service_cache);
                     let pool_state = self.pool_state.as_ref().map(Arc::clone);
                     let resize_tool = self.resize_tool.clone();
+                    let resize_global_config = self.resize_global_config.clone();
+                    let resize_permit = Arc::clone(&self.resize_permit);
                     let shutdown = Arc::clone(&self.shutdown);
                     tokio::spawn(async move {
                         if let Err(err) = handle_connection(
@@ -393,6 +414,8 @@ impl UblkDaemonServer {
                             image_service_cache,
                             pool_state,
                             resize_tool,
+                            resize_global_config,
+                            resize_permit,
                             shutdown,
                         ).await {
                             tracing::error!(?err, "daemon connection handler failed");
@@ -469,6 +492,7 @@ impl UblkDaemonServer {
 
 // ── Per-connection handler ──────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_connection(
     mut stream: tokio::net::UnixStream,
     devices: Arc<DashMap<u32, ManagedDevice>>,
@@ -476,6 +500,8 @@ async fn handle_connection(
     image_service_cache: Arc<ImageServiceCache>,
     pool_state: Option<Arc<PoolState>>,
     resize_tool: Option<ResizeToolSpec>,
+    resize_global_config: PathBuf,
+    resize_permit: Arc<Mutex<()>>,
     shutdown: Arc<Notify>,
 ) -> Result<()> {
     let Some(request) = recv_message::<DaemonRequest>(&mut stream).await? else {
@@ -515,6 +541,8 @@ async fn handle_connection(
                 requested_virtual_size,
                 known_source_virtual_size,
                 resize_tool: resize_tool.as_ref(),
+                resize_global_config: &resize_global_config,
+                resize_permit: Arc::clone(&resize_permit),
                 allow_shrink,
             };
             handle_create_overlaybd_runtime_device(
@@ -610,6 +638,8 @@ struct OverlaybdRuntimeDeviceRequest<'a> {
     requested_virtual_size: Option<u64>,
     known_source_virtual_size: Option<u64>,
     resize_tool: Option<&'a crate::protocol::ResizeToolSpec>,
+    resize_global_config: &'a Path,
+    resize_permit: Arc<Mutex<()>>,
     allow_shrink: bool,
 }
 
@@ -631,6 +661,8 @@ async fn handle_create_overlaybd_runtime_device(
             requested_virtual_size: request.requested_virtual_size,
             known_source_virtual_size: request.known_source_virtual_size,
             resize_tool: request.resize_tool,
+            resize_global_config: request.resize_global_config,
+            resize_permit: request.resize_permit,
             allow_shrink: request.allow_shrink,
         })
         .await

--- a/storage/ublk-daemon/tests/ublk_daemon_test.rs
+++ b/storage/ublk-daemon/tests/ublk_daemon_test.rs
@@ -872,7 +872,12 @@ mod server_tests {
 
         let image_service = test_image_service(dir.path()).await;
         let (ctrl_ring, _handle) = spawn_io_ring_worker::<io_uring::squeue::Entry128>(0);
-        let server = UblkDaemonServer::new(sock_path.clone(), ctrl_ring, image_service);
+        let server = UblkDaemonServer::new(
+            sock_path.clone(),
+            ctrl_ring,
+            image_service,
+            dir.path().join("resize-overlaybd-global.json"),
+        );
 
         // Run server in background.
         let server_task = tokio::spawn(async move { server.run().await });
@@ -911,6 +916,7 @@ mod server_tests {
             sock_path.clone(),
             ctrl_ring,
             image_service,
+            dir.path().join("resize-overlaybd-global.json"),
         ));
 
         let server_clone = Arc::clone(&server);
@@ -946,6 +952,7 @@ mod server_tests {
             sock_path.clone(),
             ctrl_ring,
             image_service,
+            dir.path().join("resize-overlaybd-global.json"),
         ));
 
         let server_clone = Arc::clone(&server);
@@ -977,7 +984,12 @@ mod server_tests {
 
         let image_service = test_image_service(dir.path()).await;
         let (ctrl_ring, _handle) = spawn_io_ring_worker::<io_uring::squeue::Entry128>(0);
-        let server = UblkDaemonServer::new(sock_path.clone(), ctrl_ring, image_service);
+        let server = UblkDaemonServer::new(
+            sock_path.clone(),
+            ctrl_ring,
+            image_service,
+            dir.path().join("resize-overlaybd-global.json"),
+        );
 
         // Server should fail because the socket is in use.
         let result = server.run().await;
@@ -997,6 +1009,7 @@ mod server_tests {
             sock_path.clone(),
             ctrl_ring,
             image_service,
+            dir.path().join("resize-overlaybd-global.json"),
         ));
 
         let server_clone = Arc::clone(&server);
@@ -1041,6 +1054,7 @@ mod server_tests {
             sock_path.clone(),
             ctrl_ring,
             image_service,
+            dir.path().join("resize-overlaybd-global.json"),
         ));
 
         let server_clone = Arc::clone(&server);
@@ -1085,6 +1099,7 @@ mod server_tests {
             sock_path.clone(),
             ctrl_ring,
             image_service,
+            dir.path().join("resize-overlaybd-global.json"),
         ));
 
         let server_clone = Arc::clone(&server);
@@ -1125,6 +1140,7 @@ mod server_tests {
             sock_path.clone(),
             ctrl_ring,
             image_service,
+            dir.path().join("resize-overlaybd-global.json"),
         ));
 
         let server_clone = Arc::clone(&server);


### PR DESCRIPTION
## What

Give every OverlayBD cache consumer its own `cacheDir` instead of sharing `{image-cache}/remote-blocks`:

- rootfs runtime (Rust `FileCacheBackend`) → `remote-blocks` (unchanged)
- memory snapshot (Rust `FileCacheBackend`) → `memory-blocks`
- `overlaybd-apply` (C++ file cache, OCI → overlaybd conversion) → `convert-blocks`
- `overlaybd-resize` (C++ file cache) → `resize-blocks`

`overlaybd-resize` receives its dedicated generated global config (`resize-overlaybd-global.json`) through a new daemon CLI argument, and daemon resize invocations are serialized under a daemon-wide permit. Config validation now also rejects user-configured rootfs/memory global config paths that collide with the derived convert/resize config paths.

## Why

All generated OverlayBD global configs pointed at the same `cacheDir` (`remote-blocks`), with two distinct failure modes:

1. The offline C++ tools (`overlaybd-apply`, `overlaybd-resize`) initialize the C++ flat file cache on the shared directory. That cache recursively indexes every file it finds — including the Rust cache's `<digest>/data` and `<digest>/meta.bin` — and its eviction does `truncate(0)`+`unlink` on them. With the Rust cache above ~90% of `cacheSizeGB`, any tool invocation past the 10s eviction timer batch-empties Rust per-entry directories, and `truncate(0)` on a live daemon mmap raises SIGBUS, killing the ublk daemon and all its devices.
2. The daemon runs two independent Rust `FileCacheBackend` instances (rootfs and memory) over the same directory. Each keeps its own bitmap/mmap/LRU and eviction worker, so one backend can hole-punch or delete entries the other still considers valid — the same class of corruption without any C++ process involved.

`overlaybd-apply` has no functional need for the cache at all (conversion only opens local layers). `overlaybd-resize` legitimately reads remote lowers, so it keeps `cacheType=file` with on-demand reads in its own directory; background download is disabled for both tool configs.

## Related issue

N/A — no tracking issue.

## Scope and non-goals

Included:

- Four isolated cache directories with generated configs rewritten on every setup/startup.
- `resize-overlaybd-global.json` plumbed from `AppConfig` into the daemon (`--resize-global-config`) and used only for the resize child's `--service_config_path`; base-size resolution and post-resize verification keep using the runtime config.
- Daemon-wide `tokio::sync::Mutex` permit around `overlaybd-resize` (the C++ cache has no cross-process coordination), released on success, non-zero exit, and timeout (kill + reap).
- Validation that rootfs/memory/convert/resize global config paths are pairwise distinct (lexical + canonical alias detection).
- Unit tests for config generation, path validation, resize argv, permit release after failure/timeout, and the fresh-launch (`known_source_virtual_size=None`) shape.

Non-goals (deliberately excluded):

- Shared process-wide Rust `CachePool` with QoS for rootfs/memory (would avoid duplicated caching but is a larger cache-architecture change).
- Dynamic cross-cache disk quota management; each cache currently inherits `image.cache.remote_blocks.max_size_gb` independently.
- C++ cache cross-process locking (upstream OverlayBD concern).

## Design and behavior changes

Generated config layout:

```text
{home}/overlaybd/overlaybd-global.json          -> {image-cache}/remote-blocks   (rootfs)
{home}/overlaybd/mem-overlaybd-global.json      -> {image-cache}/memory-blocks   (memory)
{home}/overlaybd/convert-overlaybd-global.json  -> {image-cache}/convert-blocks  (apply, download off)
{home}/overlaybd/resize-overlaybd-global.json   -> {image-cache}/resize-blocks   (resize, download off)
```

Resize config flow: `AppConfig::resolved_overlaybd_resize_global_config_path()` → `UblkDaemonConfig` → `UblkDaemonSpawnConfig` → daemon `--resize-global-config` → `UblkDaemonServer` → per-connection `MaterializeOverlaybdRuntimeRequest` → `run_resize_tool`. The resize permit is acquired immediately before spawning the child and dropped before Rust-side verification.

## Compatibility and operations

- Public API or generated protocol: unchanged. The daemon gains a required `--resize-global-config` CLI arg; server and daemon ship together, and the in-repo client is the only spawner.
- Configuration or defaults: `config.validate()` now rejects rootfs/memory global config paths that alias the derived convert/resize config paths (previously silently overwritten at setup). No default behavior change.
- Snapshot manifest, artifact layout, or storage format: unchanged. New cache directories are created on demand; `memory-blocks` starts cold once (existing `remote-blocks` content is not migrated).
- Upgrade and rollback: rollback to the previous version is safe (it ignores the new config files/directories).
- Host requirements, permissions, ports, or dependencies: unchanged.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit` (see note below)
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes) — N/A, no `services/` changes
- [ ] Generated clients/server regenerated with the documented `make` target — N/A, no generated code touched
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed — N/A, no steady-state performance change intended

Commands and results (Linux host with KVM/ublk):

```text
make fmt                                    # pass
make clippy                                 # pass (-D warnings)
make test-unit                              # 693 passed, 1 failed (see note)
cargo test -p uvm-ublk-daemon               # 46 unit + 40 integration passed
cargo test -p agentenv setup::deps --lib    # 17 passed
cargo test -p agentenv --lib validate_rejects_  # 9 passed
```

End-to-end on the same host: created a sandbox with `diskSizeMB` larger than the base image (300 GiB on a 256 GiB image); observed the real invocation

```text
overlaybd-resize --config .../image.json --size ... --service_config_path .../resize-overlaybd-global.json
```

with `resize-blocks/` gaining the C++ cache entry and `remote-blocks/` containing only Rust per-entry directories afterwards; sandbox booted and the device showed the requested size.

`make test-unit` note: the single failure is `privileges::tests::scoped_spawn_clears_child_capabilities_without_mutating_caller` (`src/privileges.rs`, untouched by this PR). It asserts a spawned child retains no `CapPrm`, which does not hold when tests run as root on this host; pre-existing and environment-dependent.

Skipped checks and reasons: services tests, codegen, benchmarks — no related changes.

## Risks and reviewer notes

- Permit queueing vs client RPC timeout: serialized resizes can queue; the client runtime-device timeout is sized for one resize, so a burst of concurrent oversized cold-starts can time out client-side while the daemon finishes the device (orphaned until restart). Pre-existing failure class amplified by serialization; tracked as a follow-up (observability + orphan cleanup), not addressed here.
- Each of the four caches inherits the full `image.cache.remote_blocks.max_size_gb`, so worst-case aggregate cache usage grows; `convert-blocks` stays near-empty in practice (local-layer conversion only).
- Concurrent `overlaybd-apply` processes share `convert-blocks`, but in the current pipeline conversion opens only local layers, so the C++ cache produces no remote entries there; revisit if conversion ever opens remote lowers.
- Most important files: `src/setup/deps.rs` (four generated configs), `src/cfg.rs` (derived paths + collision validation), `storage/ublk-daemon/src/runtime.rs` (resize child config + permit).

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
