### PR TITLE
chore(release): bump version to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aenv"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "agentenv"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agentenv-observability",
  "agentenv_http_server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
## What

- Bump the shared workspace package version from 0.1.1 to 0.1.2.
- Refresh the agentenv and aenv entries in Cargo.lock.

## Why

Prepare the workspace for the v0.1.2 release. The release workflow validates both package versions against the pushed tag before building and publishing artifacts.

## Scope and non-goals

This PR changes release metadata only. It does not change runtime behavior, APIs, configuration, or dependencies.

## Design and behavior changes

N/A; version metadata only.

## Compatibility and operations

- Public API or generated protocol: N/A
- Configuration or defaults: N/A
- Snapshot manifest, artifact layout, or storage format: N/A
- Upgrade and rollback: N/A
- Host requirements, permissions, ports, or dependencies: N/A

After merge, pushing v0.1.2 will trigger the release workflow that builds artifacts, publishes images, generates release notes, and creates the GitHub release.

## Risks and reviewer notes

Low risk. Confirm this PR is merged before creating the v0.1.2 tag; tagging an earlier commit would fail release version validation.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.