### PR TITLE
fix: sanitize singleton CPU config intersections

### DIFF
--- a/services/scheduler/internal/cpu_template.go
+++ b/services/scheduler/internal/cpu_template.go
@@ -41,14 +41,10 @@ type cpuidLeafKey struct {
 // IntersectCpuConfigs computes a conservative bitwise AND intersection of
 // Firecracker cpu_config_json strings. Only entries present in every input
 // config are retained; bitmap fields for shared entries are ANDed together.
-// Returns an empty string when jsons is empty; returns jsons[0] unchanged
-// when only one config is provided.
+// Returns an empty string when jsons is empty.
 func IntersectCpuConfigs(jsons []string) (string, error) {
 	if len(jsons) == 0 {
 		return "", nil
-	}
-	if len(jsons) == 1 {
-		return jsons[0], nil
 	}
 
 	configs := make([]cpuConfig, len(jsons))

--- a/services/scheduler/internal/cpu_template_test.go
+++ b/services/scheduler/internal/cpu_template_test.go
@@ -52,13 +52,15 @@ func TestIntersectCpuConfigs_Empty(t *testing.T) {
 }
 
 func TestIntersectCpuConfigs_Single(t *testing.T) {
-	input := buildConfig(nil, nil, nil)
+	safe := cpuidModifier{Leaf: "0x1", Subleaf: "0x0", Modifiers: []registerMod{{Register: "eax", Bitmap: bm32(1)}}}
+	input := buildConfig(nil, []cpuidModifier{safe, {Leaf: "0xb", Subleaf: "0x1", Modifiers: []registerMod{{Register: "eax", Bitmap: bm32(2)}}}}, nil)
+	want := buildConfig(nil, []cpuidModifier{safe}, nil)
 	out, err := IntersectCpuConfigs([]string{input})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if out != input {
-		t.Errorf("single config: want %q, got %q", input, out)
+	if out != want {
+		t.Errorf("single config: want %q, got %q", want, out)
 	}
 }
 


### PR DESCRIPTION
## What

Fix the single-node startup failure when using the scheduler.

## Why

In a single-node setup with the scheduler enabled, CPU config intersection took the fast path and returned the config unchanged. This preserved CPUID leaf `0xB`, subleaf `0x1`, which caused Firecracker startup to fail.

## Related issue

Closes #137

## Scope and non-goals

Included:

- Update the scheduler CPU config intersection logic.

Non-goals:

- Changes to node logic.

## Design and behavior changes

Single-node CPU configs no longer take the fast path. They now use the same filtering and validation logic as multi-node configs.

## Compatibility and operations

- Public API or generated protocol: No changes.
- Configuration or defaults: No changes.
- Snapshot manifest, artifact layout, or storage format: No changes.
- Upgrade and rollback: No changes.
- Host requirements, permissions, ports, or dependencies: No changes.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [x] `make -C services test` (required when `services/` changes)
- [x] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

Skipped checks and reasons:

Documentation updates and performance benchmarks were skipped because this change does not affect documentation or performance.

## Risks and reviewer notes

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.