### PR TITLE
docs: add Mermaid diagrams for better readability

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,6 +61,10 @@ jobs:
 
       - uses: taiki-e/install-action@mdbook
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook-mermaid@0.17.0
+
       - name: Build docs
         run: |
           ln -sf ../../src/api/openapi.yml docs/src/openapi.yml

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -11,4 +11,7 @@ build-dir = "book"
 git-repository-url = "https://github.com/kvcache-ai/AgentENV"
 edit-url-template = "https://github.com/kvcache-ai/AgentENV/edit/main/docs/{path}"
 additional-css = ["theme/version-selector.css"]
-additional-js = ["theme/version-selector.js"]
+additional-js = ["theme/version-selector.js", "mermaid-init.js"]
+
+[preprocessor.mermaid]
+command = "mdbook-mermaid"

--- a/docs/mermaid-init.js
+++ b/docs/mermaid-init.js
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+(() => {
+    const mermaidScriptUrl = 'https://cdn.jsdelivr.net/npm/mermaid@11.12.0/dist/mermaid.min.js';
+    const mermaidScriptIntegrity = 'sha384-o+g/BxPwhi0C3RK7oQBxQuNimeafQ3GE/ST4iT2BxVI4Wzt60SH4pq9iXVYujjaS';
+    const darkThemes = ['ayu', 'navy', 'coal'];
+    const lightThemes = ['light', 'rust'];
+
+    const classList = document.getElementsByTagName('html')[0].classList;
+
+    let lastThemeWasLight = true;
+    for (const cssClass of classList) {
+        if (darkThemes.includes(cssClass)) {
+            lastThemeWasLight = false;
+            break;
+        }
+    }
+
+    const initializeMermaid = () => {
+        const theme = lastThemeWasLight ? 'default' : 'dark';
+        window.mermaid.initialize({ startOnLoad: false, theme });
+        window.mermaid.run().catch((error) => {
+            console.error('Failed to render Mermaid diagrams', error);
+        });
+    };
+
+    const mermaidScript = document.createElement('script');
+    mermaidScript.src = mermaidScriptUrl;
+    mermaidScript.integrity = mermaidScriptIntegrity;
+    mermaidScript.crossOrigin = 'anonymous';
+    mermaidScript.onload = initializeMermaid;
+    mermaidScript.onerror = () => {
+        console.error(`Failed to load Mermaid from ${mermaidScriptUrl}`);
+    };
+    document.head.appendChild(mermaidScript);
+
+    // Simplest way to make mermaid re-render the diagrams in the new theme is via refreshing the page
+
+    for (const darkTheme of darkThemes) {
+        const themeButton = document.getElementById(`mdbook-theme-${darkTheme}`);
+        themeButton?.addEventListener('click', () => {
+            if (lastThemeWasLight) {
+                window.location.reload();
+            }
+        });
+    }
+
+    for (const lightTheme of lightThemes) {
+        const themeButton = document.getElementById(`mdbook-theme-${lightTheme}`);
+        themeButton?.addEventListener('click', () => {
+            if (!lastThemeWasLight) {
+                window.location.reload();
+            }
+        });
+    }
+})();

--- a/docs/src/concepts/overview.md
+++ b/docs/src/concepts/overview.md
@@ -4,28 +4,14 @@ AgentENV runs AI agents inside isolated Firecracker microVMs. Each sandbox is a 
 
 ## System Overview
 
-```
-                    ┌──────────────────────────────────────────────────┐
-                    │                  AgentENV Node                   │
-                    │                                                  │
-                    │  ┌──────────┐   ┌──────────────┐                 │
-                    │  │ API      │──>│ Orchestrator │                 │
-                    │  │ (Axum)   │   │ (lifecycle)  │                 │
-                    │  └──────────┘   └──────┬───────┘                 │
-                    │                        │                         │
-                    │              ┌─────────▼───────────┐             │
-                    │              │  Firecracker VM     │             │
-                    │              │                     │             │
-                    │              │  /dev/vda (rootfs)  │             │
-                    │              │  /dev/vdb (extra)   │             │
-                    │              │                     │             │
-                    │              └─────────────────────┘             │
-                    │                        │                         │
-                    │              ┌─────────▼────────────┐            │
-                    │              │  Block Device Layer  │            │
-                    │              │  (overlaybd + ublk)  │            │
-                    │              └──────────────────────┘            │
-                    └──────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph node[AgentENV Node]
+        api["API<br/>(Axum)"] --> orchestrator["Orchestrator<br/>(lifecycle)"]
+        orchestrator --> vm["Firecracker VM<br/>/dev/vda (rootfs)<br/>/dev/vdb (extra)"]
+        vm --> block["Block Device Layer<br/>(overlaybd + ublk)"]
+    end
+    style node fill:transparent,stroke:gray
 ```
 
 ## Request Flow
