### PR TITLE
fix(snapshot): preserve exported image config

### DIFF
--- a/docs/src/concepts/snapshots.md
+++ b/docs/src/concepts/snapshots.md
@@ -59,6 +59,15 @@ Notes:
 - Deleting a snapshot also attempts to delete its published manifest from the
   registry.
 
+Published rootfs images preserve the snapshot's effective OCI runtime fields
+(`Env`, `WorkingDir`, `User`, `Entrypoint`, `Cmd`, `ExposedPorts`, `Volumes`,
+and `Labels`) and retain unmodeled fields from the source rootfs config when
+available. AgentENV-specific startup commands remain snapshot metadata and are
+not converted into OCI `Entrypoint` or `Cmd`; use explicit OCI command metadata
+when that behavior must survive image export. Republishing a snapshot with this
+metadata changes its manifest digest, so an existing published tag still
+requires a new tag or deletion.
+
 ## Export a Snapshot Rootfs as a Standalone OCI Image
 
 `aenv-snapshot-image` (build with `make build-snapshot-image`; not part of the
@@ -85,6 +94,8 @@ check is not atomic against concurrent tag writers. The tool records no new
 publication state. If the selected reference is already recorded as a
 snapshot-managed publication, the tool warns that it may be deleted with the
 snapshot; other exported references live independently of snapshot deletion.
+The standalone export preserves the same effective OCI runtime fields described
+under [OverlayBD Image Publication](#overlaybd-image-publication).
 
 ## Manage Snapshots
 

--- a/src/snapshot/image_export/service.rs
+++ b/src/snapshot/image_export/service.rs
@@ -1,7 +1,7 @@
 //! Committed-snapshot rootfs image export: load the record, resolve the
-//! target, and publish the rootfs layer stack plus a minimal OCI config as a
-//! plain OCI image through `regctl`. Attached drives and memory snapshots
-//! never participate.
+//! target, and publish the rootfs layer stack plus the snapshot runtime OCI
+//! config as a plain OCI image through `regctl`. Attached drives and memory
+//! snapshots never participate.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -15,8 +15,8 @@ use super::target::{
 use crate::cfg::{ConfigManager, SnapshotImageStoragePolicy, SnapshotRepositoryBackendKind};
 use crate::digest;
 use crate::snapshot::repository::backends::common::acr::{
-    build_oci_image_manifest, host_architecture_for_oci, minimal_oci_config_blob, OciDescriptor,
-    SourceRegistryRepository,
+    build_oci_image_manifest, host_architecture_for_oci, snapshot_oci_config_blob, OciDescriptor,
+    SnapshotOciConfigInput, SourceRegistryRepository,
 };
 use crate::snapshot::repository::backends::{oss, posixfs};
 use crate::snapshot::repository::{RepositoryError, RepositoryResult, SnapshotRepository};
@@ -149,10 +149,14 @@ impl SnapshotImageService {
             });
         }
 
-        // The minimal config and the manifest are deterministic per snapshot
+        // The snapshot config and the manifest are deterministic per snapshot
         // and tag, so the manifest digest identifies the exact image.
+        let config_input = SnapshotOciConfigInput::new(
+            &committed.context,
+            committed.image_configs.rootfs_config(),
+        );
         let (config_bytes, config_digest, config_size) =
-            minimal_oci_config_blob(host_architecture_for_oci())?;
+            snapshot_oci_config_blob(host_architecture_for_oci(), config_input)?;
         let descriptors = committed
             .rootfs_layers
             .iter()
