### PR TITLE
fix(network): support iptables-legacy with CAP_NET_RAW

### DIFF
--- a/.github/actions/sandbox-ci-setup/action.yml
+++ b/.github/actions/sandbox-ci-setup/action.yml
@@ -141,8 +141,8 @@ runs:
         [[ -d /sys/module/ublk_drv ]]
         output="$(scripts/run-with-capabilities.sh sh -c 'id -u; sed -n "s/^CapEff:[[:space:]]*//p" /proc/self/status')"
         [[ "$(sed -n '1p' <<< "$output")" != "0" ]]
-        # CAP_NET_ADMIN (bit 12) | CAP_SYS_ADMIN (bit 21) = 0x201000.
-        [[ "$(sed -n '2p' <<< "$output")" == "0000000000201000" ]]
+        # CAP_NET_ADMIN (bit 12) | CAP_NET_RAW (bit 13) | CAP_SYS_ADMIN (bit 21) = 0x203000.
+        [[ "$(sed -n '2p' <<< "$output")" == "0000000000203000" ]]
         scripts/run-with-capabilities.sh sh -c '
           test -s /etc/overlaybd/overlaybd.json
           test -r /etc/overlaybd/overlaybd.json

--- a/crates/linux-cap/src/lib.rs
+++ b/crates/linux-cap/src/lib.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io;
 
 pub const CAP_NET_ADMIN: i32 = 12;
+pub const CAP_NET_RAW: i32 = 13;
 pub const CAP_SYS_ADMIN: i32 = 21;
 
 const PR_CAP_AMBIENT: libc::c_int = 47;

--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -13,7 +13,7 @@ provisions `/dev/kvm` permissions, loads the `ublk_drv` kernel module, and
 downloads the required AgentENV runtime assets.
 
 Installation requires root, but the installed service does not run as root. It
-uses a dedicated `aenv` system account with `CAP_NET_ADMIN` and
+uses a dedicated `aenv` system account with `CAP_NET_ADMIN`, `CAP_NET_RAW`, and
 `CAP_SYS_ADMIN`, plus group access to `/dev/kvm` and the ublk devices.
 
 ## Setup

--- a/docs/src/troubleshooting/common-issues.md
+++ b/docs/src/troubleshooting/common-issues.md
@@ -39,7 +39,7 @@ AENV_VIRTUALIZATION_MODE=pvm
 
 **Symptom**: Sandbox creation fails with network namespace or iptables errors.
 
-**Solution**: The server requires both `CAP_NET_ADMIN` and `CAP_SYS_ADMIN` in
+**Solution**: The server requires `CAP_NET_ADMIN`, `CAP_NET_RAW`, and `CAP_SYS_ADMIN` in
 its effective, permitted, and inheritable sets. The installed systemd unit
 configures these automatically. For a source checkout, use `make start-server`
 or `scripts/run-with-capabilities.sh <server-binary>`; do not run the whole

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -338,8 +338,8 @@ EnvironmentFile=${ENV_FILE}
 ExecStart=${INSTALL_DIR}/server
 RuntimeDirectory=aenv
 RuntimeDirectoryMode=0750
-AmbientCapabilities=CAP_NET_ADMIN CAP_SYS_ADMIN
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_SYS_ADMIN
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_ADMIN
 NoNewPrivileges=true
 UMask=0027
 LimitNOFILE=1048576
@@ -393,8 +393,8 @@ if [[ -d /run/systemd/system ]]; then
 else
     echo "systemd not detected. Start the server manually:"
     echo "  sudo setpriv --reuid=${SERVICE_USER} --regid=${SERVICE_GROUP} --init-groups \\"
-    echo "    --inh-caps=+net_admin,+sys_admin --ambient-caps=+net_admin,+sys_admin \\"
-    echo "    --bounding-set=-all,+net_admin,+sys_admin --nnp \\"
+    echo "    --inh-caps=+net_admin,+net_raw,+sys_admin --ambient-caps=+net_admin,+net_raw,+sys_admin \\"
+    echo "    --bounding-set=-all,+net_admin,+net_raw,+sys_admin --nnp \\"
     echo "    env AENV_CONFIG_PATH=${CONFIG_PATH} AENV_HOME_PATH=${DATA_DIR} AENV_RUNTIME_PATH=${RUNTIME_DIR} \\"
     echo "    AENV_VIRTUALIZATION_MODE=${VIRTUALIZATION_MODE} \\"
     echo "    API_ADDR=127.0.0.1:8000 ${INSTALL_DIR}/server"

