### PR TITLE
feat(release): build static Linux binaries and bundle OverlayBD tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,20 +43,14 @@ jobs:
                   )
           PY
 
-  build-aenv:
-    name: Build aenv (${{ matrix.asset_name }})
+  build-darwin-cli:
+    name: Build Darwin CLI (${{ matrix.asset_name }})
     needs: validate-version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
-            target: ''
-            asset_name: aenv-linux-x86_64
-          - os: ubuntu-24.04-arm
-            target: ''
-            asset_name: aenv-linux-aarch64
           - os: macos-15
             target: x86_64-apple-darwin
             asset_name: aenv-darwin-x86_64
@@ -66,15 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            clang libclang-dev libprotobuf-dev protobuf-compiler
-
       - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
         run: brew install protobuf
 
       - uses: dtolnay/rust-toolchain@stable
@@ -84,12 +70,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build aenv
-        run: cargo build --release -p aenv ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
+        run: cargo build --release --locked -p aenv --target ${{ matrix.target }}
 
       - name: Stage artifact
         run: |
           mkdir -p dist
-          BIN=${{ matrix.target && format('target/{0}/release/aenv', matrix.target) || 'target/release/aenv' }}
+          BIN=target/${{ matrix.target }}/release/aenv
           cp "$BIN" dist/${{ matrix.asset_name }}
           strip dist/${{ matrix.asset_name }} || true
 
@@ -98,8 +84,8 @@ jobs:
           name: ${{ matrix.asset_name }}
           path: dist/${{ matrix.asset_name }}
 
-  build-server:
-    name: Build server (linux-${{ matrix.arch }})
+  build-linux:
+    name: Build Linux release (${{ matrix.arch }})
     needs: validate-version
     runs-on: ${{ matrix.os }}
     strategy:
@@ -108,39 +94,191 @@ jobs:
         include:
           - os: ubuntu-24.04
             arch: x86_64
+            rust_target: x86_64-unknown-linux-musl
+            zig_target: x86_64-linux-musl
+            openssl_target: linux-x86_64
             modes: kvm pvm
           - os: ubuntu-24.04-arm
             arch: aarch64
+            rust_target: aarch64-unknown-linux-musl
+            zig_target: aarch64-linux-musl
+            openssl_target: linux-aarch64
             modes: kvm
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install system dependencies
+      - name: Install native build prerequisites
         run: |
+          set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            clang libclang-dev libprotobuf-dev protobuf-compiler
+            build-essential \
+            clang \
+            cmake \
+            curl \
+            libclang-dev \
+            libprotobuf-dev \
+            linux-libc-dev \
+            make \
+            ninja-build \
+            perl \
+            pkg-config \
+            protobuf-compiler \
+            xz-utils
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build server binaries
+      - name: Build static Linux binaries
+        env:
+          ZIG_VERSION: 0.15.2
+          OPENSSL_VERSION: 3.5.7
         run: |
