### PR TITLE
docs: update egress control docs

### DIFF
--- a/docs/src/concepts/sandboxes.md
+++ b/docs/src/concepts/sandboxes.md
@@ -153,14 +153,16 @@ Each sandbox runs in its own network namespace. By default, outbound internet ac
 curl -X POST \
   -H 'X-API-Key: test-key' \
   -H 'Content-Type: application/json' \
-  -d '{"templateID": "my-ubuntu", "allowInternetAccess": false}' \
+  -d '{"templateID": "my-ubuntu", "allow_internet_access": false}' \
   http://127.0.0.1:8000/sandboxes
 ```
 
-For fine-grained egress control, pass a `network` object when creating the sandbox. Allowed entries take precedence over denied entries:
+For fine-grained egress control, pass a `network` object when creating the sandbox. Egress is allow-by-default, and `allowOut` entries take precedence over matching `denyOut` entries. `allowOut` by itself does not create an allowlist: destinations that do not match a deny rule remain reachable.
 
-- `allowOut` — CIDR, IP, or domain patterns
+- `allowOut` — CIDR or IP. Domain patterns are currently not supported.
 - `denyOut` — CIDR or IP
+
+To create an allowlist, deny all traffic and then add the allowed exceptions with `allowOut`. You can deny all traffic explicitly with `denyOut: ["0.0.0.0/0"]`, or use `allow_internet_access: false` together with `allowOut`.
 
 ```bash
 curl -X POST \
@@ -169,7 +171,7 @@ curl -X POST \
   -d '{
     "templateID": "my-ubuntu",
     "network": {
-      "allowOut": ["8.8.8.8/32", "example.com", "*.example.com"],
+      "allowOut": ["8.8.8.8/32", "1.1.1.1/32"],
       "denyOut": ["0.0.0.0/0"]
     }
   }' \
@@ -186,7 +188,7 @@ curl -X PUT \
   http://127.0.0.1:8000/sandboxes/<sandbox-id>/network
 ```
 
-Omitting both fields clears all egress rules.
+Omitting both fields clears all per-sandbox egress rules and restores the default allow behavior.
 
 ---
 


### PR DESCRIPTION
## What

Clarify the egress control document and update stale examples.

## Related issue

Closes #156

## Scope and non-goals

Documentation

## Design and behavior changes

None

## Compatibility and operations

- Public API or generated protocol: N/A
- Configuration or defaults: N/A
- Snapshot manifest, artifact layout, or storage format: N/A
- Upgrade and rollback: N/A
- Host requirements, permissions, ports, or dependencies: N/A

## Validation

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Skipped checks and reasons:

Doc changes only

## Risks and reviewer notes

None

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
