### PR TITLE
test: remove redundant tests and merge similar tests

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1287,106 +1287,54 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn memory_snapshot_config_defaults_are_valid() -> Result<()> {
-        let default = MemorySnapshotConfig::default();
-        assert!(!default.compression_enabled);
-        assert!(!default.track_dirty_pages);
-        assert_eq!(
-            default.compression_algorithm,
-            MemorySnapshotCompressionAlgorithm::Lz4
-        );
-        assert_eq!(default.compression_workers, 1);
+    fn bundled_default_config_loads() -> Result<()> {
         let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let config = ConfigManager::new_from_path(&workspace.join("config/default.toml"))?;
-        assert!(!config.config().memory_snapshot.compression_enabled);
-        assert!(!config.config().memory_snapshot.track_dirty_pages);
-        assert_eq!(
-            config.config().memory_snapshot.compression_algorithm,
-            MemorySnapshotCompressionAlgorithm::Lz4,
-        );
-        assert_eq!(config.config().memory_snapshot.compression_workers, 1);
+        ConfigManager::new_from_path(&workspace.join("config/default.toml"))?;
         Ok(())
     }
 
     #[test]
-    fn memory_snapshot_track_dirty_pages_validates_supported_combinations() -> Result<()> {
-        let temp = tempdir()?;
-        let path = temp.path().join("config.toml");
-        std::fs::write(
-            &path,
-            "virtualization_mode = \"kvm\"\n[memory_snapshot]\ntrack_dirty_pages = true\ndirect_overlaybd = true\n",
-        )?;
-        let config = ConfigManager::new_from_path(&path)?;
-        assert!(config.config().memory_snapshot.track_dirty_pages);
-        assert!(config.config().memory_snapshot.direct_overlaybd);
-        assert_eq!(config.config().virtualization_mode, VirtualizationMode::Kvm);
-        std::fs::write(
-            &path,
-            "virtualization_mode = \"kvm\"\n[memory_snapshot]\ntrack_dirty_pages = true\ndirect_overlaybd = false\n",
-        )?;
-        let error = ConfigManager::new_from_path(&path).unwrap_err();
-        assert!(
-            error.to_string().contains(
-                "memory_snapshot.track_dirty_pages=true requires memory_snapshot.direct_overlaybd=true"
+    fn validate_memory_snapshot_options_enforces_dirty_page_requirements() {
+        let cases = [
+            (VirtualizationMode::Kvm, false, false, None),
+            (VirtualizationMode::Kvm, true, true, None),
+            (
+                VirtualizationMode::Kvm,
+                true,
+                false,
+                Some("requires memory_snapshot.direct_overlaybd=true"),
             ),
-            "unexpected error: {error}"
-        );
-        std::fs::write(
-            &path,
-            "virtualization_mode = \"pvm\"\n[memory_snapshot]\ntrack_dirty_pages = true\ndirect_overlaybd = true\n",
-        )?;
-        let error = ConfigManager::new_from_path(&path).unwrap_err();
-        assert!(
-            error.to_string().contains(
-                "memory_snapshot.track_dirty_pages=true is disabled in PVM mode because this combination has not been tested"
+            (
+                VirtualizationMode::Pvm,
+                true,
+                true,
+                Some("is disabled in PVM mode"),
             ),
-            "unexpected error: {error}"
-        );
-        std::fs::write(
-            &path,
-            "[memory_snapshot]\ntrack_dirty_pages = false\ndirect_overlaybd = false\n",
-        )?;
-        let config = ConfigManager::new_from_path(&path)?;
-        assert!(!config.config().memory_snapshot.track_dirty_pages);
-        assert!(!config.config().memory_snapshot.direct_overlaybd);
-        Ok(())
-    }
+        ];
 
-    #[test]
-    fn memory_snapshot_compression_config_is_valid() -> Result<()> {
-        let temp = tempdir()?;
-        let path = temp.path().join("config.toml");
-        std::fs::write(
-            &path,
-            "[memory_snapshot]\ncompression_enabled = true\ncompression_algorithm = \"zstd\"\ncompression_workers = 4\n",
-        )?;
-        let config = ConfigManager::new_from_path(&path)?;
-        assert!(config.config().memory_snapshot.compression_enabled);
-        assert_eq!(
-            config.config().memory_snapshot.compression_algorithm,
-            MemorySnapshotCompressionAlgorithm::Zstd
-        );
-        assert_eq!(config.config().memory_snapshot.compression_workers, 4);
-        std::fs::write(
-            &path,
-            "[memory_snapshot]\ncompression_enabled = true\ncompression_algorithm = \"snappy\"\n",
-        )?;
-        assert!(ConfigManager::new_from_path(&path).is_err());
-        Ok(())
-    }
+        for (virtualization_mode, track_dirty_pages, direct_overlaybd, expected_error) in cases {
+            let config = AppConfig {
+                virtualization_mode,
+                memory_snapshot: MemorySnapshotConfig {
+                    track_dirty_pages,
+                    direct_overlaybd,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
 
-    #[test]
-    fn memory_snapshot_background_download_defaults() {
-        let config = MemorySnapshotConfig::default();
-        let download = config.background_download;
-
-        assert!(download.enable);
-        assert_eq!(download.delay, 0);
-        assert_eq!(download.delay_extra, 1);
-        assert_eq!(download.try_cnt, 5);
-        assert_eq!(download.block_size, 16 * 1024 * 1024);
-        assert_eq!(download.concurrency, 4);
-        assert_eq!(download.max_inflight_blocks, 16);
+            let result = config.validate_memory_snapshot_options();
+            match expected_error {
+                Some(expected_error) => {
+                    let error = result.unwrap_err();
+                    assert!(
+                        error.to_string().contains(expected_error),
+                        "expected error containing {expected_error:?}, got: {error}"
+                    );
+                }
+                None => result.expect("supported memory snapshot options should be valid"),
+            }
+        }
     }
 
     #[test]
@@ -1403,26 +1351,44 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_disk_burst_without_sustained() {
-        let mut config = AppConfig::default();
-        config.machine.disk_rate_limit.enabled = true;
-        config.machine.disk_rate_limit.bandwidth_bytes_per_sec = 0;
-        config.machine.disk_rate_limit.bandwidth_burst_bytes = 1024;
-        let err = config.validate().unwrap_err();
-        assert!(
-            err.to_string().contains("bandwidth_burst_bytes is set but"),
-            "unexpected error: {err}"
-        );
+    fn validate_rejects_invalid_disk_rate_limit() {
+        let cases = [
+            (
+                DiskRateLimitConfig {
+                    enabled: true,
+                    bandwidth_burst_bytes: 1024,
+                    ..Default::default()
+                },
+                "bandwidth_burst_bytes is set but",
+            ),
+            (
+                DiskRateLimitConfig {
+                    enabled: true,
+                    iops_burst: 500,
+                    ..Default::default()
+                },
+                "iops_burst is set but",
+            ),
+            (
+                DiskRateLimitConfig {
+                    enabled: true,
+                    bandwidth_bytes_per_sec: i64::MAX as u64 + 1,
+                    ..Default::default()
+                },
+                "machine.disk_rate_limit.bandwidth_bytes_per_sec",
+            ),
+        ];
 
-        let mut config = AppConfig::default();
-        config.machine.disk_rate_limit.enabled = true;
-        config.machine.disk_rate_limit.iops = 0;
-        config.machine.disk_rate_limit.iops_burst = 500;
-        let err = config.validate().unwrap_err();
-        assert!(
-            err.to_string().contains("iops_burst is set but"),
-            "unexpected error: {err}"
-        );
+        for (disk_rate_limit, expected_error) in cases {
+            let mut config = AppConfig::default();
+            config.machine.disk_rate_limit = disk_rate_limit;
+
+            let err = config.validate().unwrap_err();
+            assert!(
+                err.to_string().contains(expected_error),
+                "expected error containing {expected_error:?}, got: {err}"
+            );
+        }
     }
 
     #[test]
@@ -1440,19 +1406,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_disk_rate_limit_above_i64_max() {
-        let mut config = AppConfig::default();
-        config.machine.disk_rate_limit.enabled = true;
-        config.machine.disk_rate_limit.bandwidth_bytes_per_sec = i64::MAX as u64 + 1;
-        let err = config.validate().unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("machine.disk_rate_limit.bandwidth_bytes_per_sec"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
     fn validate_accepts_consistent_disk_rate_limit() {
         let mut config = AppConfig::default();
         config.machine.disk_rate_limit.enabled = true;
@@ -1466,62 +1419,48 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_shared_overlaybd_global_config_path() {
-        let mut config = AppConfig::default();
-        let shared_path = PathBuf::from("/tmp/shared-overlaybd-global.json");
-        config.ublk.overlaybd.global_config_path = shared_path.clone();
-        config.memory_snapshot.overlaybd_global_config_path = shared_path;
+    fn validate_rejects_colliding_overlaybd_global_config_paths() {
+        let cases = [
+            (
+                "/tmp/shared-overlaybd-global.json",
+                "/tmp/shared-overlaybd-global.json",
+                "ublk.overlaybd.global_config_path",
+                "memory_snapshot.overlaybd_global_config_path",
+            ),
+            (
+                "/tmp/aenv/x/../global.json",
+                "/tmp/aenv/global.json",
+                "ublk.overlaybd.global_config_path",
+                "memory_snapshot.overlaybd_global_config_path",
+            ),
+            (
+                "/tmp/overlaybd/resize-overlaybd-global.json",
+                "/var/lib/aenv/overlaybd/mem-overlaybd-global.json",
+                "ublk.overlaybd.global_config_path",
+                "derived resize",
+            ),
+            (
+                "/tmp/overlaybd/overlaybd-global.json",
+                "/tmp/overlaybd/convert-overlaybd-global.json",
+                "memory_snapshot.overlaybd_global_config_path",
+                "derived convert",
+            ),
+        ];
 
-        let err = config.validate().unwrap_err();
-        let message = err.to_string();
-        assert!(message.contains("ublk.overlaybd.global_config_path"));
-        assert!(message.contains("memory_snapshot.overlaybd_global_config_path"));
-        assert!(message.contains("must be different"));
-    }
+        for (runtime_path, memory_path, left_name, right_name) in cases {
+            let mut config = AppConfig::default();
+            config.ublk.overlaybd.global_config_path = runtime_path.into();
+            config.memory_snapshot.overlaybd_global_config_path = memory_path.into();
 
-    #[test]
-    fn validate_rejects_aliased_overlaybd_global_config_paths() {
-        let mut config = AppConfig::default();
-        config.ublk.overlaybd.global_config_path = PathBuf::from("/tmp/aenv/x/../global.json");
-        config.memory_snapshot.overlaybd_global_config_path =
-            PathBuf::from("/tmp/aenv/global.json");
-
-        let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("must be different"), "{err}");
-
-        let mut config = AppConfig::default();
-        config.ublk.overlaybd.global_config_path = PathBuf::from("/tmp/./benv/global.json");
-        config.memory_snapshot.overlaybd_global_config_path =
-            PathBuf::from("/tmp/benv/global.json");
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn validate_rejects_rootfs_path_equal_to_derived_resize_path() {
-        let mut config = AppConfig::default();
-        config.ublk.overlaybd.global_config_path =
-            PathBuf::from("/tmp/overlaybd/resize-overlaybd-global.json");
-
-        let err = config.validate().unwrap_err();
-        let message = err.to_string();
-        assert!(message.contains("ublk.overlaybd.global_config_path"));
-        assert!(message.contains("derived resize"));
-        assert!(message.contains("must be different"));
-    }
-
-    #[test]
-    fn validate_rejects_memory_path_equal_to_derived_convert_path() {
-        let mut config = AppConfig::default();
-        config.ublk.overlaybd.global_config_path =
-            PathBuf::from("/tmp/overlaybd/overlaybd-global.json");
-        config.memory_snapshot.overlaybd_global_config_path =
-            PathBuf::from("/tmp/overlaybd/convert-overlaybd-global.json");
-
-        let err = config.validate().unwrap_err();
-        let message = err.to_string();
-        assert!(message.contains("memory_snapshot.overlaybd_global_config_path"));
-        assert!(message.contains("derived convert"));
-        assert!(message.contains("must be different"));
+            let err = config.validate().unwrap_err();
+            let message = err.to_string();
+            assert!(message.contains(left_name), "unexpected error: {err}");
+            assert!(message.contains(right_name), "unexpected error: {err}");
+            assert!(
+                message.contains("must be different"),
+                "unexpected error: {err}"
+            );
+        }
     }
 
     #[test]
@@ -1555,14 +1494,19 @@ mod tests {
     }
 
     #[test]
-    fn overlaybd_converter_cache_version_includes_tool_version() {
-        let config = AppConfig::default();
+    fn overlaybd_converter_cache_id_includes_configured_tool_version() {
+        let config = AppConfig {
+            overlaybd: Some(OverlaybdDependencyConfig {
+                version: "test-version".to_string(),
+                url: None,
+                package_url: None,
+            }),
+            ..Default::default()
+        };
         assert_eq!(
             config.resolved_overlaybd_oci_converter_id(),
-            "overlaybd-oci:v1.0.18-aenv.1:agentenv-cache-v1"
+            "overlaybd-oci:test-version:agentenv-cache-v1"
         );
-        assert!(!config.ublk.overlaybd.allow_shrink);
-        assert_eq!(config.ublk.overlaybd.resize_timeout_secs, 120);
     }
 
     #[test]
@@ -1572,16 +1516,8 @@ mod tests {
         let home_path = temp.path().join("home");
 
         assert_eq!(
-            resolve_path(&home_path, config_dir, Path::new("./env")),
-            config_dir.join("./env")
-        );
-        assert_eq!(
             resolve_path(&home_path, config_dir, Path::new("bin/firecracker")),
             config_dir.join("bin/firecracker")
-        );
-        assert_eq!(
-            resolve_path(&home_path, config_dir, Path::new("overlaybd/global.json")),
-            config_dir.join("overlaybd/global.json")
         );
         assert_eq!(
             resolve_path(&home_path, config_dir, Path::new("$AENV_HOME/image-cache")),
@@ -1917,55 +1853,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_custom_network_config() -> Result<()> {
-        let config = NetworkConfig {
-            egress: NetworkEgressConfig {
-                always_denied_cidrs: vec!["127.0.0.0/8".to_string(), "169.254.0.0/16".to_string()],
-            },
-            internal: NetworkInternalConfig {
-                host_interaction_cidr: "100.64.0.0/16".to_string(),
-                veth_cidr: "100.65.0.0/16".to_string(),
-            },
-        };
-
-        NetworkConfig::validate(&config)?;
-
-        Ok(())
-    }
-
-    #[test]
-    fn normalize_posix_snapshot_store_from_backend_section() -> Result<()> {
-        let temp = tempdir()?;
-        let config_dir = temp.path().join("configs");
-        let mut config = AppConfig::default();
-        config.snapshot.repository_backend = SnapshotRepositoryBackendKind::PosixFs;
-        config.snapshot.local_cache_path = "./snapshot-local-cache".into();
-        config.backend.posix_fs = Some(PosixFsBackendConfig {
-            snapshot_store: "./snapshot-store".into(),
-        });
-        config.normalize(&config_dir)?;
-
-        assert_eq!(
-            config
-                .backend
-                .posix_fs
-                .as_ref()
-                .map(|cfg| cfg.snapshot_store.clone()),
-            Some(config_dir.join("./snapshot-store"))
-        );
-        assert_eq!(
-            config.backend.posix_fs.as_ref().unwrap().snapshot_store,
-            config_dir.join("./snapshot-store")
-        );
-        assert_eq!(
-            config.snapshot.local_cache_path,
-            config_dir.join("./snapshot-local-cache")
-        );
-
-        Ok(())
-    }
-
-    #[test]
     fn resolve_config_path_keeps_absolute_paths_unchanged() {
         let absolute = PathBuf::from("/tmp/agentenv-absolute");
         assert_eq!(
@@ -2040,26 +1927,6 @@ mod tests {
         let err = config.validate().unwrap_err();
         assert!(
             err.to_string().contains("resize_timeout_secs must be > 0"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn validate_rejects_invalid_image_gc_watermarks() {
-        let mut config = AppConfig::default();
-        config.image.cache.gc.high_watermark_ratio = 1.2;
-        let err = config.validate().unwrap_err();
-        assert!(
-            err.to_string().contains("high_watermark_ratio"),
-            "unexpected error: {err}"
-        );
-
-        let mut config = AppConfig::default();
-        config.image.cache.gc.high_watermark_ratio = 0.5;
-        config.image.cache.gc.low_watermark_ratio = 0.7;
-        let err = config.validate().unwrap_err();
-        assert!(
-            err.to_string().contains("low_watermark_ratio"),
             "unexpected error: {err}"
         );
     }

--- a/src/cfg/image.rs
+++ b/src/cfg/image.rs
@@ -226,3 +226,37 @@ impl ImageResolverConfig {
             .collect();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_rejects_invalid_gc_watermarks() {
+        let cases = [
+            (
+                ImageCacheGcConfig {
+                    high_watermark_ratio: 1.2,
+                    ..Default::default()
+                },
+                "high_watermark_ratio",
+            ),
+            (
+                ImageCacheGcConfig {
+                    high_watermark_ratio: 0.5,
+                    low_watermark_ratio: 0.7,
+                    ..Default::default()
+                },
+                "low_watermark_ratio",
+            ),
+        ];
+
+        for (config, expected_error) in cases {
+            let err = config.validate().unwrap_err();
+            assert!(
+                err.to_string().contains(expected_error),
+                "expected error containing {expected_error:?}, got: {err}"
+            );
+        }
+    }
+}

--- a/src/cfg/network.rs
+++ b/src/cfg/network.rs
@@ -159,3 +159,23 @@ fn is_valid_dns_label(label: &str) -> bool {
         .take(bytes.len().saturating_sub(2))
         .all(|byte| matches!(*byte, b'a'..=b'z' | b'0'..=b'9' | b'-'))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_custom_network_config() -> Result<()> {
+        let config = NetworkConfig {
+            egress: NetworkEgressConfig {
+                always_denied_cidrs: vec!["127.0.0.0/8".to_string(), "169.254.0.0/16".to_string()],
+            },
+            internal: NetworkInternalConfig {
+                host_interaction_cidr: "100.64.0.0/16".to_string(),
+                veth_cidr: "100.65.0.0/16".to_string(),
+            },
+        };
+
+        NetworkConfig::validate(&config)
+    }
+}

--- a/src/sandbox/envd.rs
+++ b/src/sandbox/envd.rs
@@ -138,12 +138,9 @@ impl EnvdInstance {
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
     use std::time::Instant;
 
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::{TcpListener, TcpStream};
-    use tokio::time::timeout;
+    use tokio::net::TcpListener;
 
     use super::*;
 
@@ -169,113 +166,6 @@ mod tests {
         server.abort();
         assert!(error.to_string().contains("timed out waiting for envd"));
         assert!(started.elapsed() < Duration::from_millis(500));
-        Ok(())
-    }
-
-    async fn read_request(socket: &mut TcpStream) -> Result<String> {
-        let mut request = Vec::with_capacity(1024);
-        let mut chunk = [0_u8; 1024];
-
-        let (header_end, content_length) = loop {
-            let bytes_read = socket.read(&mut chunk).await?;
-            if bytes_read == 0 {
-                return Err(anyhow!("connection closed before request headers"));
-            }
-            request.extend_from_slice(&chunk[..bytes_read]);
-
-            if request.len() > 64 * 1024 {
-                return Err(anyhow!("request headers exceed test limit"));
-            }
-
-            let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n")
-            else {
-                continue;
-            };
-            let header_text = std::str::from_utf8(&request[..header_end + 4])?;
-            let content_length = header_text
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    name.eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim().parse::<usize>().ok())
-                        .flatten()
-                })
-                .unwrap_or(0);
-            break (header_end + 4, content_length);
-        };
-
-        while request.len() < header_end + content_length {
-            let bytes_read = socket.read(&mut chunk).await?;
-            if bytes_read == 0 {
-                return Err(anyhow!("connection closed before request body"));
-            }
-            request.extend_from_slice(&chunk[..bytes_read]);
-        }
-
-        let request_line = std::str::from_utf8(&request)?
-            .lines()
-            .next()
-            .ok_or_else(|| anyhow!("request line missing"))?;
-        Ok(request_line.to_owned())
-    }
-
-    // The first accepted socket models an idle connection retained from the
-    // previous runtime generation. A second accept models connecting to the
-    // next VM assigned the same address; bytes sent on the first socket would
-    // therefore be stale cross-generation reuse.
-    async fn serve_two_bootstrap_requests(listener: TcpListener) -> Result<Vec<SocketAddr>> {
-        const RESPONSE: &[u8] =
-            b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n";
-        let mut peer_addresses = Vec::with_capacity(2);
-        let mut held_connections = Vec::with_capacity(2);
-
-        for expected_prefix in ["GET /health ", "POST /init "] {
-            let (mut socket, peer_address) = listener.accept().await?;
-            let request_line = read_request(&mut socket).await?;
-            if !request_line.starts_with(expected_prefix) {
-                return Err(anyhow!(
-                    "expected request prefix {expected_prefix:?}, got {request_line:?}"
-                ));
-            }
-            socket.write_all(RESPONSE).await?;
-            peer_addresses.push(peer_address);
-
-            // Keep the first socket open so a pooling client would send init
-            // there and never reach the second accept.
-            held_connections.push(socket);
-        }
-
-        Ok(peer_addresses)
-    }
-
-    async fn run_bootstrap_no_reuse_interaction() -> Result<()> {
-        let listener = TcpListener::bind("127.0.0.1:0").await?;
-        let address = listener.local_addr()?;
-        let server = tokio::spawn(serve_two_bootstrap_requests(listener));
-        let envd = EnvdInstance::new(format!("http://{address}"));
-
-        envd.wait_for_ready(Duration::from_secs(2), Duration::from_millis(10))
-            .await?;
-        timeout(Duration::from_secs(2), envd.init(None, None, None))
-            .await
-            .map_err(|_| {
-                anyhow!("init reused the health connection instead of opening a new one")
-            })??;
-
-        let peer_addresses = timeout(Duration::from_secs(2), server)
-            .await
-            .map_err(|_| anyhow!("timed out waiting for two bootstrap connections"))?
-            .map_err(|err| anyhow!("mock envd task failed: {err}"))??;
-        assert_eq!(peer_addresses.len(), 2);
-        assert_ne!(peer_addresses[0].port(), peer_addresses[1].port());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn bootstrap_http_client_does_not_reuse_connections() -> Result<()> {
-        timeout(Duration::from_secs(5), run_bootstrap_no_reuse_interaction())
-            .await
-            .map_err(|_| anyhow!("timed out running complete envd bootstrap interaction"))??;
         Ok(())
     }
 }

--- a/src/sandbox/firecracker/config.rs
+++ b/src/sandbox/firecracker/config.rs
@@ -704,16 +704,6 @@ mod tests {
     }
 
     #[test]
-    fn from_app_config_maps_track_dirty_pages() -> Result<()> {
-        let mut config = base_app_config();
-        config.memory_snapshot.track_dirty_pages = true;
-
-        let common_config = FirecrackerCommonConfig::from_app_config(&config)?;
-        assert!(common_config.track_dirty_pages);
-        Ok(())
-    }
-
-    #[test]
     fn sandbox_config_binds_overlaybd_to_user_image() -> Result<()> {
         let mut config = base_app_config();
         config.ublk = UblkTomlConfig {

--- a/src/sandbox/firecracker/instance.rs
+++ b/src/sandbox/firecracker/instance.rs
@@ -626,17 +626,8 @@ fn parse_log_level(level: &str) -> Result<firecracker_client::models::logger::Le
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http_body_util::BodyExt;
-    use hyper::body::Incoming;
-    use hyper::server::conn::http1;
-    use hyper::service::service_fn;
-    use hyper::{Request, Response, StatusCode};
-    use hyper_util::rt::TokioIo;
-    use serde_json::Value;
     use std::process::Command as StdCommand;
     use tempfile::tempdir;
-    use tokio::net::UnixListener;
-    use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn wait_for_ready_times_out_when_socket_never_appears() {
@@ -766,64 +757,6 @@ mod tests {
             PathBuf::from("/tmp/mem.bin")
         );
 
-        Ok(())
-    }
-    #[tokio::test]
-    async fn fresh_and_restore_requests_include_track_dirty_pages() -> Result<()> {
-        let temp = tempdir()?;
-        let listener = UnixListener::bind(temp.path().join("firecracker.socket"))?;
-        let (requests_tx, mut requests_rx) = mpsc::unbounded_channel::<(String, Value)>();
-
-        let server = tokio::spawn(async move {
-            for _ in 0..2 {
-                let (stream, _) = listener.accept().await.expect("accept request");
-                let requests_tx = requests_tx.clone();
-                http1::Builder::new()
-                    .keep_alive(false)
-                    .serve_connection(
-                        TokioIo::new(stream),
-                        service_fn(move |request: Request<Incoming>| {
-                            let requests_tx = requests_tx.clone();
-                            async move {
-                                let path = request.uri().path().to_string();
-                                let body =
-                                    request.collect().await.expect("collect request").to_bytes();
-                                let json = serde_json::from_slice(&body).expect("decode request");
-                                requests_tx.send((path, json)).expect("send request");
-                                Ok::<_, std::convert::Infallible>(
-                                    Response::builder()
-                                        .status(StatusCode::NO_CONTENT)
-                                        .body(http_body_util::Full::new(hyper::body::Bytes::new()))
-                                        .expect("build response"),
-                                )
-                            }
-                        }),
-                    )
-                    .await
-                    .expect("serve request");
-            }
-        });
-
-        let instance = FirecrackerInstance::new(temp.path().to_path_buf());
-        instance.set_machine_config(512, 2, false, true).await?;
-        instance
-            .load_snapshot_file(
-                Path::new("vm_state.bin"),
-                Path::new("mem_backend"),
-                &[],
-                false,
-                true,
-            )
-            .await?;
-
-        let (fresh_path, fresh_body) = requests_rx.recv().await.expect("fresh request");
-        let (restore_path, restore_body) = requests_rx.recv().await.expect("restore request");
-        assert_eq!(fresh_path, "/machine-config");
-        assert_eq!(fresh_body["track_dirty_pages"], true);
-        assert_eq!(restore_path, "/snapshot/load");
-        assert_eq!(restore_body["track_dirty_pages"], true);
-
-        server.await.expect("request server");
         Ok(())
     }
 }

--- a/src/setup/deps.rs
+++ b/src/setup/deps.rs
@@ -1198,9 +1198,6 @@ mod tests {
         let mut config =
             app_config_with_overlaybd_global_configs(temp.path(), rootfs.clone(), mem.clone());
         config.image.cache.root_dir = temp.path().join("image-cache");
-        config.memory_snapshot.background_download.enable = false;
-        config.memory_snapshot.background_download.block_size = 2 * 1024 * 1024;
-        config.memory_snapshot.background_download.concurrency = 7;
 
         write_generated_overlaybd_global_configs(&config, None).expect("write global configs");
 
@@ -1222,15 +1219,6 @@ mod tests {
                 "memory cacheDir must be distinct from every other cacheDir"
             );
         }
-        let expected_memory = DownloadConfig {
-            enable: false,
-            block_size: 2 * 1024 * 1024,
-            concurrency: 7,
-            ..MemorySnapshotConfig::default()
-                .background_download
-                .to_overlaybd_download_config()
-        };
-        assert_download_json(&memory_value, &expected_memory);
     }
 
     #[test]


### PR DESCRIPTION
## What

Remove and consolidate unit tests that duplicate implementation details instead of testing owned behavior.

- replace temporary TOML fixtures with direct, table-driven config validation
- merge repeated disk rate-limit and OverlayBD path-collision cases
- move image and network validation tests into their owning modules
- remove tests that only assert defaults, direct field forwarding, or third-party deserialization
- remove heavyweight HTTP mock harnesses for directly configured Firecracker fields and envd connection pooling

## Why

Several tests repeated constants or simple assignments from production code. Others constructed temporary config files or mock HTTP servers without exercising additional AgentENV behavior.

This made the suite larger and more brittle without providing meaningful regression coverage. The remaining tests focus on validation rules, configuration relationships, and observable failure paths owned by AgentENV.

## Related issue

N/A.

## Scope and non-goals

Included:

- unit-test cleanup and reorganization
- consolidation of related validation cases
- removal of redundant test-only fixtures and helpers

Excluded:

- runtime behavior changes
- configuration or default-value changes
- integration-test changes

## Design and behavior changes

There are no runtime behavior changes.

Configuration tests now construct the relevant config objects directly and invoke their validation methods. Related invalid cases use table-driven assertions so each owned validation rule remains explicit without duplicating setup.

Tests that only mirrored direct assignments, builder options, or dependency-provided deserialization behavior were removed.

## Compatibility and operations

- Public API or generated protocol: N/A; no API or generated code changes.
- Configuration or defaults: N/A; existing values and validation behavior are unchanged.
- Snapshot manifest, artifact layout, or storage format: N/A; test-only changes.
- Upgrade and rollback: N/A; no runtime impact.
- Host requirements, permissions, ports, or dependencies: N/A; unchanged.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
cargo test -p agentenv --lib
702 passed; 0 failed; 4 ignored

cargo fmt --all -- --check
passed

cargo clippy -p agentenv --lib --tests -- -D warnings
passed
```

Skipped checks and reasons:

- Integration tests were not run because this PR only removes or reorganizes unit tests.
- Services tests, code generation, documentation, and benchmarks are not applicable because their corresponding code and behavior are unchanged.

## Risks and reviewer notes

Low risk. The retained tests continue to cover bundled config loading, supported memory snapshot combinations, disk rate limits, GC watermarks, path normalization, and OverlayBD configuration isolation.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.