@@ -54,13 +40,13 @@ AgentENV runs AI agents inside isolated Firecracker microVMs. Each sandbox is a 
 
 For multi-node deployments, a **gateway** and **scheduler** sit in front of multiple AgentENV nodes:
 
-```
-    Client ──HTTP──> Gateway (:8080) ──gRPC──> Scheduler (:9090)
-                        │                          │
-                        │    ┌─────────────────────┘
-                        │    │ node selection / lookup
-                        ▼    ▼
-                   Node A (:8000)    Node B (:8000)
+```mermaid
+flowchart LR
+    client["Client"] -->|HTTP| gateway["Gateway<br/>(:8080)"]
+    gateway -->|gRPC| scheduler["Scheduler<br/>(:9090)"]
+    gateway -->|proxy HTTP| nodeA["Node A<br/>(:8000)"]
+    gateway -->|proxy HTTP| nodeB["Node B<br/>(:8000)"]
+    scheduler -.->|node selection /<br/> lookup result| gateway
 ```
 
 The gateway routes requests by sandbox ID. For new sandboxes, the scheduler picks a node. For existing sandboxes, the scheduler looks up the node that owns it. See [Deployment](../deployment/docker-compose.md) for setup instructions.

--- a/docs/src/concepts/sandboxes.md
+++ b/docs/src/concepts/sandboxes.md
@@ -6,12 +6,20 @@ A sandbox is an isolated Firecracker microVM with its own Linux kernel, filesyst
 
 ## Lifecycle
 
-```
-Creating ──> Running ──> Pausing ──> Paused
-                │                      │
-                ├──> Snapshotting      └──> Resuming ──> Running
-                ├──> Forking
-                └──> Killing
+```mermaid
+stateDiagram-v2
+    [*] --> Creating
+    Creating --> Running
+    Running --> Pausing
+    Pausing --> Paused
+    Paused --> Resuming
+    Resuming --> Running
+    Running --> Snapshotting
+    Snapshotting --> Running
+    Running --> Forking
+    Forking --> Running
+    Running --> Killing
+    Killing --> [*]
 ```
 
 | State | Description |
