### PR TITLE
fix(gateway): proxy sandbox-routed envd metrics requests

### DIFF
--- a/services/gateway/internal/metrics.go
+++ b/services/gateway/internal/metrics.go
@@ -114,12 +114,12 @@ func setGatewayRouteSource(w http.ResponseWriter, source routeSource) {
 
 func (s *Server) instrumentGatewayHTTP(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/metrics" || s.isLocalGatewayHealthRequest(r) {
+		if s.isLocalGatewayEndpointRequest(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
-		// A sandbox-routed /health request is user traffic, so keep it
-		// instrumented like any other proxy call.
+		// Sandbox-routed /health and /metrics requests are user traffic, so
+		// keep them instrumented like any other proxy call.
 
 		method := gatewayMethodLabel(r.Method)
 		route := gatewayRouteLabel(r.URL.Path)
@@ -132,8 +132,8 @@ func (s *Server) instrumentGatewayHTTP(next http.Handler) http.Handler {
 	})
 }
 
-func (s *Server) isLocalGatewayHealthRequest(r *http.Request) bool {
-	if r.URL.Path != "/health" || hasProxyRoutingHeaders(r.Header) {
+func (s *Server) isLocalGatewayEndpointRequest(r *http.Request) bool {
+	if (r.URL.Path != "/health" && r.URL.Path != "/metrics") || hasProxyRoutingHeaders(r.Header) {
 		return false
 	}
 	hostRoute, hostRouteErr := parseHostRoute(r.Host, s.sandboxProxyDomains)

--- a/services/gateway/internal/metrics_test.go
+++ b/services/gateway/internal/metrics_test.go
@@ -2,8 +2,10 @@ package gateway
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestGatewayRouteLabelIncludesV2Sandboxes(t *testing.T) {
@@ -35,6 +37,66 @@ func TestStatusRecorderRouteSourceLabel(t *testing.T) {
 	setGatewayRouteSource(recorder, routeSourceHost)
 	if got := recorder.routeSourceLabel(); got != string(routeSourceHost) {
 		t.Fatalf("routeSourceLabel() = %q, want %q", got, string(routeSourceHost))
+	}
+}
+
+func TestInstrumentGatewayHTTPSkipsOnlyLocalEndpoints(t *testing.T) {
+	server := newTestServer(
+		t,
+		stubSchedulerClient{},
+		time.Second,
+		1024,
+		withSandboxProxyDomains("sandbox-proxy.example.invalid"),
+	)
+
+	tests := []struct {
+		name        string
+		path        string
+		host        string
+		sandboxID   string
+		targetPort  string
+		wantWrapped bool
+	}{
+		{name: "local health", path: "/health"},
+		{name: "local metrics", path: "/metrics"},
+		{
+			name:        "header-routed metrics",
+			path:        "/metrics",
+			sandboxID:   "sbx-metrics",
+			targetPort:  "49983",
+			wantWrapped: true,
+		},
+		{
+			name:        "host-routed metrics",
+			path:        "/metrics",
+			host:        "49983-sbx-metrics.sandbox-proxy.example.invalid",
+			wantWrapped: true,
+		},
+		{name: "ordinary gateway route", path: "/sandboxes", wantWrapped: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := false
+			handler := server.instrumentGatewayHTTP(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, wrapped = w.(*statusRecorder)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.host != "" {
+				req.Host = tt.host
+			}
+			if tt.sandboxID != "" {
+				req.Header.Set(headerSandboxID, tt.sandboxID)
+			}
+			if tt.targetPort != "" {
+				req.Header.Set(headerTargetPort, tt.targetPort)
+			}
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+			if wrapped != tt.wantWrapped {
+				t.Fatalf("instrumentation wrapper present = %t, want %t", wrapped, tt.wantWrapped)
+			}
+		})
 	}
 }
 

--- a/services/gateway/internal/server.go
+++ b/services/gateway/internal/server.go
@@ -94,11 +94,7 @@ func (s *Server) Handler() http.Handler {
 	// decoding %2F → / and issuing 301 redirects), which breaks proxy
 	// forwarding of percent-encoded path segments such as /files/%2F.
 	core := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/metrics" {
-			http.NotFound(w, r)
-			return
-		}
-		if r.URL.Path == "/health" {
+		if r.URL.Path == "/health" || r.URL.Path == "/metrics" {
 			hostRoute, hostRouteErr := parseHostRoute(r.Host, s.sandboxProxyDomains)
 			if hostRoute != nil || hostRouteErr != nil {
 				s.handleProxy(w, r)
@@ -113,8 +109,15 @@ func (s *Server) Handler() http.Handler {
 				s.handleProxy(w, r)
 				return
 			}
-			// Keep load balancer health checks local when they are not sandbox-routed.
-			w.WriteHeader(http.StatusNoContent)
+			if r.URL.Path == "/health" {
+				// Keep load balancer health checks local when they are not sandbox-routed.
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				// Gateway Prometheus metrics use the separate metrics listener. Keep
+				// this path unavailable on the public HTTP listener unless it is
+				// explicitly routed to a sandbox.
+				http.NotFound(w, r)
+			}
 			return
 		}
 		s.handleProxy(w, r)

--- a/services/gateway/internal/server_test.go
+++ b/services/gateway/internal/server_test.go
@@ -1361,6 +1361,22 @@ func TestFlushInterval(t *testing.T) {
 	}
 }
 
+func TestMetricsEndpointReturnsNotFoundWithoutProxyRouting(t *testing.T) {
+	server := newTestServer(t, stubSchedulerClient{}, time.Second, 1024)
+	gatewayServer := httptest.NewServer(server.Handler())
+	defer gatewayServer.Close()
+
+	resp, err := http.Get(gatewayServer.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("gateway metrics request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("gateway metrics status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
 func TestHealthEndpointReturnsGatewayHealthWithoutProxyHeaders(t *testing.T) {
 	server := newTestServer(t, stubSchedulerClient{}, time.Second, 1024)
 	gatewayServer := httptest.NewServer(server.Handler())
@@ -1382,14 +1398,14 @@ func TestHealthEndpointReturnsGatewayHealthWithoutProxyHeaders(t *testing.T) {
 	}
 }
 
-func TestHealthEndpointWithSandboxHeadersProxiesToSandbox(t *testing.T) {
+func TestHealthAndMetricsEndpointsWithSandboxHeadersProxyToSandbox(t *testing.T) {
 	type upstreamRequestSnapshot struct {
 		path         string
 		targetPort   string
 		forwardedURI string
 	}
 
-	requests := make(chan upstreamRequestSnapshot, 1)
+	requests := make(chan upstreamRequestSnapshot, 2)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests <- upstreamRequestSnapshot{
 			path:         r.URL.Path,
@@ -1402,7 +1418,7 @@ func TestHealthEndpointWithSandboxHeadersProxiesToSandbox(t *testing.T) {
 
 	server := newTestServer(t, stubSchedulerClient{
 		lookupNodeFunc: func(_ context.Context, req *schedulerv1.LookupNodeRequest, _ ...grpc.CallOption) (*schedulerv1.LookupNodeResponse, error) {
-			if req.GetSandboxId() != "sbx-health" {
+			if req.GetSandboxId() != "sbx-service" {
 				return nil, fmt.Errorf("unexpected sandbox id lookup: %q", req.GetSandboxId())
 			}
 			return &schedulerv1.LookupNodeResponse{
@@ -1417,65 +1433,73 @@ func TestHealthEndpointWithSandboxHeadersProxiesToSandbox(t *testing.T) {
 	gatewayServer := httptest.NewServer(server.Handler())
 	defer gatewayServer.Close()
 
-	req, err := http.NewRequest(http.MethodGet, gatewayServer.URL+"/health", nil)
-	if err != nil {
-		t.Fatalf("build health proxy request failed: %v", err)
-	}
-	req.Header.Set(headerSandboxID, "sbx-health")
-	req.Header.Set(headerTargetPort, "49983")
+	for _, path := range []string{"/health", "/metrics"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, gatewayServer.URL+path, nil)
+			if err != nil {
+				t.Fatalf("build proxy request failed: %v", err)
+			}
+			req.Header.Set(headerSandboxID, "sbx-service")
+			req.Header.Set(headerTargetPort, "49983")
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("health proxy request failed: %v", err)
-	}
-	defer resp.Body.Close()
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("proxy request failed: %v", err)
+			}
+			defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusNoContent {
-		t.Fatalf("health proxy status = %d, want %d", resp.StatusCode, http.StatusNoContent)
-	}
+			if resp.StatusCode != http.StatusNoContent {
+				t.Fatalf("proxy status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+			}
 
-	upstreamReq := <-requests
-	if upstreamReq.path != "/proxy/health" {
-		t.Fatalf("upstream path = %q, want %q", upstreamReq.path, "/proxy/health")
-	}
-	if upstreamReq.targetPort != "49983" {
-		t.Fatalf("target port header = %q, want %q", upstreamReq.targetPort, "49983")
-	}
-	if upstreamReq.forwardedURI != "/health" {
-		t.Fatalf("X-Forwarded-URI = %q, want %q", upstreamReq.forwardedURI, "/health")
+			upstreamReq := <-requests
+			if upstreamReq.path != "/proxy"+path {
+				t.Fatalf("upstream path = %q, want %q", upstreamReq.path, "/proxy"+path)
+			}
+			if upstreamReq.targetPort != "49983" {
+				t.Fatalf("target port header = %q, want %q", upstreamReq.targetPort, "49983")
+			}
+			if upstreamReq.forwardedURI != path {
+				t.Fatalf("X-Forwarded-URI = %q, want %q", upstreamReq.forwardedURI, path)
+			}
+		})
 	}
 }
 
-func TestHealthEndpointWithProxyHeadersMissingSandboxIDReturnsBadRequest(t *testing.T) {
+func TestHealthAndMetricsEndpointsWithProxyHeadersMissingSandboxIDReturnBadRequest(t *testing.T) {
 	server := newTestServer(t, stubSchedulerClient{}, time.Second, 1024)
 	gatewayServer := httptest.NewServer(server.Handler())
 	defer gatewayServer.Close()
 
-	req, err := http.NewRequest(http.MethodGet, gatewayServer.URL+"/health", nil)
-	if err != nil {
-		t.Fatalf("build malformed health proxy request failed: %v", err)
-	}
-	req.Header.Set(headerTargetPort, "49983")
+	for _, path := range []string{"/health", "/metrics"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, gatewayServer.URL+path, nil)
+			if err != nil {
+				t.Fatalf("build malformed proxy request failed: %v", err)
+			}
+			req.Header.Set(headerTargetPort, "49983")
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("malformed health proxy request failed: %v", err)
-	}
-	defer resp.Body.Close()
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("malformed proxy request failed: %v", err)
+			}
+			defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("malformed health proxy status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("malformed proxy status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+			}
+		})
 	}
 }
 
-func TestHealthEndpointWithHostRoutingProxiesToSandbox(t *testing.T) {
+func TestHealthAndMetricsEndpointsWithHostRoutingProxyToSandbox(t *testing.T) {
 	type upstreamRequestSnapshot struct {
 		path       string
 		sandboxID  string
 		targetPort string
 	}
 
-	requests := make(chan upstreamRequestSnapshot, 1)
+	requests := make(chan upstreamRequestSnapshot, 2)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests <- upstreamRequestSnapshot{
 			path:       r.URL.Path,
@@ -1488,7 +1512,7 @@ func TestHealthEndpointWithHostRoutingProxiesToSandbox(t *testing.T) {
 
 	server := newTestServer(t, stubSchedulerClient{
 		lookupNodeFunc: func(_ context.Context, req *schedulerv1.LookupNodeRequest, _ ...grpc.CallOption) (*schedulerv1.LookupNodeResponse, error) {
-			if req.GetSandboxId() != "sbx-health" {
+			if req.GetSandboxId() != "sbx-service" {
 				return nil, fmt.Errorf("unexpected sandbox id lookup: %q", req.GetSandboxId())
 			}
 			return &schedulerv1.LookupNodeResponse{
@@ -1502,31 +1526,35 @@ func TestHealthEndpointWithHostRoutingProxiesToSandbox(t *testing.T) {
 	gatewayServer := httptest.NewServer(server.Handler())
 	defer gatewayServer.Close()
 
-	req, err := http.NewRequest(http.MethodGet, gatewayServer.URL+"/health", nil)
-	if err != nil {
-		t.Fatalf("build health request failed: %v", err)
-	}
-	req.Host = "40988-sbx-health.sandbox-proxy.example.invalid"
+	for _, path := range []string{"/health", "/metrics"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, gatewayServer.URL+path, nil)
+			if err != nil {
+				t.Fatalf("build host-routed request failed: %v", err)
+			}
+			req.Host = "40988-sbx-service.sandbox-proxy.example.invalid"
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("host-routed health request failed: %v", err)
-	}
-	defer resp.Body.Close()
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("host-routed request failed: %v", err)
+			}
+			defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusAccepted {
-		t.Fatalf("health status = %d, want %d", resp.StatusCode, http.StatusAccepted)
-	}
+			if resp.StatusCode != http.StatusAccepted {
+				t.Fatalf("proxy status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+			}
 
-	upstreamReq := <-requests
-	if upstreamReq.path != "/proxy/health" {
-		t.Fatalf("upstream path = %q, want %q", upstreamReq.path, "/proxy/health")
-	}
-	if upstreamReq.sandboxID != "sbx-health" {
-		t.Fatalf("sandbox routing header = %q, want %q", upstreamReq.sandboxID, "sbx-health")
-	}
-	if upstreamReq.targetPort != "40988" {
-		t.Fatalf("target port header = %q, want 40988", upstreamReq.targetPort)
+			upstreamReq := <-requests
+			if upstreamReq.path != "/proxy"+path {
+				t.Fatalf("upstream path = %q, want %q", upstreamReq.path, "/proxy"+path)
+			}
+			if upstreamReq.sandboxID != "sbx-service" {
+				t.Fatalf("sandbox routing header = %q, want %q", upstreamReq.sandboxID, "sbx-service")
+			}
+			if upstreamReq.targetPort != "40988" {
+				t.Fatalf("target port header = %q, want 40988", upstreamReq.targetPort)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

- Allow exact `/metrics` requests carrying sandbox routing headers to follow the existing Gateway -> runtime node -> sandbox proxy path.
- Allow host-based sandbox proxy domains to route `/metrics` to the selected sandbox port.
- Keep unrouted `/metrics` unavailable on the Gateway public HTTP listener.
- Include sandbox-routed `/metrics` requests in Gateway HTTP instrumentation while continuing to skip the local reserved endpoint.

## Why

The Gateway currently returns 404 for every exact `/metrics` request before it parses host routing, sandbox headers, or scheduler bindings. This blocks the existing envd `GET /metrics` endpoint even when the caller supplies a valid sandbox ID and target port.

The runtime node proxy already supports the remaining path: the Gateway prefixes the request as `/proxy/metrics`, and the node strips `/proxy` before forwarding it to the sandbox interaction IP and requested port.

## Related issue

Closes #151

Related but not equivalent: #5 tracks the unimplemented E2B sandbox metrics API. This PR only fixes generic proxy access to the existing raw envd endpoint.

## Scope and non-goals

Included:

- Gateway classification for exact `/health` and `/metrics` reserved paths.
- Header-based and host-based sandbox routing for `/metrics`.
- Stable local and malformed-request behavior.
- Gateway HTTP instrumentation classification.

Not included:

- E2B `GET /sandboxes/{sandboxID}/metrics` or aggregate sandbox metrics endpoints.
- Changes to envd, scheduler APIs, node proxy behavior, or Prometheus listener configuration.
- New authentication, configuration, or generated protocol surface.

## Design and behavior changes

For exact `/health` and `/metrics`, the Gateway now resolves the routing boundary before choosing local behavior:

```text
sandbox headers or proxy host
  -> LookupNode
  -> runtime node /proxy/{path}
  -> sandbox service on the requested port

no sandbox route
  -> /health: 204 from the Gateway
  -> /metrics: 404 from the Gateway public HTTP listener
```

A routing header set that omits the sandbox ID continues to return 400. Invalid host-based routes continue through the existing proxy error mapping.

Gateway Prometheus metrics remain on the separate metrics listener, default `:9102`; this PR does not expose them from the public HTTP listener.

## Compatibility and operations

- Public API or generated protocol: no schema or generated-code changes.
- Configuration or defaults: unchanged.
- Snapshot manifest, artifact layout, or storage format: unchanged.
- Upgrade and rollback: behavior-only Gateway change; rollback restores the previous unconditional 404.
- Host requirements, permissions, ports, or dependencies: unchanged.

## Validation

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [x] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
go test ./gateway/internal
ok   agentenv/services/gateway/internal

make -C services test
PASS: gateway and scheduler packages

make -C services fmt-check
PASS

make -C services vet
PASS

git diff --check
PASS
```

Skipped checks and reasons:

- Rust formatting, clippy, unit, and integration checks: no Rust code changed.
- Generated clients/server: no OpenAPI or protobuf source changed.
- Documentation: existing proxy documentation already states that header-routed and host-routed sandbox requests forward their original paths; this fix makes `/metrics` conform to that contract.
- Benchmarks: request classification adds no new I/O or algorithmic path.

## Risks and reviewer notes

The main compatibility boundary is preserving the reserved local endpoints. Tests verify:

- header-routed `/health` and `/metrics` reach `/proxy/health` and `/proxy/metrics` on the selected runtime node;
- host-routed `/health` and `/metrics` inject the sandbox ID and target port;
- unrouted `/metrics` remains 404;
- target-port-only `/health` and `/metrics` remain 400;
- only local `/health` and `/metrics` bypass Gateway HTTP instrumentation.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.