### PR TITLE
fix(overlaybd): clear cache bitmap before destructive eviction steps

### DIFF
--- a/storage/overlaybd/src/backend/cache/full_file_cache/cache_entry.rs
+++ b/storage/overlaybd/src/backend/cache/full_file_cache/cache_entry.rs
@@ -313,10 +313,17 @@ impl CacheEntry {
     /// Uses `fallocate(PUNCH_HOLE | KEEP_SIZE)` to release disk blocks and
     /// page cache. This avoids munmap/remap while still freeing resources.
     pub(crate) async fn evict_all_blocks(&self) -> Result<u64> {
-        // Hold the write side across metadata removal, hole punching, and
-        // bitmap clearing so no refill can publish into the entry afterward.
+        // Hold the write side across bitmap clearing, metadata removal, and
+        // hole punching so no refill can publish into the entry afterward.
         let _barrier = self.refill_eviction_barrier.write().await;
         let bytes_before = self.total_cached_bytes();
+
+        // Clear the in-memory bitmap before any destructive filesystem
+        // operation: from here on every read misses and falls back to the
+        // source, so a failure partway can never leave a bitmap that claims
+        // cached data whose blocks are already gone.
+        self.index.write().clear();
+        self.dirty.store(true, Ordering::Relaxed);
 
         // Filesystem operations can block under disk pressure — exactly when
         // eviction runs — so keep them off the async executor.
@@ -324,7 +331,9 @@ impl CacheEntry {
         let data_file = self.data_file.try_clone()?;
         let source_size = self.source_size.load(Ordering::Relaxed);
         tokio::task::spawn_blocking(move || -> Result<()> {
-            // First, remove the on-disk index file.
+            // Remove the on-disk index before punching: a crash after the
+            // punch with meta.bin still present would otherwise reload a
+            // bitmap claiming blocks the punch already released.
             match std::fs::remove_file(&meta_path) {
                 Ok(_) => {}
                 Err(err) if err.raw_os_error() == Some(libc::ENOENT) => {}
@@ -342,8 +351,6 @@ impl CacheEntry {
         })
         .await??;
 
-        self.index.write().clear();
-        self.dirty.store(true, Ordering::Relaxed);
         Ok(bytes_before)
     }
 

--- a/storage/overlaybd/src/backend/cache/tests.rs
+++ b/storage/overlaybd/src/backend/cache/tests.rs
@@ -2620,3 +2620,54 @@ async fn test_concurrent_read_during_capacity_eviction() {
         }
     }
 }
+
+/// Regression for the 2026-08-11 cache-poison incident: eviction must clear
+/// the in-memory bitmap before any destructive filesystem operation, so a
+/// failed eviction can never leave a bitmap claiming blocks whose data is
+/// already gone (which would serve zeroed bytes to every later read).
+#[tokio::test]
+async fn test_eviction_clears_bitmap_before_destroying_data() {
+    let tmp = tempdir().expect("create tempdir");
+    let mut options = test_options(tmp.path());
+    options.block_size = 4096;
+    let backend = FileCacheBackend::with_options(options)
+        .await
+        .expect("backend");
+    let payload = uniform_char_random_data(4096, 31);
+    let source = Arc::new(MockSource::new(payload.clone(), Duration::ZERO));
+    let file = backend
+        .open_file_with_source_size("evict-order", source, payload.len() as u64)
+        .await
+        .expect("open cached file");
+    assert_eq!(
+        file.read_at(0, 4096).await.expect("warm read").as_ref(),
+        payload.as_slice()
+    );
+
+    // Force eviction to fail at metadata removal: meta.bin is replaced by a
+    // directory (fresh entries have no meta.bin until the first checkpoint).
+    let entry = backend
+        .get_cache_entry(&super::cache_key_digest("evict-order"))
+        .expect("entry");
+    let meta_path = entry.paths.meta_path.clone();
+    let _ = std::fs::remove_file(&meta_path);
+    std::fs::create_dir(&meta_path).expect("replace meta.bin with a directory");
+    entry
+        .evict_all_blocks()
+        .await
+        .expect_err("eviction must fail when meta removal fails");
+
+    assert!(
+        entry.index.read().is_empty(),
+        "a failed eviction must leave the in-memory bitmap cleared"
+    );
+    std::fs::remove_dir(&meta_path).expect("cleanup meta directory");
+    assert_eq!(
+        file.read_at(0, 4096)
+            .await
+            .expect("read after failed eviction")
+            .as_ref(),
+        payload.as_slice(),
+        "reads after a failed eviction must fall back to the source"
+    );
+}


### PR DESCRIPTION
## What

Reorder `CacheEntry::evict_all_blocks`: clear the in-memory block bitmap **before** removing `meta.bin` and hole-punching the data file. Pure ordering change; no new logic.

## Why

`evict_all_blocks` currently removes `meta.bin`, hole-punches the data file (its contents become zeros), and only then clears the in-memory bitmap. If the operation exits unexpectedly between the punch and the bitmap clear — e.g. a filesystem error under disk pressure, or a panic/cancellation in the blocking task — the entry is left with a bitmap that still claims blocks are cached while its data file reads back as all zeros. Every later read then hits the bitmap and serves zeros without ever falling back to the source (`header magic/type don't match` at the overlaybd layer), with no self-heal until process restart.

Clearing the bitmap first makes every partial-failure mode leave a benign "empty bitmap + intact data" state, where reads simply miss and refetch from the source.

## Related issue

No tracking issue. Found during the review of the 2026-08-11 production cache-poison incident; related to #131 (cache-directory isolation). This PR is defense-in-depth, not the incident's root-cause fix.

## Scope and non-goals

- In scope: the `evict_all_blocks` ordering change and one discriminating regression test.
- Out of scope: refill-time content validation, open-time entry-consistency validation, and self-heal retry on header-verification failure (follow-up PRs). No metrics/alerting changes.

## Design and behavior changes

Failure/crash semantics only: a mid-eviction failure now leaves "empty bitmap + intact data" (miss-and-refetch) instead of "marked bitmap + zeroed data" (poison). The successful eviction path is behaviorally unchanged.

## Compatibility and operations

- Public API or generated protocol: N/A
- Configuration or defaults: N/A
- Snapshot manifest, artifact layout, or storage format: N/A (cache entries are rebuildable artifacts)
- Upgrade and rollback: no migration; existing on-disk cache entries load as before
- Host requirements, permissions, ports, or dependencies: N/A

## Validation

- [x] `make fmt` (equivalent: `cargo fmt --check` passed)
- [x] `make clippy` (`cargo clippy -p overlaybd --all-targets -- -D warnings` passed)
- [x] Relevant unit tests: `cargo test -p overlaybd --lib -- backend::cache` — 56 passed / 0 failed, including the new regression test `test_eviction_clears_bitmap_before_destroying_data`, which fails on the pre-fix code
- [ ] `make test-unit` (not run in full; change is confined to the overlaybd cache eviction path and covered by the crate-level suite)
- [ ] `make -C services test` (no `services/` changes)
- [ ] Benchmarks (no hot-path changes; ordering-only change on the eviction cold path)

Skipped checks and reasons: KVM integration tests not run — the change does not touch device/VM paths; validation was performed on a Linux test host.

## Risks and reviewer notes

- Very low risk: ordering change only; success-path semantics unchanged.
- Review focus: `evict_all_blocks` in `storage/overlaybd/src/backend/cache/full_file_cache/cache_entry.rs`; regression test at the end of `tests.rs`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests (discriminating regression test that fails pre-fix).
- [x] Logs and examples contain no credentials, tokens, or private registry information.