@@ -157,10 +165,25 @@ curl -X POST \
   http://127.0.0.1:8000/sandboxes
 ```
 
-For fine-grained egress control, pass a `network` object when creating the sandbox. Egress is allow-by-default, and `allowOut` entries take precedence over matching `denyOut` entries. `allowOut` by itself does not create an allowlist: destinations that do not match a deny rule remain reachable.
+For fine-grained egress control, pass a `network` object when creating the sandbox. Within user-configured egress rules, traffic is allow-by-default, and `allowOut` entries take precedence over matching `denyOut` entries. `allowOut` by itself does not create an allowlist: destinations that do not match a deny rule remain reachable.
 
 - `allowOut` — CIDR or IP. Domain patterns are currently not supported.
 - `denyOut` — CIDR or IP
+
+The following diagram illustrates how the rules are evaluated:
+
+```mermaid
+flowchart TD
+    A[Destination packet] --> B{Matches allowOut?}
+    B -->|Yes| C[Allow traffic]
+    B -->|No| D{Matches denyOut?}
+    D -->|Yes| E[Reject traffic]
+    D -->|No| F{"allow_internet_access?"}
+    F -->|Yes| C
+    F -->|No| E
+```
+
+`allowOut` is evaluated before `denyOut` in the user egress chain, so an allowed destination can override an overlapping user-configured deny rule. `allow_internet_access: false` sets the base policy to `Deny`, which appends a catch-all reject after those rules and makes the remaining destinations fail closed. Static internal-network deny rules are evaluated before the user egress chain and cannot be overridden by `allowOut`.
 
 To create an allowlist, deny all traffic and then add the allowed exceptions with `allowOut`. You can deny all traffic explicitly with `denyOut: ["0.0.0.0/0"]`, or use `allow_internet_access: false` together with `allowOut`.
 

--- a/docs/src/internals/architecture.md
+++ b/docs/src/internals/architecture.md
@@ -4,54 +4,27 @@ AgentENV runs AI agents inside isolated, snapshot-capable Firecracker microVMs. 
 
 ## System Overview
 
-```
-                    ┌───────────────────────────────────────────────────────────┐
-                    │                       AgentENV Node                       │
-                    │                                                           │
-                    │  ┌──────────┐   ┌──────────────┐                          │
-                    │  │ API      │──>│ Orchestrator │                          │
-                    │  │ (Axum)   │   │ (lifecycle)  │                          │
-                    │  └──────────┘   └──────┬───────┘                          │
-                    │                        │                                  │
-                    │              ┌─────────▼───────────┐                      │
-                    │              │  Firecracker VM     │                      │
-                    │              │                     │                      │
-                    │              │  /dev/vda (rootfs)  │                      │
-                    │              │  /dev/vdb (extra)───┼───┐                  │
-                    │              │  VM memory ─────────┼───┼──┐               │
-                    │              │                     │   │  │               │
-                    │              └─────────────────────┘   │  │               │
-                    │                                        │  │               │
-                    │    Block device path:                  │  │               │
-                    │              ┌────────────────────────▼──┐│               │
-                    │              │  ublk (/dev/ublkbN)       ││               │
-                    │              │  userspace block device   ││               │
-                    │              └────────────┬──────────────┘│               │
-                    │                           │               │               │
-                    │              ┌─────────────▼─────────────┐│               │
-                    │              │  overlaybd                ││               │
-                    │              │  ┌───────┐ ┌───────┐      ││               │
-                    │              │  │ upper │ │layer 0│ ...  ││               │
-                    │              │  │ (r/w) │ │(r/o)  │      ││               │
-                    │              │  └───────┘ └───────┘      ││               │
-                    │              └───────────────────────────┘│               │
-                    │                                           │               │
-                    │    Memory restore path:                   │               │
-                    │              ┌────────────────────────────▼───┐           │
-                    │              │  ublk (/dev/ublkbM)            │           │
-                    │              │  read-only memory block device │           │
-                    │              │  (shared across same-snapshot  │           │
-                    │              │   sandboxes via refcounting)   │           │
-                    │              └────────────┬───────────────────┘           │
-                    │                           │                               │
-                    │              ┌─────────────▼──────────────┐               │
-                    │              │  overlaybd (mem layers)    │               │
-                    │              │  ┌───────┐ ┌───────┐       │               │
-                    │              │  │snap N │ │snap 0 │ ...   │               │
-                    │              │  │(r/o)  │ │(r/o)  │       │               │
-                    │              │  └───────┘ └───────┘       │               │
-                    │              └────────────────────────────┘               │
-                    └───────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph node[AgentENV Node]
+        direction TB
+        api["API<br/>(Axum)"] --> orchestrator["Orchestrator<br/>(lifecycle)"]
+        orchestrator --> vm["Firecracker VM"]
+        vm --> rootfs["/dev/vda (rootfs)"]
+        rootfs --> ublkN["ublk (/dev/ublkbN)<br/>userspace block device"]
+        ublkN --> overlay["overlaybd"]
+        overlay --> upper["upper<br/>(r/w)"]
+        overlay --> layer0["layer 0, 1, 2, ...<br/>(r/o)"]
+        vm --> extra["/dev/vdb (extra)"]
+        extra --> ublkExtra["ublk device"]
+        ublkExtra --> overlayExtra["overlaybd<br/>(extra drive)"]
+        vm --> memory["VM memory"]
+        memory --> ublkM["ublk (/dev/ublkbM)<br/>read-only memory block device (shared across same-snapshot sandboxes via refcounting)"]
+        ublkM --> memLayers["overlaybd<br/>(mem layers)"]
+        memLayers --> snapN["snap N<br/>(r/o)"]
+        memLayers --> snap0["snap 0, 1, 2, ...<br/>(r/o)"]
+    end
+    style node fill:transparent,stroke:gray
 ```
 
 ## Storage 
@@ -217,13 +190,13 @@ See [P2P Artifact Transport](./p2p-design.md) for the detailed design.
 
 The multi-node control plane in `services/` routes client traffic across multiple AgentENV backend nodes.
 
-```
-    Client ──HTTP──> Gateway (:8080) ──gRPC──> Scheduler (:9090)
-                        │                          │
-                        │    ┌─────────────────────┘
-                        │    │ node selection / lookup
-                        ▼    ▼
-                   Node A (:8000)    Node B (:8000)
+```mermaid
+flowchart LR
+    client["Client"] -->|HTTP| gateway["Gateway<br/>(:8080)"]
+    gateway -->|gRPC| scheduler["Scheduler<br/>(:9090)"]
+    gateway -->|proxy HTTP| nodeA["Node A<br/>(:8000)"]
+    gateway -->|proxy HTTP| nodeB["Node B<br/>(:8000)"]
+    scheduler -.->|node selection /<br/> lookup result| gateway
 ```
 
 **Gateway** (`services/gateway/`): HTTP reverse proxy. Extracts sandbox data-plane routes from headers (`x-agentenv-sandbox-id` / `e2b-sandbox-id`) or configured host-based proxy domains (`{port}-{sandboxID}.{domain}`). Host-based routes are only enabled for explicit `gateway.sandbox_proxy_domains` entries, require RFC 952/1123 DNS-label-compatible sandbox IDs, and require the full `{port}-{sandboxID}` label to fit the 63-character DNS label limit. Runtime nodes have their own `[sandbox_proxy].domains` setting for the same host-based URL shape and return the first configured domain in sandbox metadata. In multi-node deployments, repository helpers can apply one `SANDBOX_PROXY_DOMAINS` value to both gateway and runtime node configuration. Sandbox control-plane routes such as `/sandboxes/{id}/pause` are routed by sandbox ID from the URL path; sandbox data-plane traffic is not inferred from URL path alone. For new sandboxes, calls `Schedule()` to pick a node. For existing sandboxes, calls `LookupNode()`. After sandbox creation, calls `RecordAssignment()` to seed a sandbox-to-node binding. Without explicit routing headers, it also handles cluster aggregation of `GET /sandboxes`, `GET /v2/sandboxes`, `GET /nodes`, and resolves `GET /nodes/{id}` via scheduler before proxying to the resolved node.


