### PR TITLE
feat: add opt-in dirty-page tracking for memory snapshots

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -202,6 +202,12 @@ fill_concurrency = 4
 # Experimental: create memory overlaybd layers directly from Firecracker dirty
 # ranges via process_vm_readv, skipping the intermediate mem.bin file.
 direct_overlaybd = true
+# Experimental: enable Firecracker KVM dirty-page tracking for memory snapshots.
+# Requires direct_overlaybd = true. PVM is temporarily disabled because this
+# combination has not been tested.
+# Default false uses the mincore-based memory selection path.
+# Can also be set with AGENTENV_MEMORY_SNAPSHOT_TRACK_DIRTY_PAGES.
+track_dirty_pages = false
 compression_enabled = false
 compression_algorithm = "lz4"
 # Blocking threads used to compress memory-layer blocks. 1 = sequential;

--- a/config/oss_default.toml
+++ b/config/oss_default.toml
@@ -148,6 +148,12 @@ fill_concurrency = 4
 # Experimental: create memory overlaybd layers directly from Firecracker dirty
 # ranges via process_vm_readv, skipping the intermediate mem.bin file.
 direct_overlaybd = true
+# Experimental: enable Firecracker KVM dirty-page tracking for memory snapshots.
+# Requires direct_overlaybd = true. PVM is temporarily disabled because this
+# combination has not been tested.
+# Default false uses the mincore-based memory selection path.
+# Can also be set with AGENTENV_MEMORY_SNAPSHOT_TRACK_DIRTY_PAGES.
+track_dirty_pages = false
 compression_enabled = false
 compression_algorithm = "lz4"
 # Blocking threads used to compress memory-layer blocks. 1 = sequential;

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -489,6 +489,7 @@ the default path on every startup.
 |-----|------|---------|-------------|
 | `overlaybd_global_config_path` | string | `"$AENV_HOME/overlaybd/mem-overlaybd-global.json"` | Path to the overlaybd global config used for the memory-snapshot ublk backend. Regenerated at startup (manual edits are overwritten); change only to relocate the generated file. |
 | `direct_overlaybd` | bool | `true` | Create memory overlaybd layers directly from Firecracker dirty memory ranges via `process_vm_readv`, skipping the intermediate `mem.bin` file. Set `AGENTENV_MEMORY_SNAPSHOT_DIRECT_OVERLAYBD=false` to force the legacy `mem.bin` conversion path. |
+| `track_dirty_pages` | bool | `false` | Enable Firecracker KVM dirty-page tracking for memory snapshots. When true, `direct_overlaybd` must also be `true`; PVM is temporarily disabled because this combination has not been tested. Set `AGENTENV_MEMORY_SNAPSHOT_TRACK_DIRTY_PAGES=true` to enable it. |
 | `compression_enabled` | bool | `false` | Enable compression for memory snapshot layers. When disabled, `compression_algorithm` is still parsed but has no effect. This setting affects only memory layers; the physical file name remains `overlaybd.commit`. |
 | `compression_algorithm` | string | `"lz4"` | Compression algorithm for memory snapshot layers. Valid values are only `lz4` and `zstd`. |
 

--- a/docs/src/deployment/pvm.md
+++ b/docs/src/deployment/pvm.md
@@ -223,6 +223,8 @@ virtualization_mode = "pvm"
 
 The environment variable takes precedence over the TOML value.
 