--- a/scripts/run-with-capabilities.sh
+++ b/scripts/run-with-capabilities.sh
@@ -79,14 +79,14 @@ if ! ulimit -l "$memlock_limit"; then
 fi
 
 capability_args=(
-    "--inh-caps=-all,+net_admin,+sys_admin"
-    "--ambient-caps=-all,+net_admin,+sys_admin"
-    "--bounding-set=-all,+net_admin,+sys_admin"
+    "--inh-caps=-all,+net_admin,+net_raw,+sys_admin"
+    "--ambient-caps=-all,+net_admin,+net_raw,+sys_admin"
+    "--bounding-set=-all,+net_admin,+net_raw,+sys_admin"
     --nnp
 )
 
 if [[ "$run_uid" == "0" ]]; then
-    echo "warning: ${root_warning}; running as UID 0 with only CAP_NET_ADMIN and CAP_SYS_ADMIN" >&2
+    echo "warning: ${root_warning}; running as UID 0 with only CAP_NET_ADMIN, CAP_NET_RAW, and CAP_SYS_ADMIN" >&2
     exec setpriv \
         --securebits=+noroot,+noroot_locked \
         "${capability_args[@]}" \

--- a/scripts/tests/verify-capability-runner.sh
+++ b/scripts/tests/verify-capability-runner.sh
@@ -43,7 +43,7 @@ output="$(
 mapfile -t lines <<< "$output"
 [[ "${lines[0]}" == "0" ]]
 for index in 1 2 3 4 5; do
-    [[ "${lines[$index]}" == "0000000000201000" ]]
+    [[ "${lines[$index]}" == "0000000000203000" ]]
 done
 [[ "${lines[6]}" == "1" ]]
 [[ "${lines[7]}" == "0000000000000000" ]]

--- a/scripts/tests/verify-install-service.sh
+++ b/scripts/tests/verify-install-service.sh
@@ -29,8 +29,8 @@ for directive in \
   'Group=aenv' \
   'SupplementaryGroups=kvm' \
   'RuntimeDirectory=aenv' \
-  'AmbientCapabilities=CAP_NET_ADMIN CAP_SYS_ADMIN' \
-  'CapabilityBoundingSet=CAP_NET_ADMIN CAP_SYS_ADMIN' \
+  'AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_ADMIN' \
+  'CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_ADMIN' \
   'NoNewPrivileges=true'; do
   grep -Fqx "$directive" "$unit_file"
 done

--- a/src/privileges.rs
+++ b/src/privileges.rs
@@ -5,11 +5,12 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Result};
 use tracing::warn;
 
-pub use linux_cap::{CAP_NET_ADMIN, CAP_SYS_ADMIN};
+pub use linux_cap::{CAP_NET_ADMIN, CAP_NET_RAW, CAP_SYS_ADMIN};
 
 fn capability_name(capability: i32) -> &'static str {
     match capability {
         CAP_NET_ADMIN => "CAP_NET_ADMIN",
+        CAP_NET_RAW => "CAP_NET_RAW",
         CAP_SYS_ADMIN => "CAP_SYS_ADMIN",
         _ => "unknown capability",
     }
