### PR TITLE
feat(snapshot): add artifact dimension to OSS upload observability

### DIFF
--- a/src/observability/prometheus.rs
+++ b/src/observability/prometheus.rs
@@ -123,6 +123,10 @@ pub struct MetricGuard {
 #[derive(Clone, Copy)]
 enum MetricGuardLabel {
     Operation(&'static str),
+    OperationArtifact {
+        operation: &'static str,
+        artifact: &'static str,
+    },
     Stage(&'static str),
 }
 
@@ -134,6 +138,26 @@ impl MetricGuard {
         Self {
             metric,
             label: MetricGuardLabel::Operation(operation),
+            start: Instant::now(),
+            status: "canceled",
+            recorded: false,
+        }
+    }
+
+    /// Operation metric with an additional artifact dimension, used by OSS
+    /// upload operations so per-artifact latency and cancellation stay
+    /// visible (a dropped guard still records with status "canceled").
+    pub fn operation_artifact(
+        metric: &'static str,
+        operation: &'static str,
+        artifact: &'static str,
+    ) -> Self {
+        Self {
+            metric,
+            label: MetricGuardLabel::OperationArtifact {
+                operation,
+                artifact,
+            },
             start: Instant::now(),
             status: "canceled",
             recorded: false,
@@ -166,6 +190,18 @@ impl MetricGuard {
                 metrics::histogram!(
                     self.metric,
                     "operation" => operation,
+                    "status" => self.status,
+                )
+                .record(elapsed);
+            }
+            MetricGuardLabel::OperationArtifact {
+                operation,
+                artifact,
+            } => {
+                metrics::histogram!(
+                    self.metric,
+                    "operation" => operation,
+                    "artifact" => artifact,
                     "status" => self.status,
                 )
                 .record(elapsed);

--- a/src/snapshot/repository/backends/oss/client.rs
+++ b/src/snapshot/repository/backends/oss/client.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
@@ -11,12 +12,41 @@ use object_store_operator::{
 use opendal::{Error as OpenDalError, ErrorKind as OpenDalErrorKind, Operator};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::RwLock;
+use tracing::info;
 use url::Url;
 
 use crate::observability::prometheus::MetricGuard;
 
 const CHUNK_SIZE: usize = 8 * 1024 * 1024;
 const OSS_OPERATION_DURATION: &str = "agentenv_snapshot_oss_operation_duration_seconds";
+
+/// Snapshot artifacts uploaded to OSS. Used as the `artifact` label on upload
+/// metrics and in upload completion logs so memory layers can be told apart
+/// from rootfs/attached-drive layers.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum OssUploadArtifact {
+    RootfsLayer,
+    AttachedDriveLayer,
+    MemoryLayer,
+    VmState,
+    FirecrackerManifest,
+    CatalogRecord,
+    Alias,
+}
+
+impl OssUploadArtifact {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::RootfsLayer => "rootfs_layer",
+            Self::AttachedDriveLayer => "attached_drive_layer",
+            Self::MemoryLayer => "memory_layer",
+            Self::VmState => "vm_state",
+            Self::FirecrackerManifest => "manifest",
+            Self::CatalogRecord => "record",
+            Self::Alias => "alias",
+        }
+    }
+}
 
 /// Thin wrapper around the OSS client used by the repository and resolver.
 #[derive(Clone, Debug)]
@@ -147,11 +177,17 @@ impl OssClient {
     }
 
     /// Write small data (catalog JSON, alias JSON, etc.).
-    pub(crate) async fn put_bytes(&self, key: &str, data: impl Into<Bytes>) -> Result<()> {
+    pub(crate) async fn put_bytes(
+        &self,
+        key: &str,
+        data: impl Into<Bytes>,
+        artifact: OssUploadArtifact,
+    ) -> Result<()> {
         let data = data.into();
         let size = data.len() as u64;
         let oss_key = self.full_key(key);
-        let mut metric = MetricGuard::operation(OSS_OPERATION_DURATION, "put_bytes");
+        let mut metric =
+            MetricGuard::operation_artifact(OSS_OPERATION_DURATION, "put_bytes", artifact.as_str());
         let result = self
             .run_with_operator(|operator| {
                 let data = data.clone();
@@ -165,6 +201,7 @@ impl OssClient {
             metrics::counter!(
                 "agentenv_snapshot_oss_upload_bytes_total",
                 "operation" => "put_bytes",
+                "artifact" => artifact.as_str(),
             )
             .increment(size);
         }
@@ -173,10 +210,17 @@ impl OssClient {
     }
 
     /// Upload a local file to OSS.
-    pub(crate) async fn put_file(&self, key: &str, path: &Path) -> Result<()> {
+    pub(crate) async fn put_file(
+        &self,
+        key: &str,
+        path: &Path,
+        artifact: OssUploadArtifact,
+    ) -> Result<()> {
         let oss_key = self.full_key(key);
         let path = path.to_path_buf();
-        let mut metric = MetricGuard::operation(OSS_OPERATION_DURATION, "put_file");
+        let mut metric =
+            MetricGuard::operation_artifact(OSS_OPERATION_DURATION, "put_file", artifact.as_str());
+        let start = Instant::now();
         let result: Result<u64> = async {
             let size = tokio::fs::metadata(&path)
                 .await
@@ -198,8 +242,16 @@ impl OssClient {
                 metrics::counter!(
                     "agentenv_snapshot_oss_upload_bytes_total",
                     "operation" => "put_file",
+                    "artifact" => artifact.as_str(),
                 )
                 .increment(size);
+                info!(
+                    key = %oss_key,
+                    artifact = artifact.as_str(),
+                    size_bytes = size,
+                    elapsed_ms = start.elapsed().as_millis(),
+                    "oss file uploaded"
+                );
                 Ok(())
             }
             Err(err) => Err(err),

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -10,7 +10,7 @@ use overlaybd::dense_export;
 use overlaybd::layer_metadata::read_overlaybd_layer_uuid;
 use tracing::{debug, info, warn};
 
-use super::client::OssClient;
+use super::client::{OssClient, OssUploadArtifact};
 use super::layout::OssSnapshotArtifactLayout;
 use crate::cfg::SnapshotImageStoragePolicy;
 use crate::sandbox::FirecrackerSnapshotManifest;
@@ -245,6 +245,7 @@ impl SnapshotRepository for OssSnapshotRepository {
                 .put_file(
                     &layout.artifact_key(SNAPSHOT_ARTIFACT_LAYOUT.vm_state),
                     vm_state_local_path,
+                    OssUploadArtifact::VmState,
                 )
                 .await
                 .map_err(|e| {
@@ -265,6 +266,7 @@ impl SnapshotRepository for OssSnapshotRepository {
                 .put_bytes(
                     &layout.artifact_key(SNAPSHOT_ARTIFACT_LAYOUT.firecracker_manifest),
                     persisted_manifest_bytes,
+                    OssUploadArtifact::FirecrackerManifest,
                 )
                 .await
                 .map_err(|e| RepositoryError::backend("write firecracker manifest to oss", e))?;
@@ -531,7 +533,11 @@ impl OssSnapshotRepository {
         let bytes = serde_json::to_vec_pretty(record)
             .map_err(|e| RepositoryError::backend("serialize snapshot record", e))?;
         self.client
-            .put_bytes(&OssSnapshotArtifactLayout::record_key(&record.id), bytes)
+            .put_bytes(
+                &OssSnapshotArtifactLayout::record_key(&record.id),
+                bytes,
+                OssUploadArtifact::CatalogRecord,
+            )
             .await
             .map_err(|e| RepositoryError::backend("write snapshot record", e))
     }
@@ -626,7 +632,7 @@ impl OssSnapshotRepository {
             // Step 5: write our binding (unconditional — OSS does not
             // support conditional headers on S3-compatible writes).
             self.client
-                .put_bytes(&key, payload.clone())
+                .put_bytes(&key, payload.clone(), OssUploadArtifact::Alias)
                 .await
                 .map_err(|e| RepositoryError::backend("write alias binding", e))?;
 
@@ -673,10 +679,11 @@ impl OssSnapshotRepository {
     async fn export_managed_disk_image(
         &self,
         image_config_path: &Path,
+        artifact: OssUploadArtifact,
     ) -> RepositoryResult<DiskImageExportOutcome> {
         Ok(DiskImageExportOutcome {
             layers: self
-                .derive_and_upload_disk_image_layers(image_config_path)
+                .derive_and_upload_disk_image_layers(image_config_path, artifact)
                 .await?,
             publication: None,
         })
@@ -685,6 +692,7 @@ impl OssSnapshotRepository {
     async fn derive_and_upload_disk_image_layers(
         &self,
         image_config_path: &Path,
+        artifact: OssUploadArtifact,
     ) -> RepositoryResult<Vec<OverlaybdLayerRef>> {
         let image_config = load_overlaybd_image_config(image_config_path).map_err(|e| {
             RepositoryError::backend(
@@ -703,13 +711,20 @@ impl OssSnapshotRepository {
                 let layer_path = Path::new(&layer.file);
                 if !layer.digest.is_empty() && layer.size > 0 {
                     let managed = self
-                        .import_managed_layer_with_descriptor(layer_path, &layer.digest, layer.size)
+                        .import_managed_layer_with_descriptor(
+                            layer_path,
+                            &layer.digest,
+                            layer.size,
+                            artifact,
+                        )
                         .await?;
                     layers.push(OverlaybdLayerRef::Managed(managed));
                     continue;
                 }
                 if crate::image::local_layer::rootfs_layer_is_runtime_generated_delta(layer_path) {
-                    let managed = self.import_descriptorless_rootfs_layer(layer_path).await?;
+                    let managed = self
+                        .import_descriptorless_rootfs_layer(layer_path, artifact)
+                        .await?;
                     layers.push(OverlaybdLayerRef::Managed(managed));
                     continue;
                 }
@@ -786,12 +801,16 @@ impl OssSnapshotRepository {
                         layer_path,
                         &layer.digest,
                         layer.size,
+                        OssUploadArtifact::MemoryLayer,
                     )
                     .await?,
                 );
                 continue;
             }
-            layers.push(self.import_managed_layer_by_hash(layer_path).await?);
+            layers.push(
+                self.import_managed_layer_by_hash(layer_path, OssUploadArtifact::MemoryLayer)
+                    .await?,
+            );
         }
 
         Ok(layers)
@@ -803,11 +822,17 @@ impl OssSnapshotRepository {
         subject: DiskImageSubject,
         image_config_path: &Path,
     ) -> RepositoryResult<DiskImageExportOutcome> {
+        let artifact = match &subject {
+            DiskImageSubject::Rootfs => OssUploadArtifact::RootfsLayer,
+            DiskImageSubject::AttachedDrive { .. } => OssUploadArtifact::AttachedDriveLayer,
+        };
         if !matches!(
             self.snapshot_image_storage,
             SnapshotImageStoragePolicy::SourceRegistry
         ) {
-            return self.export_managed_disk_image(image_config_path).await;
+            return self
+                .export_managed_disk_image(image_config_path, artifact)
+                .await;
         }
         match self
             .acr_exporter
@@ -831,7 +856,8 @@ impl OssSnapshotRepository {
                     reason = %feature,
                     "falling back to managed disk image layers"
                 );
-                self.export_managed_disk_image(image_config_path).await
+                self.export_managed_disk_image(image_config_path, artifact)
+                    .await
             }
             result => result,
         }
@@ -975,6 +1001,7 @@ impl OssSnapshotRepository {
     async fn import_descriptorless_rootfs_layer(
         &self,
         source: &Path,
+        artifact: OssUploadArtifact,
     ) -> RepositoryResult<ManagedLayer> {
         let canonical = std::fs::canonicalize(source).map_err(|e| {
             RepositoryError::backend(
@@ -983,14 +1010,18 @@ impl OssSnapshotRepository {
             )
         })?;
         if dense_export::should_dense_export_layer(&canonical) {
-            return self.import_sparse_overlaybd_layer_dense(&canonical).await;
+            return self
+                .import_sparse_overlaybd_layer_dense(&canonical, artifact)
+                .await;
         }
-        self.import_managed_layer_by_hash(&canonical).await
+        self.import_managed_layer_by_hash(&canonical, artifact)
+            .await
     }
 
     async fn import_sparse_overlaybd_layer_dense(
         &self,
         canonical: &Path,
+        artifact: OssUploadArtifact,
     ) -> RepositoryResult<ManagedLayer> {
         let dense_temp = tempfile::NamedTempFile::new().map_err(|e| {
             RepositoryError::backend(
@@ -1014,8 +1045,7 @@ impl OssSnapshotRepository {
                 )
             })?;
         let oss_key = OssSnapshotArtifactLayout::managed_layer_key(&descriptor.digest);
-        upload_managed_layer_if_missing(&self.client, &oss_key, &dense_path, &descriptor.digest)
-            .await?;
+        upload_managed_layer_if_missing(&self.client, &oss_key, &dense_path, artifact).await?;
 
         Ok(ManagedLayer {
             digest: descriptor.digest,
@@ -1024,7 +1054,11 @@ impl OssSnapshotRepository {
         })
     }
 
-    async fn import_managed_layer_by_hash(&self, source: &Path) -> RepositoryResult<ManagedLayer> {
+    async fn import_managed_layer_by_hash(
+        &self,
+        source: &Path,
+        artifact: OssUploadArtifact,
+    ) -> RepositoryResult<ManagedLayer> {
         let canonical = std::fs::canonicalize(source).map_err(|e| {
             RepositoryError::backend(
                 format!("canonicalize managed layer '{}'", source.display()),
@@ -1040,8 +1074,7 @@ impl OssSnapshotRepository {
                 )
             })?;
         let oss_key = OssSnapshotArtifactLayout::managed_layer_key(&descriptor.sha256);
-        upload_managed_layer_if_missing(&self.client, &oss_key, &canonical, &descriptor.sha256)
-            .await?;
+        upload_managed_layer_if_missing(&self.client, &oss_key, &canonical, artifact).await?;
 
         Ok(ManagedLayer {
             digest: descriptor.sha256,
@@ -1055,6 +1088,7 @@ impl OssSnapshotRepository {
         source: &Path,
         digest: &str,
         size: u64,
+        artifact: OssUploadArtifact,
     ) -> RepositoryResult<ManagedLayer> {
         let canonical = std::fs::canonicalize(source).map_err(|e| {
             RepositoryError::backend(
@@ -1085,7 +1119,7 @@ impl OssSnapshotRepository {
         // Descriptor-backed imports intentionally trust internally generated
         // content digests and only validate the cheap size invariant here.
         let oss_key = OssSnapshotArtifactLayout::managed_layer_key(digest);
-        upload_managed_layer_if_missing(&self.client, &oss_key, &canonical, digest).await?;
+        upload_managed_layer_if_missing(&self.client, &oss_key, &canonical, artifact).await?;
 
         Ok(ManagedLayer {
             digest: digest.to_string(),
@@ -1112,7 +1146,7 @@ async fn upload_managed_layer_if_missing(
     client: &OssClient,
     key: &str,
     canonical: &Path,
-    digest: &str,
+    artifact: OssUploadArtifact,
 ) -> RepositoryResult<()> {
     let already_exists = client
         .exists(key)
@@ -1120,10 +1154,15 @@ async fn upload_managed_layer_if_missing(
         .map_err(|e| RepositoryError::backend("check managed layer existence", e))?;
 
     if !already_exists {
-        client.put_file(key, canonical).await.map_err(|e| {
-            RepositoryError::backend(format!("upload managed layer '{}'", canonical.display()), e)
-        })?;
-        debug!(digest = %digest, key, "uploaded managed layer to oss");
+        client
+            .put_file(key, canonical, artifact)
+            .await
+            .map_err(|e| {
+                RepositoryError::backend(
+                    format!("upload managed layer '{}'", canonical.display()),
+                    e,
+                )
+            })?;
     }
 
     Ok(())
@@ -1325,7 +1364,7 @@ mod tests {
         );
 
         let layers = test_repository()
-            .derive_and_upload_disk_image_layers(&image)
+            .derive_and_upload_disk_image_layers(&image, OssUploadArtifact::RootfsLayer)
             .await
             .expect("derive layers");
 


### PR DESCRIPTION
## What

- Snapshot OSS upload metrics (`agentenv_snapshot_oss_upload_bytes_total`,
  and the `put_file`/`put_bytes` series of
  `agentenv_snapshot_oss_operation_duration_seconds`) gain an `artifact`
  label: `rootfs_layer` / `attached_drive_layer` / `memory_layer` /
  `vm_state` / `manifest` / `record` / `alias`.
- Each completed `put_file` logs `key`, `artifact`, `size_bytes`,
  `elapsed_ms` at info level.

## Why

Upload metrics could not distinguish memory layers from disk layers, and
canceled uploads left no per-artifact trace. Slow or canceled snapshot
publishes can now be attributed to a specific artifact.

## Related issue

None.

## Scope and non-goals

In scope: the OSS repository upload path and the shared `MetricGuard`.
Non-goals: no timeout/retry behavior changes; POSIX backend, ACR/regctl
path, and the download/resolver path are untouched.

## Design and behavior changes

- New `MetricGuard::operation_artifact` label variant; guards dropped
  mid-flight still record `status="canceled"`, now with the artifact.
- New `OssUploadArtifact` enum threaded through the publish flow;
  `DiskImageSubject` maps to rootfs/attached-drive artifact.
- Removed the now-redundant `debug!("uploaded managed layer to oss")` (the
  managed-layer key already contains the digest) and its `digest` parameter.

## Compatibility and operations

- Public API or generated protocol: N/A — no API changes.
- Configuration or defaults: N/A.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: upload metric series gain an `artifact` label;
  `sum by (operation)`-style queries remain valid. Rollback is a revert.
- Host requirements, permissions, ports, or dependencies: N/A.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
make fmt                                # OK
make clippy                             # OK, workspace-wide, no warnings (Linux host)
cargo test -p agentenv --lib snapshot:: # 116 passed, 0 failed
```

Skipped checks and reasons:

- `make test-unit`: covered by CI; the unit tests of the touched module were
  run directly (see above).
- Integration tests: require KVM/ublk hosts; this change touches no runtime
  path.
- `services/`, generated code, docs, benchmarks: not affected.

## Risks and reviewer notes

- The duration histogram has mixed label sets (only `put_file`/`put_bytes`
  carry `artifact`); valid Prometheus, existing aggregations unaffected.
- ~4 extra info log lines per snapshot publish.
- Focus: `src/snapshot/repository/backends/oss/client.rs`,
  `src/snapshot/repository/backends/oss/repository.rs`,
  `src/observability/prometheus.rs`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
  (Label threading only; no metrics-assertion harness exists — covered by
  the existing snapshot test suite and clippy.)
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
