### PR TITLE
experiment(cli): evaluate AgentENV-owned completion hook

### DIFF
--- a/crates/aenv/src/client/mod.rs
+++ b/crates/aenv/src/client/mod.rs
@@ -23,10 +23,24 @@ impl Client {
     }
 
     pub fn new(url: &str, api_key: &str) -> Result<Self> {
+        Self::new_with_timeouts(
+            url,
+            api_key,
+            Duration::from_secs(5),
+            Duration::from_secs(120),
+        )
+    }
+
+    pub fn new_with_timeouts(
+        url: &str,
+        api_key: &str,
+        connect_timeout: Duration,
+        request_timeout: Duration,
+    ) -> Result<Self> {
         let base = url.trim_end_matches('/').to_string();
         let agent = ureq::AgentBuilder::new()
-            .timeout_connect(Duration::from_secs(5))
-            .timeout(Duration::from_secs(120))
+            .timeout_connect(connect_timeout)
+            .timeout(request_timeout)
             .build();
         Ok(Self {
             agent,

--- a/crates/aenv/src/commands/completion.rs
+++ b/crates/aenv/src/commands/completion.rs
@@ -5,6 +5,10 @@ use clap::CommandFactory;
 use clap::ValueEnum;
 use clap_complete::Shell as ClapShell;
 use std::io::Write;
+use std::time::Duration;
+
+const DYNAMIC_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
+const DYNAMIC_REQUEST_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Shell to generate completion for.
 ///
@@ -32,6 +36,88 @@ pub struct Args {
     pub shell: Shell,
 }
 
+#[derive(ClapArgs)]
+pub struct CompleteArgs {
+    /// Zero-based cursor position in the shell word list.
+    #[arg(long)]
+    pub index: usize,
+    /// The command line words, including `aenv` as the first word.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+    pub words: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SandboxStateFilter {
+    Running,
+    Paused,
+    Active,
+}
+
+pub fn run_dynamic(args: CompleteArgs) -> Result<()> {
+    let Some((filter, prefix)) = dynamic_request(&args.words, args.index) else {
+        return Ok(());
+    };
+
+    let Ok(credentials) = crate::auth::load() else {
+        return Ok(());
+    };
+    let Ok(client) = crate::client::Client::new_with_timeouts(
+        &credentials.url,
+        &credentials.api_key,
+        DYNAMIC_CONNECT_TIMEOUT,
+        DYNAMIC_REQUEST_TIMEOUT,
+    ) else {
+        return Ok(());
+    };
+    let Ok(mut sandboxes) = client.list_sandboxes() else {
+        return Ok(());
+    };
+
+    sandboxes.sort_by(|left, right| left.sandbox_id.cmp(&right.sandbox_id));
+    for sandbox in sandboxes {
+        if state_matches(filter, sandbox.state.as_deref()) && sandbox.sandbox_id.starts_with(prefix)
+        {
+            println!("{}", sandbox.sandbox_id);
+        }
+    }
+    Ok(())
+}
+
+fn state_matches(filter: SandboxStateFilter, state: Option<&str>) -> bool {
+    match filter {
+        SandboxStateFilter::Running => state == Some("running"),
+        SandboxStateFilter::Paused => state == Some("paused"),
+        SandboxStateFilter::Active => matches!(state, Some("running" | "paused")),
+    }
+}
+
+fn dynamic_request(words: &[String], index: usize) -> Option<(SandboxStateFilter, &str)> {
+    if words.first().map(String::as_str) != Some("aenv") || index >= words.len() {
+        return None;
+    }
+    let current = words[index].as_str();
+    let command = words.get(1).map(String::as_str)?;
+    let filter = match command {
+        "pause" | "exec" | "upload" | "download" | "timeout" if index == 2 => {
+            SandboxStateFilter::Running
+        }
+        "resume" if index == 2 => SandboxStateFilter::Paused,
+        "connect" | "cn" | "delete" | "rm" if index == 2 => SandboxStateFilter::Active,
+        "snapshot" if words.get(2).map(String::as_str) == Some("create") && index == 3 => {
+            SandboxStateFilter::Running
+        }
+        "snapshot"
+            if words.get(2).map(String::as_str) == Some("list")
+                && index > 3
+                && words[..index].last().map(String::as_str) == Some("--sandbox-id") =>
+        {
+            SandboxStateFilter::Active
+        }
+        _ => return None,
+    };
+    Some((filter, current))
+}
+
 /// Generate a completion script for the requested shell and write it to stdout.
 pub fn run(args: Args) -> Result<()> {
     write_completion(args.shell, &mut std::io::stdout().lock())
@@ -50,10 +136,57 @@ fn write_completion<W: Write>(shell: Shell, out: &mut W) -> Result<()> {
     let mut cmd = crate::Cli::command();
     let mut script = Vec::new();
     clap_complete::generate(ClapShell::from(shell), &mut cmd, "aenv", &mut script);
+    script.extend_from_slice(dynamic_wrapper(shell).as_bytes());
     match out.write_all(&script).and_then(|_| out.flush()) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(err).context("writing completion script to stdout"),
+    }
+}
+
+fn dynamic_wrapper(shell: Shell) -> &'static str {
+    match shell {
+        Shell::Bash => {
+            r#"
+
+_aenv_dynamic() {
+    local dynamic
+    dynamic=$(command aenv __complete --index "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null)
+    if [[ -n "$dynamic" ]]; then
+        COMPREPLY=( $(compgen -W "$dynamic" -- "${COMP_WORDS[COMP_CWORD]}") )
+        return
+    fi
+    _aenv "$@"
+}
+complete -o nospace -o bashdefault -o nosort -F _aenv_dynamic aenv
+"#
+        }
+        Shell::Zsh => {
+            r#"
+
+_aenv_dynamic() {
+    local -a dynamic
+    dynamic=("${(@f)$(command aenv __complete --index $((CURRENT - 1)) -- "${words[@]}" 2>/dev/null)}")
+    if (( ${#dynamic} )); then
+        _describe 'sandbox' dynamic
+        return
+    fi
+    _aenv "$@"
+}
+compdef _aenv_dynamic aenv
+"#
+        }
+        Shell::Fish => {
+            r#"
+
+function __aenv_dynamic
+    set -l words (commandline -opc)
+    set -a words (commandline -ct)
+    command aenv __complete --index (math (count $words) - 1) -- $words 2>/dev/null
+end
+complete -c aenv -a '(__aenv_dynamic)'
+"#
+        }
     }
 }
 
@@ -225,5 +358,37 @@ mod tests {
                 .contains("writing completion script to stdout"),
             "error should carry completion context; got: {err}"
         );
+    }
+
+    #[test]
+    fn dynamic_request_recognizes_sandbox_positions() {
+        let words = vec!["aenv".into(), "pause".into(), "sb".into()];
+        assert_eq!(
+            dynamic_request(&words, 2),
+            Some((SandboxStateFilter::Running, "sb"))
+        );
+    }
+
+    #[test]
+    fn dynamic_request_supports_active_sandbox_commands() {
+        let words = vec!["aenv".into(), "cn".into(), "sb".into()];
+        assert_eq!(
+            dynamic_request(&words, 2),
+            Some((SandboxStateFilter::Active, "sb"))
+        );
+    }
+
+    #[test]
+    fn dynamic_request_ignores_remote_exec_arguments() {
+        let words = vec!["aenv".into(), "exec".into(), "sb".into(), "echo".into()];
+        assert_eq!(dynamic_request(&words, 3), None);
+    }
+
+    #[test]
+    fn generated_scripts_install_dynamic_adapters() {
+        let bash = generate_for(Shell::Bash);
+        assert!(bash.contains("_aenv_dynamic"));
+        assert!(generate_for(Shell::Zsh).contains("compdef _aenv_dynamic aenv"));
+        assert!(generate_for(Shell::Fish).contains("__aenv_dynamic"));
     }
 }

--- a/crates/aenv/src/main.rs
+++ b/crates/aenv/src/main.rs
@@ -35,6 +35,9 @@ enum Cmd {
     Download(commands::download::Args),
     /// Generate shell completion scripts
     Completion(commands::completion::Args),
+    /// Internal dynamic completion protocol
+    #[command(name = "__complete", hide = true)]
+    Complete(commands::completion::CompleteArgs),
     /// Attach an interactive shell to a running sandbox
     #[command(visible_alias = "cn")]
     Connect(commands::connect::Args),
@@ -69,6 +72,7 @@ fn main() -> Result<()> {
         Cmd::Upload(a) => commands::upload::run(a),
         Cmd::Download(a) => commands::download::run(a),
         Cmd::Completion(a) => commands::completion::run(a),
+        Cmd::Complete(a) => commands::completion::run_dynamic(a),
         Cmd::Connect(a) => commands::connect::run(a),
         Cmd::Pause(a) => commands::pause::run(a),
         Cmd::Resume(a) => commands::resume::run(a),

--- a/docs/superpowers/specs/2026-08-08-aenv-sandbox-completion-design.md
+++ b/docs/superpowers/specs/2026-08-08-aenv-sandbox-completion-design.md
@@ -1,0 +1,93 @@
+# AENV sandbox-ID dynamic completion
+
+## Goal
+
+Add a local-only, first follow-up to merged PR #89: complete sandbox IDs for
+the existing `aenv` CLI without changing the AgentENV server API. Dynamic
+lookup must be fast and invisible on failure; static completion supplied by
+`aenv completion bash|zsh|fish` must remain available in every case.
+
+## Scope
+
+This change completes only sandbox IDs. It deliberately excludes template and
+snapshot names, installer integration, and any server-side completion API.
+
+The completion state policy is centralized rather than embedded in individual
+commands:
+
+| Commands | Eligible sandbox state |
+| --- | --- |
+| `exec`, `upload`, `download`, `pause`, `timeout`, `snapshot create` | `Running` |
+| `resume` | `Paused` |
+| `connect`, `delete`, `snapshot list --sandbox-id` | `Running` or `Paused` |
+
+## Design
+
+`aenv` gains an internal `__complete` command. The command accepts a small,
+versioned request produced by a shell adapter, identifies whether the cursor is
+at a supported sandbox-ID argument, and prints matching candidates. It is not
+documented as a user-facing API.
+
+The command constructs a completion-specific `Client` with short connection
+and total request timeouts. It calls the existing `GET /v2/sandboxes` endpoint,
+filters `ListedSandbox` records by the policy above and by the typed prefix,
+deduplicates IDs, and writes only machine-readable candidates to stdout.
+
+Missing credentials, non-success responses, malformed output, unavailable
+servers, and timeouts produce no candidates and no stderr output. Completion
+must never use the normal CLI client's five-second connect or 120-second total
+timeout.
+
+The generated Bash, Zsh, and Fish static scripts will call the internal command
+only at the supported argument positions. The static generator remains the
+source of truth for all other commands, flags, aliases, enum values, and path
+arguments. Shell-specific glue translates the shared candidate format into each
+shell's candidate/description convention.
+
+## Candidate output
+
+The first version uses tab-separated records:
+
+```text
+<sandbox-id>\t<alias or template ID> (<state>)
+```
+
+The first field is always the inserted value. Shell adapters may ignore the
+description where their completion system does not safely render it.
+
+## Testing
+
+- Unit-test command/argument recognition and the state-policy table.
+- Test prefix filtering, deduplication, stable ordering, and candidate
+  serialization.
+- Use a local mock HTTP server to test successful lookup and every failure
+  fallback. Assert the fallback is empty and writes nothing to stderr.
+- Snapshot-test the generated shell wrappers for Bash, Zsh, and Fish and test
+  that they preserve static completion outside a sandbox-ID position.
+- Run `cargo fmt --all -- --check`, `cargo check -p aenv --bin aenv`, and the
+  focused `aenv` test suite.
+
+## Delivery order
+
+1. Add the isolated policy, lookup, output protocol, and tests.
+2. Add shell adapters for Bash, Zsh, and Fish on top of the shared protocol.
+3. Verify the generated static scripts continue to expose all PR #89 behavior.
+4. In a separate follow-up, handle template/snapshot names and `start --cold`.
+5. In a later follow-up, add installer and uninstaller integration.
+
+## Risks and mitigations
+
+- **Shell integration is the slowest part.** Generated `clap_complete` scripts
+  do not provide a stable dynamic hook. Keep adapters small, assert their
+  generated text in tests, and avoid coupling the core lookup logic to one
+  shell.
+- **Completion can make interactive shells feel broken.** The completion-only
+  client uses sub-second timeouts and suppresses all runtime errors.
+- **Command semantics can drift.** One state-policy table and command-level
+  tests make changes to command applicability explicit.
+
+## Non-goals
+
+- Changing `clap` to its unstable dynamic-completion API.
+- Adding persistent caches or new server endpoints.
+- Editing users' shell startup files.

--- a/docs/superpowers/specs/2026-08-12-aenv-completion-agentenv-hook.md
+++ b/docs/superpowers/specs/2026-08-12-aenv-completion-agentenv-hook.md
@@ -1,0 +1,39 @@
+# AENV CLI Dynamic Completion: AgentENV-Owned Hook
+
+## Summary
+
+This experiment keeps the static completion generator introduced by PR #89 and
+adds a small shell adapter that calls a hidden internal command:
+
+```text
+aenv __complete --index <cursor> -- <shell words...>
+```
+
+The hook reads the existing sandbox list API, filters IDs by the command's
+expected state, and prints one candidate per line. Network errors, missing
+credentials, and unsupported cursor positions are silent so completion never
+breaks the command line.
+
+## Supported dynamic positions
+
+- Running sandbox: `pause`, `exec`, `upload`, `download`, `timeout`, and
+  `snapshot create`
+- Paused sandbox: `resume`
+- Active sandbox (running or paused): `connect`/`cn`, `delete`/`rm`, and
+  `snapshot list --sandbox-id`
+
+The shell-specific adapter is appended to the generated Bash, Zsh, or Fish
+script. Bash and Zsh fall back to the static adapter when the hook returns no
+results; Fish simply contributes no dynamic candidates in that case.
+
+## Why this is an alternative
+
+Unlike the `clap_complete` `unstable-dynamic` experiment, this approach does
+not depend on Clap's unstable shell protocol. The protocol and command shape
+are owned by AgentENV, which makes the implementation easier to inspect and
+extend, but requires maintaining three small shell adapters and the cursor
+interpretation logic.
+
+This is intentionally a parallel design for issue #37. The two branches are
+not intended to be merged together; maintainers can choose the API and
+maintenance trade-off they prefer.


### PR DESCRIPTION
## Summary

This is the second parallel experiment for #37. It keeps the static completion generator and appends Bash/Zsh/Fish adapters that call an AgentENV-owned internal protocol: `aenv __complete`.

## What it adds

- Hidden `aenv __complete --index ... -- <shell words...>` entry point.
- Dynamic candidates backed by the existing sandbox list API.
- State-aware candidates for running, paused, and active sandbox IDs.
- Short completion-specific network timeouts and silent failure behavior.
- Focused tests and a design note.

## Trade-off

The protocol is owned by AgentENV and does not depend on `clap_complete` unstable-dynamic, but AgentENV must maintain cursor parsing plus three shell adapters. Clap still includes the hidden hook in generated command metadata, which is a small maintenance detail to discuss. The companion PR evaluates the upstream unstable dynamic engine. These are alternatives; please review and choose one direction rather than merging both.

## Verification

- `cargo fmt --all`
- `cargo check -p aenv --bin aenv`
- focused completion tests (15 passed)
- generated Bash script and no-credential hook invocation