@@ -23,7 +24,7 @@ fn capability_name(capability: i32) -> &'static str {
 pub fn require_runtime_capabilities() -> Result<()> {
     let sets = linux_cap::CapabilitySets::current().context("read process capability sets")?;
     let is_root = nix::unistd::Uid::effective().is_root();
-    let missing = [CAP_NET_ADMIN, CAP_SYS_ADMIN]
+    let missing = [CAP_NET_ADMIN, CAP_NET_RAW, CAP_SYS_ADMIN]
         .into_iter()
         .filter(|capability| {
             if is_root {
@@ -37,7 +38,7 @@ pub fn require_runtime_capabilities() -> Result<()> {
 
     if !missing.is_empty() {
         bail!(
-            "AENV runtime is missing required Linux capabilities: {}. Start it with CAP_NET_ADMIN and CAP_SYS_ADMIN in the inheritable, permitted, and effective sets (the installed systemd unit configures this automatically)",
+            "AENV runtime is missing required Linux capabilities: {}. Start it with CAP_NET_ADMIN, CAP_NET_RAW, and CAP_SYS_ADMIN in the inheritable, permitted, and effective sets (the installed systemd unit configures this automatically)",
             missing.join(", ")
         );
     }
@@ -183,18 +184,20 @@ mod tests {
     #[test]
     fn parses_capability_sets() {
         let status =
-            "CapInh:\t0000000000201000\nCapPrm:\t0000000000201000\nCapEff:\t0000000000201000\n";
+            "CapInh:\t0000000000203000\nCapPrm:\t0000000000203000\nCapEff:\t0000000000203000\n";
         let sets = linux_cap::CapabilitySets::from_proc_status(status).unwrap();
         assert!(sets.is_delegable(CAP_NET_ADMIN).unwrap());
+        assert!(sets.is_delegable(CAP_NET_RAW).unwrap());
         assert!(sets.is_delegable(CAP_SYS_ADMIN).unwrap());
     }
 
     #[test]
     fn capability_must_be_present_in_all_required_sets() {
         let status =
-            "CapInh:\t0000000000201000\nCapPrm:\t0000000000201000\nCapEff:\t0000000000001000\n";
+            "CapInh:\t0000000000203000\nCapPrm:\t0000000000203000\nCapEff:\t0000000000001000\n";
         let sets = linux_cap::CapabilitySets::from_proc_status(status).unwrap();
         assert!(sets.is_delegable(CAP_NET_ADMIN).unwrap());
+        assert!(!sets.is_delegable(CAP_NET_RAW).unwrap());
         assert!(!sets.is_delegable(CAP_SYS_ADMIN).unwrap());
     }
 

--- a/src/sandbox/network/iptables_util.rs
+++ b/src/sandbox/network/iptables_util.rs
@@ -105,7 +105,11 @@ fn build_restore_script(commands: &[IptablesRestoreCommand]) -> String {
 }
 
 fn apply_restore_script(script: &str) -> Result<()> {
-    crate::privileges::run_with_scoped_capabilities(&[crate::privileges::CAP_NET_ADMIN], || {
+    let capabilities = [
+        crate::privileges::CAP_NET_ADMIN,
+        crate::privileges::CAP_NET_RAW,
+    ];
+    crate::privileges::run_with_scoped_capabilities(&capabilities, || {
         let mut child = Command::new("iptables-restore")
             .arg("--noflush")
             .stdin(Stdio::piped())

--- a/src/sandbox/network/manager.rs
+++ b/src/sandbox/network/manager.rs
@@ -486,7 +486,10 @@ impl NetworkManager {
             "iptables-save",
             "iptables-save",
             &[],
-            &[crate::privileges::CAP_NET_ADMIN],
+            &[
+                crate::privileges::CAP_NET_ADMIN,
+                crate::privileges::CAP_NET_RAW,
+            ],
             &firewall_conflict_patterns,
             "detected iptables rules referencing AgentENV interfaces or network ranges; sandbox traffic may be redirected, filtered, or rewritten by another program",
         );
@@ -719,8 +722,9 @@ mod tests {
     }
 
     fn has_network_runtime_capabilities() -> bool {
-        let required =
-            (1u64 << crate::privileges::CAP_NET_ADMIN) | (1u64 << crate::privileges::CAP_SYS_ADMIN);
+        let required = (1u64 << crate::privileges::CAP_NET_ADMIN)
+            | (1u64 << crate::privileges::CAP_NET_RAW)
+            | (1u64 << crate::privileges::CAP_SYS_ADMIN);
         std::fs::read_to_string("/proc/self/status")
             .ok()
             .and_then(|status| {
@@ -1237,7 +1241,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires CAP_NET_ADMIN/CAP_SYS_ADMIN and intentionally crashes a child process"]
+    #[ignore = "requires CAP_NET_ADMIN/CAP_NET_RAW/CAP_SYS_ADMIN and intentionally crashes a child process"]
     fn panic_exit_with_pooled_slot_is_cleaned_by_exit_hook() {
         const CHILD_ENV: &str = "AENV_NETWORK_PANIC_CHILD";
         const TEST_NAME: &str =

--- a/src/sandbox/network/slot.rs
+++ b/src/sandbox/network/slot.rs
@@ -1061,7 +1061,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires CAP_NET_ADMIN/CAP_SYS_ADMIN and affects system configuration"]
+    #[ignore = "requires CAP_NET_ADMIN/CAP_NET_RAW/CAP_SYS_ADMIN and affects system configuration"]
     fn test_network_lifecycle() {
         crate::logging::init_for_tests();
 
@@ -1070,7 +1070,7 @@ mod tests {
         let slot = unused_test_slot();
 
         // 1. Create Network
-        // This requires CAP_NET_ADMIN and CAP_SYS_ADMIN.
+        // This requires CAP_NET_ADMIN, CAP_NET_RAW, and CAP_SYS_ADMIN.
         match slot.create_network() {
             Ok(_) => {}
             Err(e) => {


### PR DESCRIPTION
### Summary

iptables-legacy needs CAP_NET_RAW in addition to CAP_NET_ADMIN. Pass it through the runtime and scoped helpers so sandbox networking works on hosts using the legacy backend.