@@ -374,8 +378,10 @@ async fn materialize_downloaded_layer(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fs;
 
+    use serde_json::json;
     use tempfile::TempDir;
 
     use super::super::regctl::fixture::{
@@ -387,7 +393,7 @@ mod tests {
     use crate::snapshot::mock::MockSnapshotRepository;
     use crate::snapshot::repository::backends::posixfs::PosixFsSnapshotArtifactLayout;
     use crate::snapshot::{
-        rootfs_snapshot_image_tag, PersistedDiskImagePublication, SnapshotRecord,
+        rootfs_snapshot_image_tag, CommandContext, PersistedDiskImagePublication, SnapshotRecord,
     };
 
     const TARGET_REPOSITORY: &str = "reg.example/team/newapp";
@@ -530,7 +536,20 @@ mod tests {
             &digests[1],
             b"managed local layer",
         );
-        let committed = committed_with_layers(layers);
+        let mut committed = committed_with_layers(layers);
+        committed.context = CommandContext::new(
+            HashMap::from([("APP_ENV".to_string(), "snapshot".to_string())]),
+            "/workspace",
+        );
+        committed.image_configs.add(
+            None::<String>,
+            "/",
+            json!({
+                "Env": ["APP_ENV=source"],
+                "WorkingDir": "/source",
+                "StopSignal": "SIGTERM"
+            }),
+        );
 
         let result = publish(&service, &committed).await.unwrap();
 
@@ -543,6 +562,12 @@ mod tests {
         for digest in digests.iter().map(String::as_str).chain([config_digest]) {
             assert!(blob_path(dir.path(), TARGET_REPOSITORY, digest).exists());
         }
+        let config_bytes =
+            fs::read(blob_path(dir.path(), TARGET_REPOSITORY, config_digest)).expect("config blob");
+        let config: serde_json::Value = serde_json::from_slice(&config_bytes).unwrap();
+        assert_eq!(config["config"]["Env"], json!(["APP_ENV=snapshot"]));
+        assert_eq!(config["config"]["WorkingDir"], "/workspace");
+        assert_eq!(config["config"]["StopSignal"], "SIGTERM");
         let piped = fs::read(blob_path(dir.path(), TARGET_REPOSITORY, &digests[2])).unwrap();
         assert_eq!(piped, b"cross-registry layer");
 

--- a/src/snapshot/repository/backends/common/acr/manifest.rs
+++ b/src/snapshot/repository/backends/common/acr/manifest.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 use crate::digest;
 use crate::snapshot::repository::{RepositoryError, RepositoryResult};
+use crate::snapshot::CommandContext;
 
 pub(crate) const OCI_IMAGE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
 pub(crate) const OCI_IMAGE_CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.image.config.v1+json";
@@ -55,54 +57,169 @@ struct OciManifest {
     annotations: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Serialize)]
-struct MinimalOciConfig<'a> {
-    created: &'a str,
-    architecture: &'a str,
-    os: &'a str,
-    config: MinimalRuntimeConfig,
-    rootfs: MinimalRootfs,
-    history: Vec<serde_json::Value>,
+/// Effective runtime metadata plus the optional source rootfs OCI config.
+#[derive(Clone, Copy)]
+pub(crate) struct SnapshotOciConfigInput<'a> {
+    context: &'a CommandContext,
+    raw_config: Option<&'a Value>,
+}
+
+impl<'a> SnapshotOciConfigInput<'a> {
+    pub(crate) fn new(context: &'a CommandContext, raw_config: Option<&'a Value>) -> Self {
+        Self {
+            context,
+            raw_config,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "PascalCase")]
-struct MinimalRuntimeConfig {
-    env: Vec<String>,
-    working_dir: String,
+struct OciConfig<'a> {
+    created: &'a str,
+    architecture: &'a str,
+    os: &'a str,
+    config: Value,
+    rootfs: MinimalRootfs,
+    history: Vec<Value>,
 }
 
 #[derive(Debug, Serialize)]
 struct MinimalRootfs {
     #[serde(rename = "type")]
     rootfs_type: &'static str,
+    // OverlayBD snapshot layers are not ordinary uncompressed OCI tar diffs,
+    // so this intentionally stays empty for AgentENV-only use.
     diff_ids: Vec<String>,
+}
+
+fn oci_config_blob(
+    architecture: &str,
+    config: Value,
+    operation: &'static str,
+) -> RepositoryResult<(Vec<u8>, String, u64)> {
+    let config = OciConfig {
+        created: "1970-01-01T00:00:00Z",
+        architecture,
+        os: "linux",
+        config,
+        rootfs: MinimalRootfs {
+            rootfs_type: "layers",
+            diff_ids: Vec::new(),
+        },
+        history: Vec::new(),
+    };
+    let bytes =
+        serde_json::to_vec(&config).map_err(|error| RepositoryError::backend(operation, error))?;
+    let digest = digest::sha256_digest(&bytes);
+    let size = bytes.len() as u64;
+    Ok((bytes, digest, size))
+}
+
+fn set_optional(config: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if let Some(value) = value {
+        config.insert(key.to_string(), value);
+    } else {
+        config.remove(key);
+    }
+}
+
+fn empty_object_map(values: &[String]) -> Value {
+    Value::Object(
+        values
+            .iter()
+            .map(|value| (value.clone(), Value::Object(Map::new())))
+            .collect(),
+    )
+}
+
+fn canonicalize_json(value: Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.into_iter().map(canonicalize_json).collect()),
+        Value::Object(values) => {
+            let mut entries: Vec<_> = values.into_iter().collect();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            Value::Object(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| (key, canonicalize_json(value)))
+                    .collect(),
+            )
+        }
+        value => value,
+    }
+}
+
+fn merged_runtime_config(input: SnapshotOciConfigInput<'_>) -> Value {
+    let mut config = input
+        .raw_config
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let context = input.context;
+
+    let mut env: Vec<_> = context
+        .env_vars
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect();
+    env.sort();
+    config.insert("Env".to_string(), serde_json::json!(env));
+    config.insert(
+        "WorkingDir".to_string(),
+        Value::String(context.workdir.clone()),
+    );
+    set_optional(&mut config, "User", context.user.clone().map(Value::String));
+    set_optional(
+        &mut config,
+        "Entrypoint",
+        context
+            .entrypoint
+            .clone()
+            .map(|value| serde_json::json!(value)),
+    );
+    set_optional(
+        &mut config,
+        "Cmd",
+        context.cmd.clone().map(|value| serde_json::json!(value)),
+    );
+    set_optional(
+        &mut config,
+        "ExposedPorts",
+        (!context.exposed_ports.is_empty()).then(|| empty_object_map(&context.exposed_ports)),
+    );
+    set_optional(
+        &mut config,
+        "Volumes",
+        (!context.volumes.is_empty()).then(|| empty_object_map(&context.volumes)),
+    );
+    set_optional(
+        &mut config,
+        "Labels",
+        (!context.labels.is_empty()).then(|| serde_json::json!(context.labels)),
+    );
+
+    canonicalize_json(Value::Object(config))
+}
+
+pub(crate) fn snapshot_oci_config_blob(
+    architecture: &str,
+    input: SnapshotOciConfigInput<'_>,
+) -> RepositoryResult<(Vec<u8>, String, u64)> {
+    oci_config_blob(
+        architecture,
+        merged_runtime_config(input),
+        "serialize snapshot OCI config",
+    )
 }
 
 pub(crate) fn minimal_oci_config_blob(
     architecture: &str,
 ) -> RepositoryResult<(Vec<u8>, String, u64)> {
-    let config = MinimalOciConfig {
-        created: "1970-01-01T00:00:00Z",
+    oci_config_blob(
         architecture,
-        os: "linux",
-        config: MinimalRuntimeConfig {
-            env: Vec::new(),
-            working_dir: String::new(),
-        },
-        rootfs: MinimalRootfs {
-            rootfs_type: "layers",
-            // OverlayBD snapshot layers are not ordinary uncompressed OCI tar
-            // diffs, so this intentionally stays empty for AgentENV-only use.
-            diff_ids: Vec::new(),
-        },
-        history: Vec::new(),
-    };
-    let bytes = serde_json::to_vec(&config)
-        .map_err(|e| RepositoryError::backend("serialize minimal OCI config", e))?;
-    let digest = digest::sha256_digest(&bytes);
-    let size = bytes.len() as u64;
-    Ok((bytes, digest, size))
+        serde_json::json!({"Env": [], "WorkingDir": ""}),
+        "serialize minimal OCI config",
+    )
 }
 
 /// OCI architecture string of the host running this binary.
