### PR TITLE
docs: add production scale metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ AgentENV (AENV) is a platform for running agent environments at scale, powering 
 
 ## 🚀 Why AgentENV
 
-- **Scale across diverse environments**: AENV runs massive numbers of Firecracker environments across machines and diverse OCI-compatible images, loaded on demand via [overlaybd](https://containerd.github.io/overlaybd/#/). Local disk acts as a bounded cache, retaining hot data and evicting cold, so images can exceed disk capacity while startup stays fast cluster-wide, without pre-warming every host.
+- **Scale across diverse environments**: AENV runs massive numbers of Firecracker environments across machines, loading diverse OCI-compatible images on demand via [overlaybd](https://containerd.github.io/overlaybd/#/) and scaling to [1.5 million images in production](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf). Local disk acts as a bounded cache, retaining hot data and evicting cold, so the aggregate image and snapshot footprint can exceed local disk capacity by several orders of magnitude while startup stays fast cluster-wide, without pre-warming every host.
 - **Make idle environments inexpensive**: Snapshot-backed environments boot or resume in under 50 ms and pause in under 100 ms. Idle environments can quickly release CPU and memory, then return when new work arrives.
 - **Native snapshot and fork support**: AENV snapshots memory and filesystem changes incrementally, completing in under 100 ms even under heavy disk modification. A running environment can fork into multiple independent sandboxes for parallel agent workflows. Snapshots persist to S3-compatible object storage or a shared distributed filesystem to prevent data loss.
-- **Preserve performance and density over time**: AENV delivers high-performance I/O via ublk while sharing the host page cache across storage and memory-snapshot data. Memory ballooning returns reclaimable guest memory to the host, sustaining high overcommit as environments run longer and diverge.
+- **Preserve performance and density over time**: AENV delivers high-performance I/O via ublk while sharing the host page cache across storage and memory-snapshot data. Memory ballooning returns reclaimable guest memory to the host, achieving a 9.6x memory overcommit ratio in production as environments run longer and diverge.
 
 ---
 
@@ -58,8 +58,6 @@ Install both the server and the `aenv` CLI, then start the server as a systemd s
 curl -fsSL https://raw.githubusercontent.com/kvcache-ai/AgentENV/main/scripts/install.sh | sudo bash
 sudo systemctl start aenv
 ```
-
-If this installation fails because standard KVM is unavailable, follow the [PVM deployment guide](https://kvcache-ai.github.io/AgentENV/dev/deployment/pvm.html) instead.
 
 *Option B — Docker*
 


### PR DESCRIPTION
## What

- Document production scale of 1.5 million images and link the Kimi K3 technical report.
- Add the 9.6x production memory overcommit ratio.
- Clarify that aggregate image and snapshot data can exceed local disk capacity by several orders of magnitude.
- Remove the duplicate PVM deployment-guide reference.

## Why

The README currently describes scalability and memory density qualitatively. Adding production figures makes those capabilities concrete and gives readers a clearer picture of AgentENV at scale.

## Related issue

N/A

## Scope and non-goals

This PR changes README wording only. It does not change runtime behavior, configuration, APIs, or generated code.

## Design and behavior changes

N/A; documentation only.

## Compatibility and operations

- Public API or generated protocol: N/A
- Configuration or defaults: N/A
- Snapshot manifest, artifact layout, or storage format: N/A
- Upgrade and rollback: N/A
- Host requirements, permissions, ports, or dependencies: N/A

## Validation

- [ ] make fmt
- [ ] make clippy
- [ ] make test-unit
- [ ] Relevant Rust integration tests
- [ ] make -C services test
- [ ] Generated clients/server regenerated
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

    git diff --check
    Result: passed

Skipped checks and reasons:

Builds and tests were skipped because this PR changes README text only.

## Risks and reviewer notes

Low risk. Reviewers should confirm the production metrics and wording.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.