### PR DESCRIPTION
## What

Replace selected ASCII architecture and lifecycle diagrams in the mdBook documentation with Mermaid diagrams, and enable Mermaid rendering in the documentation build.

## Why

The architecture, sandbox lifecycle, egress-rule, and multi-node control-plane diagrams are easier to read, maintain, and render consistently as Mermaid diagrams than as fixed-width ASCII art.

## Related issue

N/A

## Scope and non-goals

- Convert relationship diagrams in the concepts and internals documentation.
- Add the mdBook Mermaid preprocessor and browser-side Mermaid initialization.
- Keep source directory trees, command examples, and other non-diagram text unchanged.
- No runtime, API, storage, scheduler, or generated-code behavior changes.

## Design and behavior changes

- `docs/book.toml` enables the `mdbook-mermaid` preprocessor and loads `mermaid-init.js`.
- Mermaid diagrams preserve the original component relationships, labels, lifecycle transitions, storage paths, and control-plane routing semantics.
- The browser initializer loads Mermaid 11.12.0 from jsDelivr with an integrity hash and selects a light or dark Mermaid theme based on the mdBook theme.
- The distributed control-plane diagram shows Gateway as the data-plane proxy and Scheduler as the node selection/lookup service.

## Compatibility and operations

- Public API or generated protocol: N/A; documentation-only change.
- Configuration or defaults: N/A.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: Reverting this commit restores the previous ASCII diagrams and removes Mermaid preprocessing.
- Host requirements, permissions, ports, or dependencies: Documentation builds now require `mdbook-mermaid`; CI installs `mdbook-mermaid@0.17.0`.

## Validation

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
mdbook build docs
INFO Book building has started
INFO Running the html backend
INFO HTML book written to /home/ubuntu/AgentENV/docs/book

git diff --check
Passed
```

Skipped checks and reasons:

Rust, services, generated-code, and benchmark checks were skipped because this PR only changes documentation and documentation build assets.

## Risks and reviewer notes

- Mermaid rendering depends on the pinned jsDelivr asset and the `mdbook-mermaid` preprocessor.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