+Memory snapshot dirty-page tracking (`memory_snapshot.track_dirty_pages = true`) is temporarily disabled in PVM mode because this combination has not been tested.
+
 To build a PVM Docker image:
 
 ```bash

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -415,6 +415,10 @@ pub struct MemorySnapshotConfig {
     pub overlaybd_global_config_path: PathBuf,
     #[config(env = "AGENTENV_MEMORY_SNAPSHOT_DIRECT_OVERLAYBD", default = true)]
     pub direct_overlaybd: bool,
+    /// Enable Firecracker KVM dirty-page tracking for memory snapshots.
+    /// Default: false, preserving the mincore-based path.
+    #[config(env = "AGENTENV_MEMORY_SNAPSHOT_TRACK_DIRTY_PAGES", default = false)]
+    pub track_dirty_pages: bool,
     #[config(default = false)]
     pub compression_enabled: bool,
     #[config(default = "lz4")]
@@ -880,6 +884,7 @@ impl AppConfig {
         if self.ublk.overlaybd.resize_timeout_secs == 0 {
             bail!("invalid ublk.overlaybd config: resize_timeout_secs must be > 0");
         }
+        self.validate_memory_snapshot_options()?;
         self.validate_memory_snapshot_background_download()?;
         self.validate_overlaybd_global_config_paths()?;
         self.validate_disk_rate_limit()?;
@@ -927,6 +932,25 @@ impl AppConfig {
                     i64::MAX
                 );
             }
+        }
+        Ok(())
+    }
+
+    fn validate_memory_snapshot_options(&self) -> Result<()> {
+        let memory = &self.memory_snapshot;
+        if !memory.track_dirty_pages {
+            return Ok(());
+        }
+        if self.virtualization_mode == VirtualizationMode::Pvm {
+            bail!(
+                "memory_snapshot.track_dirty_pages=true is disabled in PVM mode because this combination has not been tested"
+            );
+        }
+        if !memory.direct_overlaybd {
+            bail!(concat!(
+                "memory_snapshot.track_dirty_pages=true requires ",
+                "memory_snapshot.direct_overlaybd=true for cumulative dirty snapshots"
+            ));
         }
         Ok(())
     }
@@ -1267,19 +1291,23 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn memory_snapshot_compression_config_is_valid() -> Result<()> {
+    fn memory_snapshot_config_defaults_are_valid() -> Result<()> {
         let default = MemorySnapshotConfig::default();
         assert!(!default.compression_enabled);
+        assert!(!default.track_dirty_pages);
         assert_eq!(
             default.compression_algorithm,
             MemorySnapshotCompressionAlgorithm::Lz4
         );
         assert_eq!(default.compression_workers, 1);
-
         let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
         for relative in ["config/default.toml", "config/oss_default.toml"] {
             let config = ConfigManager::new_from_path(&workspace.join(relative))?;
             assert!(!config.config().memory_snapshot.compression_enabled);
+            assert!(
+                !config.config().memory_snapshot.track_dirty_pages,
+                "unexpected track_dirty_pages default in {relative}"
+            );
             assert_eq!(
                 config.config().memory_snapshot.compression_algorithm,
                 MemorySnapshotCompressionAlgorithm::Lz4,
@@ -1291,7 +1319,55 @@ mod tests {
                 "unexpected compression_workers default in {relative}"
             );
         }
+        Ok(())
+    }
 
+    #[test]
+    fn memory_snapshot_track_dirty_pages_validates_supported_combinations() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "virtualization_mode = \"kvm\"\n[memory_snapshot]\ntrack_dirty_pages = true\ndirect_overlaybd = true\n",
+        )?;
+        let config = ConfigManager::new_from_path(&path)?;
+        assert!(config.config().memory_snapshot.track_dirty_pages);
+        assert!(config.config().memory_snapshot.direct_overlaybd);
+        assert_eq!(config.config().virtualization_mode, VirtualizationMode::Kvm);
+        std::fs::write(
+            &path,
+            "virtualization_mode = \"kvm\"\n[memory_snapshot]\ntrack_dirty_pages = true\ndirect_overlaybd = false\n",
+        )?;
+        let error = ConfigManager::new_from_path(&path).unwrap_err();
+        assert!(
+            error.to_string().contains(
+                "memory_snapshot.track_dirty_pages=true requires memory_snapshot.direct_overlaybd=true"
+            ),
+            "unexpected error: {error}"
+        );
+        std::fs::write(
+            &path,
+            "virtualization_mode = \"pvm\"\n[memory_snapshot]\ntrack_dirty_pages = true\ndirect_overlaybd = true\n",
+        )?;
+        let error = ConfigManager::new_from_path(&path).unwrap_err();
+        assert!(
+            error.to_string().contains(
+                "memory_snapshot.track_dirty_pages=true is disabled in PVM mode because this combination has not been tested"
+            ),
+            "unexpected error: {error}"
+        );
+        std::fs::write(
+            &path,
+            "[memory_snapshot]\ntrack_dirty_pages = false\ndirect_overlaybd = false\n",
+        )?;
+        let config = ConfigManager::new_from_path(&path)?;
+        assert!(!config.config().memory_snapshot.track_dirty_pages);
+        assert!(!config.config().memory_snapshot.direct_overlaybd);
+        Ok(())
+    }
+
+    #[test]
+    fn memory_snapshot_compression_config_is_valid() -> Result<()> {
         let temp = tempdir()?;
         let path = temp.path().join("config.toml");
         std::fs::write(
@@ -1305,7 +1381,6 @@ mod tests {
             MemorySnapshotCompressionAlgorithm::Zstd
         );
         assert_eq!(config.config().memory_snapshot.compression_workers, 4);
-
         std::fs::write(
             &path,
             "[memory_snapshot]\ncompression_enabled = true\ncompression_algorithm = \"snappy\"\n",

--- a/src/sandbox/firecracker/config.rs
+++ b/src/sandbox/firecracker/config.rs
@@ -127,6 +127,10 @@ pub struct FirecrackerCommonConfig {
     /// is enabled and written to a `firecracker.log` file alongside the stdout log.
     pub firecracker_log_level: Option<String>,
     pub runtime_policy: FirecrackerRuntimePolicy,
+    /// Enable Firecracker KVM dirty-page tracking for memory snapshot capture.
+    /// The serde default keeps older persisted snapshot configs compatible.
+    #[serde(default)]
+    pub track_dirty_pages: bool,
     pub envd_version: String,
     /// Control plane port inside the VM (default: 49983).
     pub control_plane_port: u16,
@@ -173,6 +177,7 @@ impl FirecrackerCommonConfig {
             stderr_path: None,
             firecracker_log_level: None,
             runtime_policy,
+            track_dirty_pages: false,
             envd_version: EnvdConfig::default().version,
             control_plane_port: ToolsConfig::default().control_plane_port,
             env_vars: None,
@@ -199,6 +204,7 @@ impl FirecrackerCommonConfig {
         let mut common = Self::new(firecracker_binary, tools_drive_version, runtime_policy);
         common.envd_version = config.envd.version.clone();
         common.disk_rate_limit = config.machine.disk_rate_limit.clone();
+        common.track_dirty_pages = config.memory_snapshot.track_dirty_pages;
         common.rootfs_allow_shrink = config.ublk.overlaybd.allow_shrink;
         common.control_plane_port = config.tools.control_plane_port;
         common.firecracker_work_base_dir = config.firecracker.work_dir.clone();
@@ -725,6 +731,16 @@ mod tests {
 
         let common_config = FirecrackerCommonConfig::from_app_config(&config)?;
         assert!(common_config.ublk_config.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn from_app_config_maps_track_dirty_pages() -> Result<()> {
+        let mut config = base_app_config();
+        config.memory_snapshot.track_dirty_pages = true;
+
+        let common_config = FirecrackerCommonConfig::from_app_config(&config)?;
+        assert!(common_config.track_dirty_pages);
         Ok(())
     }
 

--- a/src/sandbox/firecracker/instance.rs
+++ b/src/sandbox/firecracker/instance.rs
@@ -530,6 +530,7 @@ impl FirecrackerInstance {
         mem_backend_path: &Path,
         network_overrides: &[(&str, &str)],
         resume_vm: bool,
+        track_dirty_pages: bool,
     ) -> Result<()> {
         let snapshot_path = self.resolve_host_path(snapshot_path);
         let mut params = SnapshotLoadParams::new(snapshot_path.to_string_lossy().into_owned());
@@ -538,6 +539,7 @@ impl FirecrackerInstance {
             mem_backend_path.to_string_lossy().into_owned(),
         )));
         params.resume_vm = Some(resume_vm);
+        params.track_dirty_pages = Some(track_dirty_pages);
         if !network_overrides.is_empty() {
             params.network_overrides = Some(
                 network_overrides
@@ -624,8 +626,17 @@ fn parse_log_level(level: &str) -> Result<firecracker_client::models::logger::Le
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http_body_util::BodyExt;
+    use hyper::body::Incoming;
+    use hyper::server::conn::http1;
+    use hyper::service::service_fn;
+    use hyper::{Request, Response, StatusCode};
+    use hyper_util::rt::TokioIo;
+    use serde_json::Value;
     use std::process::Command as StdCommand;
     use tempfile::tempdir;
+    use tokio::net::UnixListener;
+    use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn wait_for_ready_times_out_when_socket_never_appears() {
@@ -755,6 +766,64 @@ mod tests {
             PathBuf::from("/tmp/mem.bin")
         );
 
+        Ok(())
+    }
+    #[tokio::test]
+    async fn fresh_and_restore_requests_include_track_dirty_pages() -> Result<()> {
+        let temp = tempdir()?;
+        let listener = UnixListener::bind(temp.path().join("firecracker.socket"))?;
+        let (requests_tx, mut requests_rx) = mpsc::unbounded_channel::<(String, Value)>();
+
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.expect("accept request");
+                let requests_tx = requests_tx.clone();
+                http1::Builder::new()
+                    .keep_alive(false)
+                    .serve_connection(
+                        TokioIo::new(stream),
+                        service_fn(move |request: Request<Incoming>| {
+                            let requests_tx = requests_tx.clone();
+                            async move {
+                                let path = request.uri().path().to_string();
+                                let body =
+                                    request.collect().await.expect("collect request").to_bytes();
+                                let json = serde_json::from_slice(&body).expect("decode request");
+                                requests_tx.send((path, json)).expect("send request");
+                                Ok::<_, std::convert::Infallible>(
+                                    Response::builder()
+                                        .status(StatusCode::NO_CONTENT)
+                                        .body(http_body_util::Full::new(hyper::body::Bytes::new()))
+                                        .expect("build response"),
+                                )
+                            }
+                        }),
+                    )
+                    .await
+                    .expect("serve request");
+            }
+        });
+
+        let instance = FirecrackerInstance::new(temp.path().to_path_buf());
+        instance.set_machine_config(512, 2, false, true).await?;
+        instance
+            .load_snapshot_file(
+                Path::new("vm_state.bin"),
+                Path::new("mem_backend"),
+                &[],
+                false,
+                true,
+            )
+            .await?;
+
+        let (fresh_path, fresh_body) = requests_rx.recv().await.expect("fresh request");
+        let (restore_path, restore_body) = requests_rx.recv().await.expect("restore request");
+        assert_eq!(fresh_path, "/machine-config");
+        assert_eq!(fresh_body["track_dirty_pages"], true);
+        assert_eq!(restore_path, "/snapshot/load");
+        assert_eq!(restore_body["track_dirty_pages"], true);
+
+        server.await.expect("request server");
         Ok(())
     }
 }

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -812,10 +812,11 @@ impl FirecrackerSandbox {
         memory_output: OverlaybdCompactOutput,
     ) -> Result<(PathBuf, u64)> {
         let mem_overlaybd_dir = snapshot_dir.join("mem_overlaybd");
-        if ConfigManager::global_config()
-            .memory_snapshot
-            .direct_overlaybd
-        {
+        let config = ConfigManager::global_config();
+        let use_direct_overlaybd =
+            config.memory_snapshot.direct_overlaybd || self.launch.common().track_dirty_pages;
+        // Persisted dirty sandboxes must keep cumulative direct capture after restart.
+        if use_direct_overlaybd {
             let firecracker_pid = self.fc_instance.pid()?;
             self.fc_instance
                 .create_state_only_snapshot(vm_state_path)
@@ -1581,7 +1582,13 @@ impl FirecrackerSandbox {
         // Override the network interface to use the new tap0 in our namespace
         let network_overrides = [("eth0", "tap0")];
         self.fc_instance
-            .load_snapshot_file(&vm_state_src, &mem_device_path, &network_overrides, false)
+            .load_snapshot_file(
+                &vm_state_src,
+                &mem_device_path,
+                &network_overrides,
+                false,
+                config.common.track_dirty_pages,
+            )
             .await?;
 
         let mmds_metadata = self.mmds_metadata(&config.common);
@@ -1679,7 +1686,12 @@ impl FirecrackerSandbox {
         self.configure_logger(&config.common).await?;
 
         self.fc_instance
-            .set_machine_config(config.mem_size_mib, config.vcpu_count, false, false)
+            .set_machine_config(
+                config.mem_size_mib,
+                config.vcpu_count,
+                false,
+                config.common.track_dirty_pages,
+            )
             .await?;
 
         if let Some(cpu_json) = config.common.cpu_config_json.as_deref() {


### PR DESCRIPTION
## What

Add an opt-in `memory_snapshot.track_dirty_pages` configuration that enables Firecracker dirty-page tracking for direct memory snapshot capture.

- Pass the option when creating a fresh VM and when restoring a VM from a snapshot.
- Persist the option in `FirecrackerCommonConfig` so the capture behavior follows the sandbox that was launched with it.
- Require `direct_overlaybd=true` when dirty-page tracking is enabled.
- Reject dirty-page tracking in PVM mode because this combination has not been tested.
- Document the new configuration field, environment variable, defaults, and PVM limitation.

## Why

The current mincore-based capture path selects resident pages, including pages that were only read. For workloads with a large read-only resident set, this can copy substantially more memory than the guest actually modified.

Firecracker dirty-page tracking selects pages written after tracking begins. This provides the opt-in behavior requested by #119 while preserving the current behavior by default. The dirty bitmap is cumulative across captures, so a later snapshot can restore pages written both before and after an earlier capture.

## Related issue

Closes #119

Related to #120, but this PR does not implement per-snapshot dirty epochs.

## Scope and non-goals

Included:

- New `memory_snapshot.track_dirty_pages` boolean, defaulting to `false`.
- `AGENTENV_MEMORY_SNAPSHOT_TRACK_DIRTY_PAGES` environment-variable support.
- Configuration validation for the supported KVM + direct-overlaybd combination.
- Firecracker request propagation for fresh VM creation and snapshot restore.
- Backward-compatible persistence through a serde-defaulted common-config field.
- Unit tests for configuration parsing, mapping, and Firecracker Unix-socket request bodies.
- Configuration and PVM documentation updates.

Non-goals / intentionally excluded:

- PVM support before that combination is tested.
- Dirty-page tracking through the legacy `mem.bin` capture path.
- Per-capture dirty bitmap clearing or the snapshot-epoch model discussed in #120.
- Changes to snapshot manifests, OverlayBD layer formats, or public APIs.
- A claim of universal snapshot-performance improvement.

## Design and behavior changes

`MemorySnapshotConfig::track_dirty_pages` is mapped into `FirecrackerCommonConfig` and persisted with the sandbox. Fresh VM setup and snapshot restore both forward the persisted value to their corresponding Firecracker requests.

The direct capture decision uses either the current global `direct_overlaybd` setting or the persisted dirty-tracking setting. This prevents a sandbox launched with dirty tracking from falling back to the legacy capture path after a server restart or configuration change.

Configuration validation fails early for unsupported combinations:

- `track_dirty_pages=true` with `direct_overlaybd=false` is rejected because the legacy path cannot provide the required cumulative dirty-page behavior.
- `track_dirty_pages=true` in PVM mode is rejected with an explicit untested-combination error.

Existing configurations continue to use mincore behavior because the new setting defaults to `false`.

## Compatibility and operations

- Public API or generated protocol: N/A; no public API or generated protocol changes.
- Configuration or defaults: Adds an optional boolean and environment variable. The default is `false`, so existing deployments retain current behavior. Enabling it requires KVM and `direct_overlaybd=true`.
- Snapshot manifest, artifact layout, or storage format: Unchanged. The persisted Firecracker common config gains a serde-defaulted field, so existing persisted sandbox configurations remain readable.
- Upgrade and rollback: Upgrades preserve existing behavior until the option is enabled. Snapshot artifacts keep the existing format; disable the option before rolling back if the older deployment should not receive the new configuration field.
- Host requirements, permissions, ports, or dependencies: No new host dependencies, permissions, or ports. The option is limited to KVM because PVM has not been validated.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [x] Benchmarks or performance comparison completed

Commands and results:

```text
make fmt
# passed

