### PR TITLE
fix(api): accept allowInternetAccess as an alias so isolation requests can't silently fail open

### DIFF
--- a/src/api/generated/src/models.rs
+++ b/src/api/generated/src/models.rs
@@ -2874,7 +2874,13 @@ pub struct NewSandbox {
     pub secure: Option<bool>,
 
     /// Allow sandbox to access the internet. When set to false, it behaves the same as specifying denyOut to 0.0.0.0/0 in the network config.
-    #[serde(rename = "allow_internet_access")]
+    // `allow_internet_access` stays canonical, matching the E2B NewSandbox
+    // contract. The alias additionally accepts `allowInternetAccess` — the
+    // spelling SandboxDetail returns and NewColdSandbox takes — because an
+    // unrecognised key here is silently dropped, yielding
+    // BaseSandboxNetworkPolicy::Default (open) when the caller asked for Deny.
+    // Manual patch: preserve on regeneration.
+    #[serde(rename = "allow_internet_access", alias = "allowInternetAccess")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_internet_access: Option<bool>,
 
@@ -5912,7 +5918,9 @@ pub struct SandboxNetworkUpdateConfig {
     pub deny_out: Option<Vec<String>>,
 
     /// Allow sandbox to access the internet. When set to false, it behaves the same as specifying denyOut to 0.0.0.0/0 in the network config.
-    #[serde(rename = "allow_internet_access")]
+    // Same alias as NewSandbox so both endpoints accept both spellings.
+    // Manual patch: preserve on regeneration.
+    #[serde(rename = "allow_internet_access", alias = "allowInternetAccess")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_internet_access: Option<bool>,
 }

--- a/src/api/impls/sandbox.rs
+++ b/src/api/impls/sandbox.rs
@@ -1498,4 +1498,42 @@ mod tests {
 
         assert_eq!(policy, SandboxNetworkPolicy::default());
     }
+
+    // Regression: the generated NewSandbox model renamed this field to
+    // "allow_internet_access" while the spec (and the aenv CLI) send
+    // "allowInternetAccess", so POST /sandboxes silently dropped it and
+    // sandboxes created with --no-internet came up with an open base policy.
+    #[test]
+    fn new_sandbox_accepts_camel_case_allow_internet_access() {
+        let body: models::NewSandbox = serde_json::from_str(
+            r#"{"templateID": "tpl", "allowInternetAccess": false,
+                "network": {"allowOut": ["198.51.100.7"]}}"#,
+        )
+        .expect("camelCase allowInternetAccess must deserialize");
+        assert_eq!(body.allow_internet_access, Some(false));
+
+        let policy = network_policy_from_create(body.allow_internet_access, body.network.as_ref())
+            .expect("policy from create");
+        assert_eq!(policy.base_policy, BaseSandboxNetworkPolicy::Deny);
+        assert_eq!(policy.egress.allowed_cidrs, ["198.51.100.7/32"]);
+    }
+
+    #[test]
+    fn new_sandbox_still_accepts_snake_case_allow_internet_access() {
+        let body: models::NewSandbox =
+            serde_json::from_str(r#"{"templateID": "tpl", "allow_internet_access": true}"#)
+                .expect("legacy snake_case spelling must keep deserializing");
+        assert_eq!(body.allow_internet_access, Some(true));
+    }
+
+    #[test]
+    fn network_update_accepts_both_allow_internet_access_spellings() {
+        let snake: models::SandboxNetworkUpdateConfig =
+            serde_json::from_str(r#"{"allow_internet_access": false}"#).unwrap();
+        assert_eq!(snake.allow_internet_access, Some(false));
+
+        let camel: models::SandboxNetworkUpdateConfig =
+            serde_json::from_str(r#"{"allowInternetAccess": false}"#).unwrap();
+        assert_eq!(camel.allow_internet_access, Some(false));
+    }
 }


### PR DESCRIPTION
Follows the direction you suggested in #156: `allow_internet_access` stays canonical on `NewSandbox` for E2B compatibility, and `allowInternetAccess` is accepted as a serde alias. Nothing is renamed and no existing client changes behaviour.

You were right that the field name is intentional — I checked the E2B spec you linked and it has the same split (`NewSandbox` takes snake_case, `SandboxDetail` returns camelCase), so AgentENV is mirroring the contract correctly.

### What this fixes

The residual problem is what happens when a caller sends the *other* spelling. serde drops the unknown key, so the field arrives as `None`; `base_policy_from_allow_internet_access` maps `None` to `BaseSandboxNetworkPolicy::Default` rather than `Deny`, and the sandbox is created with unrestricted egress after isolation was explicitly requested. Nothing rejects the request and nothing logs it.

`GET /sandboxes/{id}` then reports `allowInternetAccess: null`, which reads as "never set" rather than "your setting was discarded" — so it isn't obvious from the readback either.

Callers land on the wrong spelling because the contract is internally inconsistent: `allowInternetAccess` is what the response hands back and what `NewColdSandbox` accepts. The alias closes that trap without touching the canonical name.

There's a second-order effect worth noting: `allowOut` domain rules only arm under a `Deny` base policy, so a create combining `allowInternetAccess: false` with domain rules produced a sandbox with no egress restriction at all — neither the deny nor the allowlist.

### Changes

- `NewSandbox`: `#[serde(rename = "allow_internet_access", alias = "allowInternetAccess")]`
- `SandboxNetworkUpdateConfig`: same alias, so both endpoints behave alike
- Three regression tests: camelCase and snake_case on create, both spellings on update, and `Deny` base-policy propagation from a camelCase create body

Both model edits are in a generated file and carry comments so a regeneration doesn't silently revert them. If you'd rather express this in `openapi.yml` and regenerate — which is the more durable fix, and what you hinted at — I'm happy to close this in favour of that; the tests would still be worth keeping either way.

### Not addressed here

Whether an unrecognised field in a network-policy body should be rejected outright rather than ignored. `deny_unknown_fields` on these two models would turn this whole class of mistake into a 4xx instead of an open sandbox, and stays E2B-compatible since conforming clients only send known fields. It's a behaviour change, so it seemed wrong to bundle it — raised separately in #156 if you think it's worth pursuing.

Closes #156 if you take this approach; happy to adjust or withdraw.