-          cargo build --release -p agentenv --bin server
-          cargo build --release -p uvm-ublk-daemon
+          set -euo pipefail
+
+          work_dir="$(mktemp -d "$RUNNER_TEMP/agentenv-static-release.XXXXXXXX")"
+          trap 'rm -rf "$work_dir"' EXIT
+
+          zig_archive="zig-${{ matrix.arch }}-linux-$ZIG_VERSION.tar.xz"
+          zig_dir="$work_dir/zig-$ZIG_VERSION"
+          curl -fsSL --retry 5 \
+            "https://ziglang.org/download/$ZIG_VERSION/$zig_archive" \
+            -o "$work_dir/$zig_archive"
+          mkdir -p "$zig_dir"
+          tar -xJf "$work_dir/$zig_archive" -C "$zig_dir" --strip-components=1
+          zig="$zig_dir/zig"
+
+          toolchain_dir="$work_dir/toolchain"
+          mkdir -p "$toolchain_dir"
+
+          write_compiler_wrapper() {
+            local output=$1
+            local mode=$2
+            local compiler_template
+            compiler_template='#!/usr/bin/env bash
+          set -euo pipefail
+          args=()
+          skip_next=false
+          for arg in "$@"; do
+              if $skip_next; then
+                  skip_next=false
+                  continue
+              fi
+              case "$arg" in
+                  --target=*) continue ;;
+                  --target) skip_next=true; continue ;;
+                  *) args+=("$arg") ;;
+              esac
+          done
+          exec "ZIG_PATH" COMPILER_MODE -target ZIG_TARGET "${args[@]}"
+          '
+            printf '%s' "$compiler_template" > "$output"
+            sed -i \
+              "s|ZIG_PATH|$zig|g; s|COMPILER_MODE|$mode|g; s|ZIG_TARGET|${{ matrix.zig_target }}|g" \
+              "$output"
+            chmod +x "$output"
+          }
+
+          write_compiler_wrapper "$toolchain_dir/musl-cc" cc
+          write_compiler_wrapper "$toolchain_dir/musl-cxx" c++
+
+          for tool_name in ar ranlib; do
+            tool_wrapper="$toolchain_dir/musl-$tool_name"
+            printf '#!/bin/sh\nexec "%s" %s "$@"\n' "$zig" "$tool_name" > "$tool_wrapper"
+            chmod +x "$tool_wrapper"
+          done
+
+          linker_template='#!/usr/bin/env bash
+          set -euo pipefail
+          args=()
+          skip_next=false
+          for arg in "$@"; do
+              if $skip_next; then
+                  skip_next=false
+                  continue
+              fi
+              case "$arg" in
+                  --target=*) continue ;;
+                  --target) skip_next=true; continue ;;
+                  */self-contained/*crt*.o) continue ;;
+                  -lstdc++) args+=("-lc++") ;;
+                  *) args+=("$arg") ;;
+              esac
+          done
+          exec "ZIG_PATH" c++ -target ZIG_TARGET "${args[@]}"
+          '
+          printf '%s' "$linker_template" > "$toolchain_dir/musl-linker"
+          sed -i \
+            "s|ZIG_PATH|$zig|g; s|ZIG_TARGET|${{ matrix.zig_target }}|g" \
+            "$toolchain_dir/musl-linker"
+          chmod +x "$toolchain_dir/musl-linker"
+
+          target_env_key="${{ matrix.rust_target }}"
+          target_env_key="${target_env_key//-/_}"
+          target_key="${{ matrix.rust_target }}"
+          target_key="${target_key^^}"
+          target_key="${target_key//-/_}"
+          export "CC_${target_env_key}=$toolchain_dir/musl-cc"
+          export "CXX_${target_env_key}=$toolchain_dir/musl-cxx"
+          export "AR_${target_env_key}=$toolchain_dir/musl-ar"
+          export "CARGO_TARGET_${target_key}_LINKER=$toolchain_dir/musl-linker"
+
+          openssl_source_dir="$work_dir/openssl-$OPENSSL_VERSION"
+          openssl_install_dir="$work_dir/openssl-musl-${{ matrix.arch }}"
+          openssl_archive="$work_dir/openssl-$OPENSSL_VERSION.tar.gz"
+          curl -fsSL --retry 5 \
+            "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" \
+            -o "$openssl_archive"
+          tar -xzf "$openssl_archive" -C "$work_dir"
+
+          (
+            cd "$openssl_source_dir"
+            CC="$toolchain_dir/musl-cc" \
+              AR="$toolchain_dir/musl-ar" \
+              RANLIB="$toolchain_dir/musl-ranlib" \
+              ./Configure \
+              "${{ matrix.openssl_target }}" \
+              no-shared \
+              no-tests \
+              no-module \
+              --prefix="$openssl_install_dir" \
+              --libdir=lib
+            make -j"$(nproc)" build_libs
+            mkdir -p "$openssl_install_dir/include" "$openssl_install_dir/lib"
+            cp -a include/openssl "$openssl_install_dir/include/"
+            cp -a libcrypto.a libssl.a "$openssl_install_dir/lib/"
+          )
+
+          export OPENSSL_STATIC=1
+          export OPENSSL_DIR="$openssl_install_dir"
+          export OPENSSL_LIB_DIR="$openssl_install_dir/lib"
+          export OPENSSL_INCLUDE_DIR="$openssl_install_dir/include"
+
+          cargo build --release --locked --target "${{ matrix.rust_target }}" -p aenv
+          cargo build --release --locked --target "${{ matrix.rust_target }}" \
+            -p uvm-ublk-daemon --bin uvm-ublk-daemon
+          cargo build --release --locked --target "${{ matrix.rust_target }}" \
+            -p agentenv --bin server
+
+          mkdir -p dist
+          target_dir="target/${{ matrix.rust_target }}/release"
+          cp "$target_dir/aenv" "dist/aenv-linux-${{ matrix.arch }}"
 
       - name: Stage artifacts
         run: |
           set -euo pipefail
+          TARGET_DIR="target/${{ matrix.rust_target }}/release"
 
           for MODE in ${{ matrix.modes }}; do
             BUNDLE="dist/bundle-$MODE"
             mkdir -p "$BUNDLE/ublk"
-            cp target/release/server "$BUNDLE/server"
+            cp "$TARGET_DIR/server" "$BUNDLE/server"
             strip "$BUNDLE/server"
-            cp target/release/uvm-ublk-daemon "$BUNDLE/ublk/uvm-ublk-daemon"
+            cp "$TARGET_DIR/uvm-ublk-daemon" "$BUNDLE/ublk/uvm-ublk-daemon"
             strip "$BUNDLE/ublk/uvm-ublk-daemon"
             cp config/default.toml "$BUNDLE/default.toml"
 
@@ -184,11 +322,14 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: server-bundles-${{ matrix.arch }}
-          path: dist/aenv-server-linux-${{ matrix.arch }}*.tar.gz
+          path: |
+            dist/aenv-linux-${{ matrix.arch }}
+            dist/aenv-server-linux-${{ matrix.arch }}*.tar.gz
+          if-no-files-found: error
 
   release:
     name: Create GitHub Release
-    needs: [build-aenv, build-server]
+    needs: [build-darwin-cli, build-linux]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -361,6 +502,7 @@ jobs:
           file: deploy/docker/Dockerfile.agentenv
           platforms: linux/amd64
           push: true
+          cache-from: type=gha,scope=agentenv-runtime
           build-args: |
             AENV_VIRTUALIZATION_MODE=pvm
           tags: |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If your server does not support standard KVM, see the [PVM deployment guide](htt
 
 **1. Install and start the server**
 
-*Option A — install script (Ubuntu 24.04)*
+*Option A — install script (Ubuntu)*
 
 Install both the server and the `aenv` CLI, then start the server as a systemd service:
 

--- a/config/deps_manifest.toml
+++ b/config/deps_manifest.toml
@@ -19,12 +19,8 @@ version = "0.1.0"
 url = "ghcr.io/kvcache-ai/agentenv-tools:{version}"
 
 [overlaybd]
-version = "v1.0.18"
-# The official release asset filename embeds the release date and git hash.
-# When bumping `version`, update the full filename in `package_url` too.
-# Automatic overlaybd package download currently targets Ubuntu release
-# assets only; other distros must provide overlaybd with path overrides.
-package_url = "https://github.com/containerd/overlaybd/releases/download/{version}/overlaybd-1.0.18-20260710.cee2186.{target}.deb"
+version = "v1.0.18-aenv.1"
+package_url = "https://github.com/kvcache-ai/overlaybd/releases/download/static-{version}/overlaybd-tools-{version}-linux-{arch}.tar.gz"
 
 [regclient]
 version = "v0.11.5"
@@ -44,28 +40,17 @@ url = "https://github.com/protocolbuffers/protobuf/releases/download/v{version}/
 common = [
   "ca-certificates",
 ]
-ubuntu = [
-  "libaio1t64|libaio1",
-]
-debian = [
-  "libaio1t64|libaio1",
-]
-centos = [
-  "libaio",
-]
-rhel = [
-  "libaio",
-]
-arch = [
-  "libaio",
-]
+ubuntu = []
+debian = []
+centos = []
+rhel = []
+arch = []
 
 [packages.runtime_commands]
 # NOTE: same as [packages.runtime] above, this list is not read by the
 # Dockerfile; update `deploy/docker/Dockerfile.agentenv` manually to match.
 curl = { default = "curl" }
 "debugfs" = { default = "e2fsprogs" }
-"dpkg-deb" = { default = "dpkg" }
 "ip" = { default = "iproute2", centos = "iproute", rhel = "iproute" }
 "iptables-restore" = { default = "iptables" }
 "iptables-save" = { default = "iptables" }

--- a/deploy/docker/Dockerfile.agentenv
+++ b/deploy/docker/Dockerfile.agentenv
@@ -64,12 +64,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        dpkg \
         e2fsprogs \
         iproute2 \
         iptables \
         jq \
-        libaio1t64 \
         sudo \
         umoci \
         zstd \

--- a/docs/src/deployment/manual-compile.md
+++ b/docs/src/deployment/manual-compile.md
@@ -6,7 +6,7 @@ If you want to skip building from source, see [Quick Start](../getting-started/q
 
 ## Prerequisites
 
-- Ubuntu 24.04 with Linux kernel 6.8+
+- Ubuntu with Linux kernel 6.8+
 - `/dev/kvm` access for Firecracker microVM execution
 - Rust toolchain (stable) — install via [rustup](https://rustup.rs)
 - `sudo` access

--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Linux kernel 6.8+**; the install script additionally requires **Ubuntu 24.04**
+- **Linux kernel 6.8+**; the install script additionally requires **Ubuntu**
 - `/dev/kvm` access for Firecracker microVM execution
 
 > If your server does not support standard KVM, use the dedicated
@@ -20,7 +20,7 @@ uses a dedicated `aenv` system account with `CAP_NET_ADMIN` and
 
 ### 1. Install and start the server
 
-**Option A — Install Script (Ubuntu 24.04)**
+**Option A — Install Script (Ubuntu)**
 
 The script installs both the server and the `aenv` CLI. Set `AENV_HOME_PATH` to
 choose the data directory; if it is not set, AENV stores runtime dependencies

--- a/docs/src/internals/persistence-artifact-inventory.md
+++ b/docs/src/internals/persistence-artifact-inventory.md
@@ -31,11 +31,11 @@ Owned by `src/setup/*` and `src/cfg.rs`.
 | CPU template helper | `<deps_path>/firecracker/{version}/cpu-template-helper` | Optional Firecracker helper executable | Detects host CPU config for cluster-wide CPU intersection | Extracted from Firecracker package when present. |
 | Kernel image | `<deps_path>/kernel/{version}/vmlinux.bin` | Guest kernel | VM boot source | Downloaded during setup. Old versions are retained until manually removed. |
 | Tools drive | `<deps_path>/tools/{version}/tools.ext4` | Read-only ext4 image with envd/tools | Firecracker root drive shared by sandboxes and pinned by snapshots through its immutable release version | Extracted from OCI or imported from `tools.drive_path` during setup. Old versions are retained until manually removed. |
-| Overlaybd tools | `<deps_path>/overlaybd/bin/*`, `<deps_path>/overlaybd/lib/*` | `overlaybd-create`, `overlaybd-apply`, `overlaybd-commit`, `overlaybd-resize`, libraries | OCI-to-overlaybd conversion and packaging | Installed during setup when release metadata does not match. |
+| Overlaybd tools | `<deps_path>/overlaybd/bin/*` | Statically linked `overlaybd-create`, `overlaybd-apply`, `overlaybd-commit`, and `overlaybd-resize` | OCI-to-overlaybd conversion and packaging | Installed during setup when release metadata does not match. |
 | Overlaybd release metadata | `<deps_path>/overlaybd/tools-release.json` | Installed overlaybd release identifier | Detects whether tools need reinstalling | Rewritten on setup when release changes. |
-| Overlaybd package downloads | `<deps_path>/overlaybd/downloads/*` | Downloaded package archives | Setup cache for overlaybd release packages | Kept after install; no automatic GC. |
+| Overlaybd package downloads | `<deps_path>/overlaybd/downloads/*` | Temporary downloaded package archives | Setup staging for overlaybd release packages | Removed after a successful install. |
 | Generated overlaybd config | `$AENV_HOME/overlaybd/overlaybd-global.json`, `$AENV_HOME/overlaybd/mem-overlaybd-global.json` | Runtime global config, cache path, credentials config | Configures overlaybd runtime and memory snapshot overlaybd access | Rewritten during setup/startup. |
-| Overlaybd runtime log | `<deps_path>/overlaybd/overlaybd.log` | Overlaybd runtime logs | Debugging | Appended by overlaybd runtime; no automatic GC. |
+| Overlaybd runtime log | `$AENV_HOME/overlaybd/overlaybd.log` | Overlaybd runtime logs | Debugging | Appended by overlaybd runtime; no automatic GC. |
 
 ## Firecracker Sandbox
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1288,7 +1288,7 @@ mod tests {
         let config = AppConfig::default();
         assert_eq!(
             config.resolved_overlaybd_oci_converter_id(),
-            "overlaybd-oci:v1.0.18:agentenv-cache-v1"
+            "overlaybd-oci:v1.0.18-aenv.1:agentenv-cache-v1"
         );
         assert!(!config.ublk.overlaybd.allow_shrink);
         assert_eq!(config.ublk.overlaybd.resize_timeout_secs, 120);

--- a/src/setup/overlaybd.rs
+++ b/src/setup/overlaybd.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::process::Command;
 
 use anyhow::{bail, Context, Result};
 use nix::unistd::{chown, Gid};
@@ -9,13 +8,6 @@ use tracing::{debug, info};
 use crate::cfg::OverlaybdDependencyConfig;
 
 use super::deps::{copy_file, download_file, set_executable, set_file_mode};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct OverlaybdReleaseTarget {
-    os_id: String,
-    version_id: String,
-    arch: String,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct OverlaybdInstalledRelease {
@@ -30,16 +22,6 @@ const OVERLAYBD_TOOL_NAMES: &[&str] = &[
     "overlaybd-commit",
     "overlaybd-resize",
 ];
-// Ubuntu release asset published by overlaybd upstream, used as a portable
-// fallback for non-Ubuntu (e.g. RPM-family) hosts. See
-// `configured_overlaybd_release`. Ubuntu 22.04 is chosen specifically because
-// it's the oldest published asset linked against OpenSSL 3 (`libssl.so.3`):
-// older assets (18.04/20.04) require `libssl.so.1.1`, which modern
-// RPM-family distros (RHEL 9 / TencentOS 4, etc.) no longer ship, while the
-// newer 24.04 asset requires `libaio.so.1t64`, which most non-Ubuntu distros
-// don't package either.
-const FALLBACK_UBUNTU_VERSION: &str = "22.04";
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ConfiguredOverlaybdRelease {
     tag_name: String,
@@ -51,8 +33,7 @@ pub async fn ensure_release_tools(
     overlaybd_dir: &Path,
     arch: &str,
 ) -> Result<()> {
-    let target = detect_overlaybd_release_target(arch)?;
-    let configured_release = configured_overlaybd_release(overlaybd, &target)?;
+    let configured_release = configured_overlaybd_release(overlaybd, arch)?;
     let asset_name = configured_release
         .package_url
         .rsplit('/')
@@ -101,7 +82,7 @@ pub async fn ensure_release_tools(
         },
     )?;
 
-    // The downloaded .deb is only needed during extraction; remove it (and the
+    // The downloaded archive is only needed during extraction; remove it (and the
     // now-empty downloads dir) so it does not bloat container image layers built
     // via `--setup-only`.
     let _ = std::fs::remove_file(&package_path);
@@ -112,7 +93,7 @@ pub async fn ensure_release_tools(
 
 fn configured_overlaybd_release(
     overlaybd: &OverlaybdDependencyConfig,
-    target: &OverlaybdReleaseTarget,
+    arch: &str,
 ) -> Result<ConfiguredOverlaybdRelease> {
     let tag_name = overlaybd.version.trim();
     if tag_name.is_empty() {
@@ -129,56 +110,16 @@ fn configured_overlaybd_release(
         bail!("overlaybd.package_url not set in config");
     }
 
-    let target_fragment = match target.os_id.as_str() {
-        "ubuntu" => format!("ubuntu1.{}.{}", target.version_id, target.arch),
-        // Overlaybd upstream only publishes Ubuntu release assets. Each asset
-        // bundles its own shared libraries (see `install_overlaybd_release_tools`),
-        // so it runs fine on other glibc-based distros. Fall back to the
-        // oldest published Ubuntu build (lowest glibc requirement) for known
-        // RPM-family distros so the CLI tools install without a native asset.
-        "tencentos"
-        | "centos"
-        | "centos-stream"
-        | "rhel"
-        | "redhat"
-        | "redhatenterpriseserver"
-        | "openeuler"
-        | "openEuler" => {
-            format!("ubuntu1.{}.{}", FALLBACK_UBUNTU_VERSION, target.arch)
-        }
-        other => bail!(
-            "unsupported overlaybd release target: os={} version={} arch={}",
-            other,
-            target.version_id,
-            target.arch
-        ),
-    };
+    match arch {
+        "x86_64" | "aarch64" => {}
+        other => bail!("unsupported overlaybd release architecture: {other}"),
+    }
 
     Ok(ConfiguredOverlaybdRelease {
         tag_name: tag_name.to_string(),
         package_url: package_url_template
             .replace("{version}", tag_name)
-            .replace("{target}", &target_fragment),
-    })
-}
-
-fn detect_overlaybd_release_target(arch: &str) -> Result<OverlaybdReleaseTarget> {
-    let os_release = std::fs::read_to_string("/etc/os-release").context("read /etc/os-release")?;
-    let mut os_id = None;
-    let mut version_id = None;
-
-    for line in os_release.lines() {
-        if let Some(value) = line.strip_prefix("ID=") {
-            os_id = Some(value.trim_matches('"').to_string());
-        } else if let Some(value) = line.strip_prefix("VERSION_ID=") {
-            version_id = Some(value.trim_matches('"').to_string());
-        }
-    }
-
-    Ok(OverlaybdReleaseTarget {
-        os_id: os_id.context("missing ID in /etc/os-release")?,
-        version_id: version_id.context("missing VERSION_ID in /etc/os-release")?,
-        arch: arch.to_string(),
+            .replace("{arch}", arch),
     })
 }
 
@@ -216,42 +157,31 @@ fn extract_overlaybd_package(package_path: &Path, destination: &Path) -> Result<
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or_default();
-    if package_name.ends_with(".deb") {
-        which::which("dpkg-deb").context("dpkg-deb is required to extract overlaybd .deb")?;
-        let status = Command::new("dpkg-deb")
-            .arg("-x")
-            .arg(package_path)
-            .arg(destination)
-            .status()
-            .context("run dpkg-deb to extract overlaybd package")?;
-        if !status.success() {
-            bail!("dpkg-deb failed to extract {}", package_path.display());
-        }
+    if package_name.ends_with(".tar.gz") {
+        let file = std::fs::File::open(package_path)
+            .with_context(|| format!("open overlaybd package {}", package_path.display()))?;
+        let decoder = flate2::read::GzDecoder::new(file);
+        let mut archive = tar::Archive::new(decoder);
+        archive
+            .unpack(destination)
+            .with_context(|| format!("extract overlaybd package {}", package_path.display()))?;
         return Ok(());
     }
 
     bail!(
-        "unsupported overlaybd package format for {} (only .deb is supported currently)",
+        "unsupported overlaybd package format for {} (expected .tar.gz)",
         package_path.display()
     );
 }
 
 fn install_overlaybd_release_tools(extracted_root: &Path, overlaybd_dir: &Path) -> Result<()> {
-    let source_bin_dir = extracted_root.join("opt/overlaybd/bin");
-    let source_lib_dir = extracted_root.join("opt/overlaybd/lib");
+    let source_bin_dir = extracted_root.join("bin");
     if !source_bin_dir.is_dir() {
         bail!(
             "overlaybd release payload missing bin dir at {}",
             source_bin_dir.display()
         );
     }
-    if !source_lib_dir.is_dir() {
-        bail!(
-            "overlaybd release payload missing lib dir at {}",
-            source_lib_dir.display()
-        );
-    }
-
     std::fs::create_dir_all(overlaybd_dir)
         .with_context(|| format!("create overlaybd dir '{}'", overlaybd_dir.display()))?;
     let staging = tempfile::Builder::new()
@@ -259,9 +189,7 @@ fn install_overlaybd_release_tools(extracted_root: &Path, overlaybd_dir: &Path) 
         .tempdir_in(overlaybd_dir)
         .context("create overlaybd release staging dir")?;
     let staged_bin = staging.path().join("bin");
-    let staged_lib = staging.path().join("lib");
     copy_dir_recursive(&source_bin_dir, &staged_bin)?;
-    copy_dir_recursive(&source_lib_dir, &staged_lib)?;
 
     for tool in OVERLAYBD_TOOL_NAMES {
         let staged = staged_bin.join(tool);
@@ -274,157 +202,36 @@ fn install_overlaybd_release_tools(extracted_root: &Path, overlaybd_dir: &Path) 
         set_executable(&staged)?;
     }
 
-    replace_overlaybd_release_dirs(overlaybd_dir, &staged_bin, &staged_lib)
+    replace_overlaybd_release_bin(overlaybd_dir, &staged_bin)?;
+    remove_legacy_overlaybd_lib(overlaybd_dir)
 }
 
-fn replace_overlaybd_release_dirs(
-    overlaybd_dir: &Path,
-    staged_bin: &Path,
-    staged_lib: &Path,
-) -> Result<()> {
+fn replace_overlaybd_release_bin(overlaybd_dir: &Path, staged_bin: &Path) -> Result<()> {
     let backup = tempfile::Builder::new()
         .prefix("release-backup-")
         .tempdir_in(overlaybd_dir)
         .context("create overlaybd release backup dir")?;
     let target_bin = overlaybd_dir.join("bin");
-    let target_lib = overlaybd_dir.join("lib");
     let backup_bin = backup.path().join("bin");
-    let backup_lib = backup.path().join("lib");
 
     let had_bin = target_bin.exists();
-    let had_lib = target_lib.exists();
-    let mut backed_up_bin = false;
-    let mut backed_up_lib = false;
     if had_bin {
         std::fs::rename(&target_bin, &backup_bin).context("backup installed overlaybd bin dir")?;
-        backed_up_bin = true;
-    }
-    if had_lib {
-        if let Err(err) = std::fs::rename(&target_lib, &backup_lib) {
-            let rollback = restore_release_backup(
-                &target_bin,
-                &target_lib,
-                &backup_bin,
-                &backup_lib,
-                backed_up_bin,
-                backed_up_lib,
-            );
-            return Err(swap_failure(
-                anyhow::Error::new(err).context("backup installed overlaybd lib dir"),
-                rollback,
-                backup,
-            ));
-        }
-        backed_up_lib = true;
     }
 
     if let Err(err) = std::fs::rename(staged_bin, &target_bin) {
-        let rollback = restore_release_backup(
-            &target_bin,
-            &target_lib,
-            &backup_bin,
-            &backup_lib,
-            backed_up_bin,
-            backed_up_lib,
-        );
+        let rollback = if had_bin {
+            std::fs::rename(&backup_bin, &target_bin).context("restore previous overlaybd bin dir")
+        } else {
+            Ok(())
+        };
         return Err(swap_failure(
             anyhow::Error::new(err).context("install staged overlaybd bin dir"),
             rollback,
             backup,
         ));
     }
-    if let Err(err) = std::fs::rename(staged_lib, &target_lib) {
-        let mut rollback_errors = Vec::new();
-        record_rename_error(
-            &target_bin,
-            staged_bin,
-            "move newly installed overlaybd bin back to staging",
-            &mut rollback_errors,
-        );
-        restore_release_backup_into(
-            &target_bin,
-            &target_lib,
-            &backup_bin,
-            &backup_lib,
-            backed_up_bin,
-            backed_up_lib,
-            &mut rollback_errors,
-        );
-        let rollback = rollback_result(rollback_errors);
-        return Err(swap_failure(
-            anyhow::Error::new(err).context("install staged overlaybd lib dir"),
-            rollback,
-            backup,
-        ));
-    }
-
     Ok(())
-}
-
-fn restore_release_backup(
-    target_bin: &Path,
-    target_lib: &Path,
-    backup_bin: &Path,
-    backup_lib: &Path,
-    backed_up_bin: bool,
-    backed_up_lib: bool,
-) -> Result<()> {
-    let mut errors = Vec::new();
-    restore_release_backup_into(
-        target_bin,
-        target_lib,
-        backup_bin,
-        backup_lib,
-        backed_up_bin,
-        backed_up_lib,
-        &mut errors,
-    );
-    rollback_result(errors)
-}
-
-fn restore_release_backup_into(
-    target_bin: &Path,
-    target_lib: &Path,
-    backup_bin: &Path,
-    backup_lib: &Path,
-    backed_up_bin: bool,
-    backed_up_lib: bool,
-    errors: &mut Vec<String>,
-) {
-    if backed_up_bin {
-        record_rename_error(
-            backup_bin,
-            target_bin,
-            "restore previous overlaybd bin dir",
-            errors,
-        );
-    }
-    if backed_up_lib {
-        record_rename_error(
-            backup_lib,
-            target_lib,
-            "restore previous overlaybd lib dir",
-            errors,
-        );
-    }
-}
-
-fn record_rename_error(source: &Path, target: &Path, action: &str, errors: &mut Vec<String>) {
-    if let Err(err) = std::fs::rename(source, target) {
-        errors.push(format!(
-            "{action} '{}' -> '{}': {err}",
-            source.display(),
-            target.display()
-        ));
-    }
-}
-
-fn rollback_result(errors: Vec<String>) -> Result<()> {
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        bail!(errors.join("; "))
-    }
 }
 
 fn swap_failure(
@@ -442,6 +249,25 @@ fn swap_failure(
             ))
         }
     }
+}
+
+fn remove_legacy_overlaybd_lib(overlaybd_dir: &Path) -> Result<()> {
+    let legacy_lib = overlaybd_dir.join("lib");
+    let metadata = match std::fs::symlink_metadata(&legacy_lib) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect legacy overlaybd lib {}", legacy_lib.display()))
+        }
+    };
+
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        std::fs::remove_dir_all(&legacy_lib)
+    } else {
+        std::fs::remove_file(&legacy_lib)
+    }
+    .with_context(|| format!("remove legacy overlaybd lib {}", legacy_lib.display()))
 }
 
 fn stage_overlaybd_default_config(extracted_root: &Path, overlaybd_dir: &Path) -> Result<()> {
@@ -541,95 +367,96 @@ fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{configured_overlaybd_release, install_default_config, OverlaybdReleaseTarget};
+    use super::{
+        configured_overlaybd_release, extract_overlaybd_package, install_default_config,
+        install_overlaybd_release_tools, OVERLAYBD_TOOL_NAMES,
+    };
     use crate::cfg::OverlaybdDependencyConfig;
     use nix::unistd::Gid;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     #[test]
-    fn configured_overlaybd_release_expands_ubuntu_target_url() {
+    fn configured_overlaybd_release_expands_arch_url() {
         let config = OverlaybdDependencyConfig {
-            version: "v1.0.18".to_string(),
+            version: "v1.0.18-aenv.1".to_string(),
             url: None,
             package_url: Some(
-                "https://example.invalid/{version}/overlaybd-foo.{target}.deb".to_string(),
+                "https://example.invalid/static-{version}/overlaybd-tools-{version}-linux-{arch}.tar.gz"
+                    .to_string(),
             ),
         };
 
-        let release = configured_overlaybd_release(
-            &config,
-            &OverlaybdReleaseTarget {
-                os_id: "ubuntu".to_string(),
-                version_id: "24.04".to_string(),
-                arch: "x86_64".to_string(),
-            },
-        )
-        .expect("configured overlaybd release");
+        let release =
+            configured_overlaybd_release(&config, "aarch64").expect("configured overlaybd release");
 
-        assert_eq!(release.tag_name, "v1.0.18");
+        assert_eq!(release.tag_name, "v1.0.18-aenv.1");
         assert_eq!(
             release.package_url,
-            "https://example.invalid/v1.0.18/overlaybd-foo.ubuntu1.24.04.x86_64.deb"
+            "https://example.invalid/static-v1.0.18-aenv.1/overlaybd-tools-v1.0.18-aenv.1-linux-aarch64.tar.gz"
         );
     }
 
     #[test]
-    fn configured_overlaybd_release_falls_back_to_ubuntu_for_rpm_family_target() {
+    fn configured_overlaybd_release_rejects_unsupported_architecture() {
         let config = OverlaybdDependencyConfig {
-            version: "v1.0.16".to_string(),
+            version: "v1.0.18-aenv.1".to_string(),
             url: None,
-            package_url: Some(
-                "https://example.invalid/{version}/overlaybd-foo.{target}.deb".to_string(),
-            ),
+            package_url: Some("https://example.invalid/{arch}.tar.gz".to_string()),
         };
 
-        for os_id in [
-            "centos",
-            "centos-stream",
-            "tencentos",
-            "rhel",
-            "openeuler",
-            "openEuler",
-        ] {
-            let release = configured_overlaybd_release(
-                &config,
-                &OverlaybdReleaseTarget {
-                    os_id: os_id.to_string(),
-                    version_id: "4.4".to_string(),
-                    arch: "x86_64".to_string(),
-                },
-            )
-            .unwrap_or_else(|_| panic!("configured overlaybd release for {os_id}"));
-
-            assert_eq!(
-                release.package_url,
-                "https://example.invalid/v1.0.16/overlaybd-foo.ubuntu1.22.04.x86_64.deb"
-            );
-        }
+        let err = configured_overlaybd_release(&config, "riscv64")
+            .expect_err("unsupported architecture should fail");
+        assert!(err
+            .to_string()
+            .contains("unsupported overlaybd release architecture"));
     }
 
     #[test]
-    fn configured_overlaybd_release_rejects_unsupported_target() {
-        let config = OverlaybdDependencyConfig {
-            version: "v1.0.18".to_string(),
-            url: None,
-            package_url: Some(
-                "https://example.invalid/{version}/overlaybd-foo.{target}".to_string(),
-            ),
-        };
+    fn extracts_static_overlaybd_tarball_layout() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        std::fs::create_dir_all(source.join("bin")).expect("create source bin");
+        std::fs::write(source.join("bin/overlaybd-create"), b"tool").expect("write tool");
+        let package = temp.path().join("overlaybd-tools.tar.gz");
+        let file = std::fs::File::create(&package).expect("create package");
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        archive.append_dir_all(".", &source).expect("build package");
+        archive
+            .into_inner()
+            .expect("finish tar")
+            .finish()
+            .expect("finish gzip");
 
-        let err = configured_overlaybd_release(
-            &config,
-            &OverlaybdReleaseTarget {
-                os_id: "debian".to_string(),
-                version_id: "12".to_string(),
-                arch: "x86_64".to_string(),
-            },
-        )
-        .expect_err("unsupported target should fail");
-        assert!(err
-            .to_string()
-            .contains("unsupported overlaybd release target"));
+        extract_overlaybd_package(&package, &destination).expect("extract package");
+        assert_eq!(
+            std::fs::read(destination.join("bin/overlaybd-create")).expect("read tool"),
+            b"tool"
+        );
+    }
+
+    #[test]
+    fn installs_static_tools_without_lib_and_removes_legacy_lib() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let extracted = temp.path().join("extracted");
+        let overlaybd_dir = temp.path().join("installed");
+        std::fs::create_dir_all(extracted.join("bin")).expect("create extracted bin");
+        for tool in OVERLAYBD_TOOL_NAMES {
+            std::fs::write(extracted.join("bin").join(tool), b"static tool")
+                .expect("write static tool");
+        }
+        std::fs::create_dir_all(overlaybd_dir.join("lib")).expect("create legacy lib");
+        std::fs::write(overlaybd_dir.join("lib/liblegacy.so"), b"legacy")
+            .expect("write legacy library");
+
+        install_overlaybd_release_tools(&extracted, &overlaybd_dir)
+            .expect("install static overlaybd tools");
+
+        assert!(!overlaybd_dir.join("lib").exists());
+        for tool in OVERLAYBD_TOOL_NAMES {
+            assert!(overlaybd_dir.join("bin").join(tool).is_file());
+        }
     }
 
     #[test]

--- a/storage/overlaybd/src/tools/README.md
+++ b/storage/overlaybd/src/tools/README.md
@@ -5,14 +5,14 @@ layer conversion.
 
 The actual `overlaybd-create`, `overlaybd-apply`, and `overlaybd-commit`
 binaries are **not** committed to this repository. AgentENV setup downloads the
-configured pinned `containerd/overlaybd` release package at startup and
-extracts the tools into:
+configured pinned static OverlayBD release archive at startup and extracts the
+tools into:
 
 - `<deps_path>/overlaybd/bin`
-- `<deps_path>/overlaybd/lib`
 
-The pinned release tag and asset page URL live in `config/default.toml` under
-`[overlaybd]`.
+The pinned release tag and asset URL live in `config/deps_manifest.toml` under
+`[overlaybd]`. The tools are statically linked and do not require an
+OverlayBD-specific shared-library directory or `LD_LIBRARY_PATH`.
 
 Because AgentENV currently uses the original upstream `overlaybd-apply`
 behavior, setup also installs the packaged default config to:

--- a/storage/overlaybd/src/tools/oci.rs
+++ b/storage/overlaybd/src/tools/oci.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -14,7 +13,6 @@ pub struct OverlaybdTools {
     create_bin: PathBuf,
     apply_bin: PathBuf,
     commit_bin: PathBuf,
-    lib_dir: Option<PathBuf>,
 }
 
 pub(crate) struct CreateLayerRequest {
@@ -92,23 +90,12 @@ impl OverlaybdTools {
             create_bin: bin_dir.join("overlaybd-create"),
             apply_bin: bin_dir.join("overlaybd-apply"),
             commit_bin: bin_dir.join("overlaybd-commit"),
-            lib_dir: None,
         }
     }
 
     pub fn from_overlaybd_install_root(root: impl Into<PathBuf>) -> Self {
         let root = root.into();
-        Self {
-            create_bin: root.join("bin/overlaybd-create"),
-            apply_bin: root.join("bin/overlaybd-apply"),
-            commit_bin: root.join("bin/overlaybd-commit"),
-            lib_dir: Some(root.join("lib")),
-        }
-    }
-
-    pub fn with_lib_dir(mut self, lib_dir: impl Into<PathBuf>) -> Self {
-        self.lib_dir = Some(lib_dir.into());
-        self
+        Self::from_bin_dir(root.join("bin"))
     }
 
     pub(crate) async fn create_writable_layer(
@@ -354,16 +341,6 @@ impl OverlaybdTools {
     fn base_command(&self, bin: &Path, work_dir: &Path) -> Command {
         let mut cmd = Command::new(bin);
         cmd.current_dir(work_dir);
-        if let Some(lib_dir) = &self.lib_dir {
-            let mut value = OsString::from(lib_dir);
-            if let Some(existing) = std::env::var_os("LD_LIBRARY_PATH") {
-                if !existing.is_empty() {
-                    value.push(":");
-                    value.push(existing);
-                }
-            }
-            cmd.env("LD_LIBRARY_PATH", value);
-        }
         cmd
     }
 
@@ -618,14 +595,12 @@ mod tests {
     }
 
     #[test]
-    fn convert_runs_fake_tool_chain_in_order_and_sets_ld_library_path() {
+    fn convert_runs_fake_tool_chain_in_order() {
         let tmp = tempdir().unwrap();
         let work_dir = tmp.path().join("work");
         let bin_dir = tmp.path().join("bin");
-        let lib_dir = tmp.path().join("lib");
         let log_path = tmp.path().join("tool.log");
         fs::create_dir_all(&bin_dir).unwrap();
-        fs::create_dir_all(&lib_dir).unwrap();
 
         for tool in ["overlaybd-create", "overlaybd-apply", "overlaybd-commit"] {
             write_script(
@@ -641,7 +616,7 @@ mod tests {
         let input_layer_path = tmp.path().join("layer.tar");
         fs::write(&input_layer_path, b"not-zstd-layer").unwrap();
 
-        let tools = OverlaybdTools::from_bin_dir(&bin_dir).with_lib_dir(&lib_dir);
+        let tools = OverlaybdTools::from_bin_dir(&bin_dir);
         let req = ConvertLayerRequest {
             work_dir: work_dir.clone(),
             input_layer_path,
@@ -690,7 +665,6 @@ mod tests {
         assert!(log.contains("overlaybd-commit"));
         assert!(log.contains("--uuid 11111111-2222-3333-4444-555555555555"));
         assert!(log.contains("--parent-uuid aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
-        assert!(log.contains(&format!("LD_LIBRARY_PATH={}", lib_dir.display())));
         assert!(log.contains(&format!(
             "--service_config_path={}",
             req.global_config_path.display()
@@ -818,7 +792,7 @@ mod tests {
     }
 
     #[test]
-    fn from_overlaybd_install_root_uses_bin_and_lib_subdirs() {
+    fn from_overlaybd_install_root_uses_static_bin_subdir() {
         let tmp = tempdir().unwrap();
         let overlaybd_root = tmp.path().join("overlaybd");
         let tools = OverlaybdTools::from_overlaybd_install_root(&overlaybd_root);
@@ -832,7 +806,6 @@ mod tests {
             tools.commit_bin,
             overlaybd_root.join("bin/overlaybd-commit")
         );
-        assert_eq!(tools.lib_dir, Some(overlaybd_root.join("lib")));
     }
 
     fn write_script(path: &Path, contents: &str) {

--- a/storage/ublk-daemon/src/main.rs
+++ b/storage/ublk-daemon/src/main.rs
@@ -191,7 +191,7 @@ fn load_resize_tool_config(
     );
     Ok(Some(ResizeToolSpec {
         binary: deps_path.join("overlaybd/bin/overlaybd-resize"),
-        lib_dir: Some(deps_path.join("overlaybd/lib")),
+        lib_dir: None,
         timeout_secs: resize_timeout_secs,
     }))
 }

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -1634,7 +1634,10 @@ fn clear_page_cache(device_path: &Path) {
 
     // BLKFLSBUF ioctl number: flush buffer cache
     // Linux asm-generic/ioctl.h encodes _IO(0x12, 97) as (0x12 << 8) | 97.
-    const BLKFLSBUF: libc::c_ulong = 0x1261;
+    // libc models ioctl's request argument differently across Linux libc
+    // implementations (c_ulong on glibc, c_int on musl). Keep the request
+    // value libc-agnostic and infer the ABI-specific type at the call site.
+    const BLKFLSBUF: u32 = 0x1261;
 
     let file = match OpenOptions::new()
         .read(true)
@@ -1649,7 +1652,7 @@ fn clear_page_cache(device_path: &Path) {
     };
 
     let fd = file.as_raw_fd();
-    let ret = unsafe { libc::ioctl(fd, BLKFLSBUF) };
+    let ret = unsafe { libc::ioctl(fd, BLKFLSBUF as _) };
     if ret < 0 {
         let err = std::io::Error::last_os_error();
         tracing::warn!(?err, path = %device_path.display(), "failed to clear page cache");


### PR DESCRIPTION
## What

Add static Linux release builds and use static OverlayBD tools.

## Why

The previous Linux release depended on libraries from Ubuntu 24.04. This change makes the release binaries more portable across ubuntu versions.

## Related issue

N/A.

## Scope and non-goals

Included:

- Support static Linux releases.
- Use the static OverlayBD release package.

Non-goals:

- Support for additional package managers has not been added, so installation is not yet fully compatible with all Linux distributions.

## Design and behavior changes

- Update the OverlayBD download and extraction flow to use the static tarball.
- Update the release workflow to build static Linux binaries.

## Compatibility and operations

- Public API or generated protocol: No changes.
- Configuration or defaults: The OverlayBD version and package URL have changed.
- Snapshot manifest, artifact layout, or storage format: No changes.
- Upgrade and rollback: The OverlayBD tools are updated to static binaries. The legacy OverlayBD `lib` directory is removed during upgrade.
- Host requirements, permissions, ports, or dependencies: No changes.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test`
- [x] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

## Skipped checks and reasons:
- make -C services test: skipped because this PR does not modify services/.
- Benchmarks or performance comparison: skipped because this PR does not change performance-sensitive behavior.

## Risks and reviewer notes

- OverlayBD tools no longer include or use a lib directory because the tools are statically linked.
- Existing legacy OverlayBD libraries are removed during upgrade.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