@@ -138,7 +255,12 @@ pub(crate) fn build_oci_image_manifest(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+
     use super::*;
+    use crate::snapshot::CommandContext;
 
     #[test]
     fn minimal_config_has_documented_empty_diff_ids() {
@@ -151,6 +273,74 @@ mod tests {
         assert_eq!(value["rootfs"]["diff_ids"].as_array().unwrap().len(), 0);
         assert_eq!(size, bytes.len() as u64);
         assert_eq!(digest, crate::digest::sha256_digest(&bytes));
+    }
+
+    #[test]
+    fn snapshot_config_merges_context_and_raw_config_deterministically() {
+        let raw = json!({
+            "Env": ["STALE=1"],
+            "WorkingDir": "/old",
+            "User": "root",
+            "Entrypoint": ["/old-entrypoint"],
+            "Cmd": ["old"],
+            "ExposedPorts": {"80/tcp": {}},
+            "Volumes": {"/old-data": {}},
+            "Labels": {"old": "label"},
+            "StopSignal": "SIGTERM",
+            "Healthcheck": {"Test": ["CMD", "true"]}
+        });
+        let cases = [
+            (
+                CommandContext::new(
+                    HashMap::from([
+                        ("B".to_string(), "two".to_string()),
+                        ("A".to_string(), "one".to_string()),
+                    ]),
+                    "/workspace",
+                )
+                .with_user(Some("1000:1000".to_string()))
+                .with_exposed_ports(vec!["8080/tcp".to_string()])
+                .with_entrypoint(Some(vec!["/app".to_string()]))
+                .with_cmd(Some(vec!["serve".to_string()]))
+                .with_volumes(vec!["/data".to_string()])
+                .with_labels(HashMap::from([(
+                    "org.example.name".to_string(),
+                    "snapshot".to_string(),
+                )])),
+                json!({
+                    "Env": ["A=one", "B=two"],
+                    "WorkingDir": "/workspace",
+                    "User": "1000:1000",
+                    "Entrypoint": ["/app"],
+                    "Cmd": ["serve"],
+                    "ExposedPorts": {"8080/tcp": {}},
+                    "Volumes": {"/data": {}},
+                    "Labels": {"org.example.name": "snapshot"},
+                    "StopSignal": "SIGTERM",
+                    "Healthcheck": {"Test": ["CMD", "true"]}
+                }),
+            ),
+            (
+                CommandContext::default(),
+                json!({
+                    "Env": [],
+                    "WorkingDir": "/",
+                    "StopSignal": "SIGTERM",
+                    "Healthcheck": {"Test": ["CMD", "true"]}
+                }),
+            ),
+        ];
+
+        for (context, expected_config) in cases {
+            let (bytes, _, _) = snapshot_oci_config_blob(
+                "amd64",
+                SnapshotOciConfigInput::new(&context, Some(&raw)),
+            )
+            .unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(value["config"], expected_config);
+            assert_eq!(value["rootfs"]["diff_ids"], json!([]));
+        }
     }
 
     #[test]

--- a/src/snapshot/repository/backends/common/acr/mod.rs
+++ b/src/snapshot/repository/backends/common/acr/mod.rs
@@ -4,8 +4,8 @@ mod publisher;
 mod source_image;
 
 pub(crate) use manifest::{
-    build_oci_image_manifest, host_architecture_for_oci, minimal_oci_config_blob, OciDescriptor,
-    OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    build_oci_image_manifest, host_architecture_for_oci, snapshot_oci_config_blob, OciDescriptor,
+    SnapshotOciConfigInput, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 pub(crate) use publisher::{AcrDiskImageExporter, DiskImageExportOutcome, DiskImageSubject};
 pub(crate) use source_image::SourceRegistryRepository;

--- a/src/snapshot/repository/backends/common/acr/publisher.rs
+++ b/src/snapshot/repository/backends/common/acr/publisher.rs
@@ -16,7 +16,8 @@ use crate::snapshot::{
 
 use super::client::{AcrClient, AcrClientError};
 use super::manifest::{
-    build_oci_image_manifest, host_architecture_for_oci, minimal_oci_config_blob, OciDescriptor,
+    build_oci_image_manifest, host_architecture_for_oci, minimal_oci_config_blob,
+    snapshot_oci_config_blob, OciDescriptor, SnapshotOciConfigInput,
 };
 use super::source_image::{
     load_source_registry_image, LocalSnapshotDelta, LocalSnapshotDeltaDescriptor,
@@ -74,6 +75,7 @@ impl AcrDiskImageExporter {
         snapshot_id: &SnapshotId,
         subject: DiskImageSubject,
         image_config_path: &Path,
+        config: Option<SnapshotOciConfigInput<'_>>,
     ) -> RepositoryResult<DiskImageExportOutcome> {
         let image = load_source_registry_image(image_config_path)?;
         let target = &image.target;
@@ -117,8 +119,10 @@ impl AcrDiskImageExporter {
             }));
         }
 
-        let (config_bytes, config_digest, config_size) =
-            minimal_oci_config_blob(host_architecture_for_oci())?;
+        let (config_bytes, config_digest, config_size) = match config {
+            Some(config) => snapshot_oci_config_blob(host_architecture_for_oci(), config)?,
+            None => minimal_oci_config_blob(host_architecture_for_oci())?,
+        };
         if !client
             .blob_exists(&target.repo_blob_url, &target.repository, &config_digest)
             .await?
@@ -318,6 +322,7 @@ fn is_tag_char(ch: char) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fs;
 
     use serde_json::json;
@@ -325,6 +330,7 @@ mod tests {
 
     use super::super::client::tests::{client as test_client, fake_server, FakeState};
     use super::*;
+    use crate::snapshot::CommandContext;
 
     #[test]
     fn validates_oci_snapshot_tags() {
@@ -381,6 +387,7 @@ mod tests {
                 &crate::snapshot::SnapshotId::generate(),
                 DiskImageSubject::Rootfs,
                 &image,
+                None,
             )
             .await
             .expect_err("planned ACR source must not fall back on missing credentials");
@@ -421,9 +428,19 @@ mod tests {
         let publisher =
             AcrDiskImageExporter::new_with_client_builder(Arc::new(move |_| Ok(client.clone())));
         let snapshot_id = crate::snapshot::SnapshotId::generate();
+        let context = CommandContext::new(
+            HashMap::from([("APP_ENV".to_string(), "snapshot".to_string())]),
+            "/workspace",
+        );
+        let raw = json!({"StopSignal": "SIGTERM"});
 
         let outcome = publisher
-            .export(&snapshot_id, DiskImageSubject::Rootfs, &image)
+            .export(
+                &snapshot_id,
+                DiskImageSubject::Rootfs,
+                &image,
+                Some(SnapshotOciConfigInput::new(&context, Some(&raw))),
+            )
             .await
             .unwrap();
 
@@ -453,9 +470,15 @@ mod tests {
                 }),
             ]
         );
+        let (_, expected_config_digest, _) = snapshot_oci_config_blob(
+            host_architecture_for_oci(),
+            SnapshotOciConfigInput::new(&context, Some(&raw)),
+        )
+        .unwrap();
         let state = state.lock().unwrap();
         assert_eq!(state.manifest_puts.len(), 1);
         let manifest: serde_json::Value = serde_json::from_slice(&state.manifest_puts[0]).unwrap();
+        assert_eq!(manifest["config"]["digest"], expected_config_digest);
         assert_eq!(manifest["layers"][0]["digest"], "sha256:base");
         assert_eq!(manifest["layers"][1]["digest"], "sha256:delta");
         assert_eq!(

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -15,7 +15,7 @@ use super::layout::OssSnapshotArtifactLayout;
 use crate::cfg::SnapshotImageStoragePolicy;
 use crate::sandbox::FirecrackerSnapshotManifest;
 use crate::snapshot::repository::backends::common::acr::{
-    AcrDiskImageExporter, DiskImageExportOutcome, DiskImageSubject,
+    AcrDiskImageExporter, DiskImageExportOutcome, DiskImageSubject, SnapshotOciConfigInput,
 };
 use crate::snapshot::repository::backends::common::write_dense_overlaybd_layer_to_file;
 use crate::snapshot::repository::interfaces::SnapshotRepository;
@@ -222,12 +222,17 @@ impl SnapshotRepository for OssSnapshotRepository {
         let publish_result = async {
             validate_publish_manifest_image_configs(&manifest)?;
 
-            // 1. Export rootfs disk image.
+            // 1. Export rootfs disk image with the effective runtime config.
+            let rootfs_config = SnapshotOciConfigInput::new(
+                &metadata.context,
+                metadata.image_configs.rootfs_config(),
+            );
             let rootfs_outcome = self
                 .export_disk_image(
                     id,
                     DiskImageSubject::Rootfs,
                     &manifest.rootfs.image_config_path,
+                    Some(rootfs_config),
                 )
                 .await?;
             if let Some(publication) = rootfs_outcome.publication.clone() {
@@ -802,6 +807,7 @@ impl OssSnapshotRepository {
         snapshot_id: &SnapshotId,
         subject: DiskImageSubject,
         image_config_path: &Path,
+        config: Option<SnapshotOciConfigInput<'_>>,
     ) -> RepositoryResult<DiskImageExportOutcome> {
         if !matches!(
             self.snapshot_image_storage,
@@ -811,7 +817,7 @@ impl OssSnapshotRepository {
         }
         match self
             .acr_exporter
-            .export(snapshot_id, subject.clone(), image_config_path)
+            .export(snapshot_id, subject.clone(), image_config_path, config)
             .await
         {
             Err(RepositoryError::Unsupported { feature }) => {
@@ -872,6 +878,7 @@ impl OssSnapshotRepository {
                         drive_id: drive.drive_id.clone(),
                     },
                     &drive.image_config_path,
+                    None,
                 )
                 .await?;
             if let Some(publication) = outcome.publication.clone() {

--- a/src/types/image_configs.rs
+++ b/src/types/image_configs.rs
@@ -56,6 +56,14 @@ impl ImageConfigs {
         &self.0
     }
 
+    /// Return the raw config associated with the rootfs image, if present.
+    pub fn rootfs_config(&self) -> Option<&serde_json::Value> {
+        self.0
+            .iter()
+            .find(|entry| entry.drive_id.is_none() && entry.mount_path == "/")
+            .map(|entry| &entry.config)
+    }
+
     /// Serialize into a `serde_json::Value` (JSON array) suitable for
     /// embedding into the MMDS extra metadata map.
     pub fn to_value(&self) -> serde_json::Value {
@@ -71,17 +79,18 @@ mod tests {
     #[test]
     fn serializes_as_flat_array() {
         let mut configs = ImageConfigs::new();
-        configs.add(None::<String>, "/", json!({"Cmd": ["/bin/sh"]}));
         configs.add(Some("data"), "/mnt/data", json!({"Env": ["DATA=1"]}));
+        configs.add(None::<String>, "/", json!({"Cmd": ["/bin/sh"]}));
 
         let value = serde_json::to_value(&configs).expect("serialize");
         assert_eq!(
             value,
             json!([
-                { "mountPath": "/", "config": {"Cmd": ["/bin/sh"]} },
                 { "driveId": "data", "mountPath": "/mnt/data", "config": {"Env": ["DATA=1"]} },
+                { "mountPath": "/", "config": {"Cmd": ["/bin/sh"]} },
             ])
         );
+        assert_eq!(configs.rootfs_config(), Some(&json!({"Cmd": ["/bin/sh"]})));
     }
 
     #[test]


### PR DESCRIPTION
## What

Preserve effective snapshot runtime configuration when publishing committed snapshot rootfs layers as OCI images.

Both snapshot image paths now generate the OCI config from the committed snapshot metadata instead of always publishing a minimal empty config:

- `aenv-snapshot-image`
- automatic OSS source-registry publication

## Why

Snapshot image publication previously preserved the OverlayBD rootfs layer stack but replaced the OCI runtime config with `Env=[]` and `WorkingDir=""`, omitting fields such as `User`, `Entrypoint`, `Cmd`, `ExposedPorts`, `Volumes`, `Labels`, and `StopSignal`.

The resulting image could be reused as a `userImage`, but its runtime behavior differed from the source snapshot. This made published snapshot images filesystem-correct but configuration-incomplete.

## Related issue

N/A

## Scope and non-goals

Included:

- Preserve effective `Env`, `WorkingDir`, `User`, `Entrypoint`, `Cmd`, `ExposedPorts`, `Volumes`, and `Labels` from `CommandContext`.
- Preserve unmodeled source OCI config fields such as `StopSignal` and `Healthcheck` when a raw rootfs config is available.
- Apply the same config-building behavior to standalone export and automatic source-registry publication.
- Keep deterministic config bytes and manifest digests.
- Keep attached-drive image publication on the existing minimal config path.
- Document runtime config preservation and immutable-tag behavior.

Excluded:

- Making OverlayBD-native images portable to arbitrary OCI runtimes.
- Persisting or reconstructing full original OCI config documents, including `architecture`, `history`, or DiffIDs.
- Converting AgentENV `StartupCommand.start_cmd` into OCI `Entrypoint`/`Cmd`.
- Migrating or overwriting existing published tags.

## Design and behavior changes

A shared snapshot OCI config builder now:

1. Selects the rootfs raw config entry from `ImageConfigs` using `drive_id == None` and `mount_path == "/"`.
2. Uses the raw OCI `config` object as the base when present.
3. Replaces AgentENV-managed fields with the effective committed `CommandContext`.
4. Removes stale raw fields when the effective context no longer defines them.
5. Preserves unmodeled raw fields such as `StopSignal` and `Healthcheck`.
6. Canonically sorts JSON object keys and environment entries so identical metadata produces deterministic bytes and digests.

`SnapshotImageService` uses the committed snapshot context and rootfs raw config when exporting through `aenv-snapshot-image`.

OSS snapshot publication passes the same metadata into the ACR exporter for rootfs images. Attached-drive publication passes no runtime config and keeps the existing minimal config behavior.

## Compatibility and operations

- Public API or generated protocol: N/A. No public API or generated protocol changes.
- Configuration or defaults: N/A. No configuration keys or defaults changed.
- Snapshot manifest, artifact layout, or storage format: N/A. The committed snapshot repository schema is unchanged.
- Upgrade and rollback: Existing published image tags remain immutable. Re-exporting a snapshot after this change can produce a different config and manifest digest; users must choose a new tag or delete the old tag before republishing.
- Host requirements, permissions, ports, or dependencies: N/A. No new host requirements or dependencies.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
cargo fmt --all -- --check
# passed

git diff --check
# passed

cargo test -p agentenv --lib -- \
  snapshot::repository::backends::common::acr \
  snapshot::image_export \
  types::image_configs
# 43 passed; 0 failed

cargo clippy -p agentenv --lib --tests -- -D warnings
# passed
```

Skipped checks and reasons:

- `make test-unit`: not claimed for the final rebased tree. Earlier full runs reached 695 passed with one pre-existing remote-host capability failure in `privileges::tests::scoped_spawn_clears_child_capabilities_without_mutating_caller`, which also fails when run alone and is unrelated to these files.
- Relevant Rust integration tests: not run; this change is covered by focused unit and fake-registry publication tests.
- `make -C services test`: skipped because `services/` was not changed.
- Generated clients/server regeneration: not needed; no generated code or schema source changed.
- Benchmarks: not run; this change only alters metadata construction and registry publication config bytes.

## Risks and reviewer notes

Main review areas:

- `src/snapshot/repository/backends/common/acr/manifest.rs`: config merge and deterministic serialization semantics.
- `src/snapshot/image_export/service.rs`: standalone export wiring.
- `src/snapshot/repository/backends/oss/repository.rs`: rootfs metadata wiring.
- `src/snapshot/repository/backends/common/acr/publisher.rs`: attached drives must continue to receive `None` and use the minimal config.

Compatibility risk: published config/manifest digests change for snapshots that previously had non-default runtime metadata. The existing conflict protection intentionally prevents overwriting old tags.

`StartupCommand` remains snapshot metadata only; it is intentionally not inferred back into OCI `Entrypoint` or `Cmd`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
