### PR TITLE
fix(overlaybd): preserve premerged-index cache during full-file cache recovery

### DIFF
--- a/storage/overlaybd/src/backend/cache/full_file_cache/cache_pool.rs
+++ b/storage/overlaybd/src/backend/cache/full_file_cache/cache_pool.rs
@@ -9,6 +9,7 @@ use super::cache_entry::CacheEntry;
 use super::cache_store::CachedFile;
 use crate::config::CacheConfig;
 use crate::io::virtual_file::VirtualFile;
+use crate::lsmt::file::PREMERGED_INDEX_DIR;
 use anyhow::{anyhow, bail, Context, Result};
 use dashmap::DashMap;
 use nix::errno::Errno;
@@ -199,6 +200,11 @@ impl BackendState {
                 continue;
             }
             let cache_id = item.file_name().to_string_lossy().to_string();
+            // The LSMT premerged-index artifact cache shares this cache root
+            // but is not a full-file cache entry; leave it untouched.
+            if cache_id == PREMERGED_INDEX_DIR {
+                continue;
+            }
             let paths = EntryPaths::new(&options.cache_dir, &cache_id);
             match CacheEntry::load_from_disk(cache_id.clone(), paths, options).await {
                 Ok(entry) => {

--- a/storage/overlaybd/src/backend/cache/tests.rs
+++ b/storage/overlaybd/src/backend/cache/tests.rs
@@ -1052,6 +1052,25 @@ async fn test_cache_persistence_reload() {
 }
 
 #[tokio::test]
+async fn test_load_from_disk_preserves_premerged_index_dir() {
+    let tmp = tempdir().expect("create tempdir");
+    let reserved = tmp.path().join(crate::lsmt::file::PREMERGED_INDEX_DIR);
+    std::fs::create_dir_all(&reserved).expect("create premerged-index dir");
+    let artifact = reserved.join("deadbeef.pmidx");
+    std::fs::write(&artifact, b"pmidx-bytes").expect("write artifact");
+
+    let backend = FileCacheBackend::with_options(test_options(tmp.path()))
+        .await
+        .expect("backend init");
+    drop(backend);
+
+    assert!(
+        artifact.try_exists().expect("stat artifact"),
+        "recovery must not remove the premerged-index artifact cache"
+    );
+}
+
+#[tokio::test]
 async fn test_inflight_refill_dedup() {
     let tmp = tempdir().expect("create tempdir");
     let backend = FileCacheBackend::with_options(test_options(tmp.path()))

--- a/storage/overlaybd/src/lsmt/file/mod.rs
+++ b/storage/overlaybd/src/lsmt/file/mod.rs
@@ -12,11 +12,11 @@ pub use stack::{
     create_file_rw, is_lsmt, merge_files_ro, open_file_index, open_file_ro, open_file_rw,
     open_files_ro, open_files_ro_with_premerged_cache, stack_files,
 };
-pub(crate) use types::PARALLEL_LOAD_INDEX;
 pub use types::{
     CommitArgs, DataStat, LSMTFileType, LayerDescriptor, LayerInfo, PremergedIndexCachePolicy,
     RwLayout, MAX_STACK_LAYERS,
 };
+pub(crate) use types::{PARALLEL_LOAD_INDEX, PREMERGED_INDEX_DIR};
 
 #[cfg(test)]
 mod tests;

--- a/storage/overlaybd/src/lsmt/file/types.rs
+++ b/storage/overlaybd/src/lsmt/file/types.rs
@@ -19,7 +19,7 @@ pub(crate) const PARALLEL_LOAD_INDEX: usize = 32;
 
 pub const MAX_STACK_LAYERS: usize = 255;
 
-pub(super) const PREMERGED_INDEX_DIR: &str = "premerged-index";
+pub(crate) const PREMERGED_INDEX_DIR: &str = "premerged-index";
 pub(super) const PREMERGED_INDEX_EXT: &str = "pmidx";
 pub(super) const PREMERGED_INDEX_MAGIC: [u8; 8] = *b"PMIDX001";
 pub(super) const PREMERGED_INDEX_FORMAT_VERSION: u32 = 1;


### PR DESCRIPTION
## What

Skip the reserved `premerged-index` subdirectory when full-file cache recovery
scans `cacheDir`, plus a regression test.

## Why

The LSMT premerged-index artifact cache lives inside the scanned `cacheDir`.
Every `ImageService` creation (node restart, uvm-ublk-daemon lazy creation /
respawn) logged `load cache from disk failed err=cache meta not exists` and
deleted the whole directory, wiping the cache and racing in-flight writes
(`rename ... No such file or directory`).

## Related issue

N/A — small fix from production logs.

## Scope and non-goals

Included: recovery skip + test. Excluded: any on-disk layout change;
writer-side retry (no longer needed).

## Design and behavior changes

Recovery skips `PREMERGED_INDEX_DIR` (re-exported crate-wide as the single
source of truth). Real cache entries are still discarded on load failure.

## Compatibility and operations

No API, config, layout, or host requirement changes. Existing `.pmidx`
artifacts now persist across restarts. Safe to roll back.

## Validation

```text
cargo fmt --all -- --check                             # pass
cargo clippy -p overlaybd --all-targets -- -D warnings # pass
cargo test -p overlaybd --lib                          # 310 passed, 0 failed
```

Skipped: `make` wrappers and unrelated suites; only `overlaybd` is touched.

## Risks and reviewer notes

Main file: `storage/overlaybd/src/backend/cache/full_file_cache/cache_pool.rs`.
Only effect is that the directory named `premerged-index` survives recovery.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