make clippy
# passed

cargo test -p agentenv --lib -- --nocapture
# 692 passed, 0 failed, 4 ignored

git diff --check
# passed
```

Focused Firecracker socket tests assert that dirty tracking is enabled in both the fresh `/machine-config` request and the restore `/snapshot/load` request.

A 512 MiB anonymous guest-memory probe verified:

```text
read checksum after restore: passed
write/verify after restore: passed
s1_restores_A=true
s2_restores_A_and_B=true
DAMON-wait checksum: passed
```

Selected-byte comparison (selection/correctness diagnostic, not an end-to-end speedup claim):

| Workload | mincore selected bytes | dirty selected bytes |
| --- | ---: | ---: |
| quiet | 51,740,672 | 4,382,720 |
| read-only | 605,220,864 | 13,094,912 |
| write | 227,663,872 | 175,906,816 |
| cumulative S1 | 141,078,528 | 89,845,760 |
| cumulative S2 | 237,756,416 | 176,066,560 |

The read-only probe selected 97.8% fewer bytes with dirty tracking. In full-page-write ABBA runs, both modes selected about 619 MB, as expected. Sequential snapshot medians were 515.236 ms (mincore) and 517.641 ms (dirty), which did not show a clear regression. Random-write results were underpowered after excluding runs with swap I/O, so this PR does not claim a general performance improvement.

Skipped checks and reasons:

- `make test-unit`: not run; the focused `agentenv` library suite above was run instead.
- Repository Rust integration-test command: not run; the KVM correctness scenarios above were executed with the temporary experiment harness, which is not part of this PR.
- `make -C services test`: no `services/` changes.
- Generated clients/server regeneration: no schema or generated-code changes.

## Risks and reviewer notes

- Dirty-page tracking is cumulative: S2 includes pages dirtied before S1 as well as pages dirtied afterward. Per-snapshot epochs remain outside this PR and are related to #120.
- Performance benefit depends on workload. Read-heavy resident memory benefits in selected bytes; a workload that dirties nearly every page does not.
- PVM is intentionally rejected until it receives equivalent correctness validation.
- The legacy `mem.bin` path is intentionally rejected when dirty tracking is enabled.
- Most important review points: configuration validation in `src/cfg.rs`, persisted setting and Firecracker request propagation in `src/sandbox/firecracker/{config,instance}.rs`, and capture-path selection in `src/sandbox/firecracker/sandbox.rs`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
