### PR TITLE
fix(cli): parse Dockerfiles with parse-dockerfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "futures",
  "indicatif",
  "openssl-sys",
+ "parse-dockerfile",
  "prost",
  "reqwest 0.13.3",
  "rpassword",
@@ -5420,6 +5421,15 @@ dependencies = [
  "regex-syntax",
  "structmeta",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "parse-dockerfile"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf36e89d16b0fcc540dfe420c99d692c703c436f1ea605195bc0a95651d69e"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/aenv/Cargo.toml
+++ b/crates/aenv/Cargo.toml
@@ -22,6 +22,7 @@ envd = { path = "../../thirdparty/envd" }
 futures = "0.3"
 indicatif = "0.17"
 openssl-sys = { version = "0.9", optional = true }
+parse-dockerfile = { version = "0.1.8", default-features = false }
 prost = "0.14"
 reqwest = { version = "0.13", default-features = false, features = ["multipart", "rustls", "stream"] }
 rpassword = "7"

--- a/crates/aenv/src/commands/build.rs
+++ b/crates/aenv/src/commands/build.rs
@@ -6,15 +6,15 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use parse_dockerfile::{Command, HereDoc, Instruction, RunInstruction};
 use shell_util::shell_quote;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(ClapArgs)]
 pub struct Args {
     /// Path to the Dockerfile used to build the template
     dockerfile: PathBuf,
-    /// Template name, optionally with `:tag`
-    #[arg(short = 't', long = "tag")]
-    name: Option<String>,
+    /// Template name
+    #[arg(long)]
+    name: String,
     #[command(flatten)]
     resources: super::CpuMemoryArgs,
     /// Override the Dockerfile FROM image used as the template rootfs base. Shortnames like `ubuntu:22.04` are supported.
@@ -26,12 +26,11 @@ pub fn run(args: Args) -> Result<()> {
     let client = Client::from_env()?;
     let dockerfile = std::fs::read_to_string(&args.dockerfile)
         .with_context(|| format!("reading {}", args.dockerfile.display()))?;
-    let alias = parse_alias(args.name.as_deref(), &args.dockerfile);
     let user_image = args.user_image.or_else(|| first_from_image(&dockerfile));
     let build_plan = dockerfile_build_plan(&dockerfile)?;
 
     let req = CreateTemplateV3 {
-        name: alias.to_string(),
+        name: args.name,
         tags: Vec::new(),
         cpu_count: args.resources.cpu_count,
         memory_mb: args.resources.memory_mb,
@@ -54,17 +53,6 @@ pub fn run(args: Args) -> Result<()> {
     println!("Build started.");
     println!("Watch with: aenv template watch {}", resp.template_id);
     Ok(())
-}
-
-pub(crate) fn parse_alias(flag: Option<&str>, dockerfile: &Path) -> String {
-    flag.map(|s| s.to_string()).unwrap_or_else(|| {
-        dockerfile
-            .parent()
-            .and_then(|p| p.file_name())
-            .and_then(|s| s.to_str())
-            .unwrap_or("template")
-            .to_string()
-    })
 }
 
 pub(crate) fn first_from_image(dockerfile: &str) -> Option<String> {
@@ -285,6 +273,23 @@ fn key_value_args(instruction: &str, args: &str) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::{dockerfile_build_plan, first_from_image};
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: super::Args,
+    }
+
+    #[test]
+    fn build_requires_name_flag() {
+        let cli = TestCli::try_parse_from(["test", "Dockerfile", "--name", "my-template"])
+            .expect("--name should be accepted");
+        assert_eq!(cli.args.name, "my-template");
+
+        assert!(TestCli::try_parse_from(["test", "Dockerfile"]).is_err());
+        assert!(TestCli::try_parse_from(["test", "Dockerfile", "--tag", "old"]).is_err());
+    }
 
     #[test]
     fn first_from_image_reads_basic_from() {

--- a/crates/aenv/src/commands/build.rs
+++ b/crates/aenv/src/commands/build.rs
@@ -4,6 +4,7 @@ use crate::client::{
 };
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
+use parse_dockerfile::{Command, HereDoc, Instruction, RunInstruction};
 use shell_util::shell_quote;
 use std::path::{Path, PathBuf};
 
@@ -67,21 +68,14 @@ pub(crate) fn parse_alias(flag: Option<&str>, dockerfile: &Path) -> String {
 }
 
 pub(crate) fn first_from_image(dockerfile: &str) -> Option<String> {
-    dockerfile.lines().find_map(|raw| {
-        let line = raw.trim();
-        if line.is_empty() || line.starts_with('#') {
+    let parsed = parse_dockerfile::parse(dockerfile).ok()?;
+    parsed.instructions.iter().find_map(|instruction| {
+        let Instruction::From(from) = instruction else {
             return None;
-        }
-        let mut parts = line.split_whitespace();
-        let instruction = parts.next()?;
-        if !instruction.eq_ignore_ascii_case("FROM") {
-            return None;
-        }
-        parts
-            .find(|part| !part.starts_with("--"))
-            .filter(|image| !image.is_empty())
-            .filter(|image| *image != "scratch" && !image.starts_with('$'))
-            .map(str::to_string)
+        };
+        let image = from.image.value.as_ref();
+        (!image.is_empty() && image != "scratch" && !image.starts_with('$'))
+            .then(|| image.to_string())
     })
 }
 
@@ -92,40 +86,77 @@ struct DockerfileBuildPlan {
 }
 
 fn dockerfile_build_plan(dockerfile: &str) -> Result<DockerfileBuildPlan> {
+    let parsed = parse_dockerfile::parse(dockerfile).context("parsing Dockerfile")?;
+    let escape = parsed
+        .parser_directives
+        .escape
+        .as_ref()
+        .map_or('\\', |directive| directive.value.value);
     let mut steps = Vec::new();
     let mut entrypoint = None;
     let mut cmd = None;
 
-    for (instruction, args) in dockerfile.lines().filter_map(dockerfile_instruction) {
-        let step = match instruction.to_ascii_uppercase().as_str() {
-            "FROM" => None,
-            "RUN" | "WORKDIR" | "USER" => Some(TemplateStep {
-                r#type: instruction.to_ascii_uppercase(),
-                args: vec![args.to_string()],
+    for instruction in &parsed.instructions {
+        let step = match instruction {
+            Instruction::From(_) => None,
+            Instruction::Run(run) => Some(TemplateStep {
+                r#type: "RUN".to_string(),
+                args: vec![dockerfile_run_command(run, escape)?],
             }),
-            "ENV" | "ARG" => Some(TemplateStep {
-                r#type: instruction.to_ascii_uppercase(),
-                args: key_value_args(instruction, args)?,
+            Instruction::Workdir(workdir) => Some(TemplateStep {
+                r#type: "WORKDIR".to_string(),
+                args: vec![workdir.arguments.value.to_string()],
             }),
-            "ENTRYPOINT" => {
-                entrypoint = dockerfile_command(args);
+            Instruction::User(user) => Some(TemplateStep {
+                r#type: "USER".to_string(),
+                args: vec![user.arguments.value.to_string()],
+            }),
+            Instruction::Env(env) => Some(TemplateStep {
+                r#type: "ENV".to_string(),
+                args: key_value_args("ENV", &env.arguments.value)?,
+            }),
+            Instruction::Arg(arg) => Some(TemplateStep {
+                r#type: "ARG".to_string(),
+                args: key_value_args("ARG", &arg.arguments.value)?,
+            }),
+            Instruction::Entrypoint(instruction) => {
+                entrypoint = dockerfile_command(&instruction.arguments);
                 None
             }
-            "CMD" => {
-                cmd = dockerfile_command(args);
+            Instruction::Cmd(instruction) => {
+                cmd = dockerfile_command(&instruction.arguments);
                 None
             }
-            "SHELL" | "STOPSIGNAL" => None,
-            "EXPOSE" | "VOLUME" | "LABEL" => {
-                eprintln!(
-                    "warning: {instruction} instruction is not supported and will be ignored"
-                );
+            Instruction::Shell(_) | Instruction::Stopsignal(_) => None,
+            Instruction::Expose(_) => {
+                warn_ignored_instruction("EXPOSE");
                 None
             }
-            "COPY" | "ADD" => {
-                bail!("{instruction} instructions are not supported by AENV template builds yet")
+            Instruction::Volume(_) => {
+                warn_ignored_instruction("VOLUME");
+                None
             }
-            _ => bail!("Dockerfile instruction {instruction} is not supported"),
+            Instruction::Label(_) => {
+                warn_ignored_instruction("LABEL");
+                None
+            }
+            Instruction::Maintainer(_) => {
+                warn_ignored_instruction("MAINTAINER");
+                None
+            }
+            Instruction::Copy(_) => {
+                bail!("COPY instructions are not supported by AENV template builds yet")
+            }
+            Instruction::Add(_) => {
+                bail!("ADD instructions are not supported by AENV template builds yet")
+            }
+            Instruction::Healthcheck(_) => {
+                bail!("Dockerfile instruction HEALTHCHECK is not supported")
+            }
+            Instruction::Onbuild(_) => {
+                bail!("Dockerfile instruction ONBUILD is not supported")
+            }
+            _ => bail!("Dockerfile instruction is not supported"),
         };
         if let Some(step) = step {
             steps.push(step);
@@ -138,38 +169,88 @@ fn dockerfile_build_plan(dockerfile: &str) -> Result<DockerfileBuildPlan> {
     })
 }
 
-fn dockerfile_command(args: &str) -> Option<String> {
-    let args = args.trim();
-    if args.is_empty() {
-        return None;
-    }
-    if args.starts_with('[') {
-        if let Ok(parts) = serde_json::from_str::<Vec<String>>(args) {
-            if parts.is_empty() {
-                return None;
-            }
-            return Some(
-                parts
-                    .iter()
-                    .map(|s| shell_quote(s))
-                    .collect::<Vec<_>>()
-                    .join(" "),
-            );
+fn dockerfile_run_command(run: &RunInstruction<'_>, escape: char) -> Result<String> {
+    match (&run.arguments, run.here_docs.as_slice()) {
+        (Command::Exec(_), []) => dockerfile_command(&run.arguments)
+            .context("RUN instruction requires a non-empty command"),
+        (Command::Shell(command), []) => Ok(normalize_run_continuations(command.value, escape)),
+        (Command::Shell(command), [here_doc]) if command.value.trim().is_empty() => {
+            Ok(here_doc.value.to_string())
         }
+        (Command::Shell(command), [here_doc]) => {
+            Ok(render_run_heredoc(command.value.trim(), here_doc))
+        }
+        (_, here_docs) if here_docs.len() > 1 => {
+            bail!("multiple RUN heredocs are not supported")
+        }
+        _ => bail!("RUN heredocs are only supported for shell-form commands"),
     }
-    Some(args.to_string())
 }
 
-fn dockerfile_instruction(line: &str) -> Option<(&str, &str)> {
-    let line = line.trim();
-    if line.is_empty() || line.starts_with('#') {
-        return None;
+fn render_run_heredoc(command: &str, here_doc: &HereDoc<'_>) -> String {
+    let delimiter = unique_heredoc_delimiter(&here_doc.value);
+    let opening_delimiter = if here_doc.expand {
+        delimiter.clone()
+    } else {
+        format!("'{delimiter}'")
+    };
+    let body_newline = if here_doc.value.is_empty() || here_doc.value.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+
+    format!(
+        "<<{opening_delimiter} {command}\n{}{body_newline}{delimiter}",
+        here_doc.value
+    )
+}
+
+fn unique_heredoc_delimiter(body: &str) -> String {
+    const BASE: &str = "AENV_HEREDOC";
+
+    (0..)
+        .map(|suffix| {
+            if suffix == 0 {
+                BASE.to_string()
+            } else {
+                format!("{BASE}_{suffix}")
+            }
+        })
+        .find(|delimiter| body.lines().all(|line| line != delimiter))
+        .expect("the unbounded delimiter sequence must contain an unused value")
+}
+
+fn normalize_run_continuations(command: &str, escape: char) -> String {
+    if escape == '\\' {
+        return command.to_string();
     }
-    let (instruction, args) = line
-        .split_once(char::is_whitespace)
-        .map(|(instruction, args)| (instruction, args.trim()))
-        .unwrap_or((line, ""));
-    Some((instruction, args))
+
+    command
+        .replace(&format!("{escape}\r\n"), "\\\r\n")
+        .replace(&format!("{escape}\n"), "\\\n")
+}
+
+fn dockerfile_command(command: &Command<'_>) -> Option<String> {
+    match command {
+        Command::Exec(parts) => (!parts.value.is_empty()).then(|| {
+            parts
+                .value
+                .iter()
+                .map(|part| shell_quote(&part.value))
+                .collect::<Vec<_>>()
+                .join(" ")
+        }),
+        Command::Shell(command) => {
+            let command = command.value.trim();
+            (!command.is_empty()).then(|| command.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn warn_ignored_instruction(instruction: &str) {
+    eprintln!("warning: {instruction} instruction is not supported and will be ignored");
 }
 
 fn key_value_args(instruction: &str, args: &str) -> Result<Vec<String>> {
@@ -259,6 +340,101 @@ ARG NODE_ENV=production
     }
 
     #[test]
+    fn dockerfile_build_plan_parses_multiline_run() {
+        let plan = dockerfile_build_plan(
+            r#"FROM ubuntu:24.04
+RUN apt-get update && \
+    apt-get install -y curl
+WORKDIR /app
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 2);
+        assert_eq!(plan.steps[0].r#type, "RUN");
+        assert_eq!(
+            plan.steps[0].args,
+            ["apt-get update && \\\n    apt-get install -y curl"]
+        );
+        assert_eq!(plan.steps[1].r#type, "WORKDIR");
+    }
+
+    #[test]
+    fn dockerfile_build_plan_honors_escape_directive_for_multiline_run() {
+        let plan = dockerfile_build_plan(
+            r#"# escape=`
+FROM ubuntu:24.04
+RUN echo first && `
+    echo second
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].r#type, "RUN");
+        assert_eq!(
+            plan.steps[0].args[0],
+            r#"echo first && \
+    echo second"#
+        );
+    }
+
+    #[test]
+    fn dockerfile_build_plan_parses_bare_run_heredoc_as_script() {
+        let plan = dockerfile_build_plan(
+            r#"FROM ubuntu:24.04
+RUN <<EOF
+set -eu
+echo hello
+EOF
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].r#type, "RUN");
+        assert_eq!(plan.steps[0].args, ["set -eu\necho hello\n"]);
+    }
+
+    #[test]
+    fn dockerfile_build_plan_preserves_run_heredoc_command() {
+        let plan = dockerfile_build_plan(
+            r#"FROM ubuntu:24.04
+RUN <<EOF bash
+set -eu
+echo hello
+EOF
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].r#type, "RUN");
+        assert_eq!(
+            plan.steps[0].args,
+            ["<<AENV_HEREDOC bash\nset -eu\necho hello\nAENV_HEREDOC"]
+        );
+    }
+
+    #[test]
+    fn dockerfile_build_plan_renders_safe_quoted_heredoc_delimiter() {
+        let plan = dockerfile_build_plan(
+            r#"FROM ubuntu:24.04
+RUN <<'EOF' cat
+AENV_HEREDOC
+EOF
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(
+            plan.steps[0].args,
+            ["<<'AENV_HEREDOC_1' cat\nAENV_HEREDOC\nAENV_HEREDOC_1"]
+        );
+    }
+
+    #[test]
     fn dockerfile_build_plan_uses_entrypoint_as_start_cmd() {
         let plan = dockerfile_build_plan(
             r#"
@@ -341,6 +517,21 @@ RUN echo hi
 "#,
         )
         .unwrap();
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].r#type, "RUN");
+    }
+
+    #[test]
+    fn dockerfile_build_plan_skips_maintainer() {
+        let plan = dockerfile_build_plan(
+            r#"
+FROM ubuntu:24.04
+MAINTAINER AgentENV
+RUN echo hi
+"#,
+        )
+        .unwrap();
+
         assert_eq!(plan.steps.len(), 1);
         assert_eq!(plan.steps[0].r#type, "RUN");
     }

--- a/docs/src/concepts/templates.md
+++ b/docs/src/concepts/templates.md
@@ -42,12 +42,12 @@ aenv pull ubuntu:24.04
 Build a template by running Dockerfile instructions inside a temporary sandbox:
 
 ```bash
-aenv build ./Dockerfile
+aenv build ./Dockerfile --name my-template
 ```
 
 | Flag | Description |
 |------|-------------|
-| `-t`, `--tag <name>` | Template name. Defaults to the parent directory name of the Dockerfile |
+| `--name <name>` | Required template name |
 | `--image <ref>` | Override the `FROM` image |
 
 Supported Dockerfile instructions:
@@ -81,12 +81,12 @@ corresponding Dockerfile instructions executed during the build. The following f
 
 ### Aliases
 
-Each template is identified by a UUID. Pass `--name` or `-t` at creation time
-to assign a human-readable alias:
+Each template is identified by a UUID. Pass `--name` at creation time to assign
+a human-readable alias:
 
 ```bash
 aenv pull ubuntu:24.04 --name my-base
-aenv build ./Dockerfile -t my-service
+aenv build ./Dockerfile --name my-service
 ```
 
 The alias can be used wherever a template ID is accepted:

--- a/docs/src/getting-started/aenv-cli.md
+++ b/docs/src/getting-started/aenv-cli.md
@@ -52,19 +52,18 @@ aenv pull ubuntu:22.04 --name my-ubuntu
 | `-d, --detach` | Submit the build and return immediately without waiting |
 | `--timeout <SECS>` | Maximum seconds to wait for the build to complete |
 
-### `aenv build <dockerfile>`
+### `aenv build <dockerfile> --name <name>`
 
 Create a template from a local Dockerfile.
 
 ```bash
-aenv build ./Dockerfile
-aenv build ./Dockerfile -t my-app
-aenv build ./Dockerfile --image ghcr.io/myorg/base:latest
+aenv build ./Dockerfile --name my-app
+aenv build ./Dockerfile --name my-app --image ghcr.io/myorg/base:latest
 ```
 
 | Flag | Description |
 |------|-------------|
-| `-t, --tag <name>` | Template name. Defaults to the parent directory name |
+| `--name <name>` | Required template name |
 | `--image <image>` | Override the `FROM` image used as the rootfs base |
 
 ### `aenv template list`


### PR DESCRIPTION
## Summary

- replace the line-based aenv Dockerfile parser with parse-dockerfile
- support multiline RUN instructions and custom escape directives
- lower shell, exec-form, bare heredoc, and explicit-command heredoc RUN instructions
- ignore legacy MAINTAINER metadata while preserving existing unsupported-instruction behavior
- add focused regression coverage for parser directives, multiline commands, and heredocs

## Testing

- `cargo test -p aenv`
- `cargo clippy -p aenv -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`