### PR TITLE
fix(proxy): stop leaking the /proxy prefix and the sandbox address to clients

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -137,6 +137,13 @@ where
 {
     Router::new()
         .route(PROXY_ROUTE, any(proxy_via_prefix::<I>))
+        // `/proxy/` has nothing left after the prefix, so the wildcard route
+        // below cannot match it (catch-all params must be non-empty) and the
+        // exact route above does not either. Without this route it reaches
+        // `proxy_via_fallback`, which forwards the path unmodified and leaks
+        // the `/proxy` prefix into the sandbox. The distributed gateway builds
+        // exactly this shape whenever a client requests `/`.
+        .route("/proxy/", any(proxy_via_prefix::<I>))
         .route("/proxy/{*proxy_path}", any(proxy_via_prefix::<I>))
         .fallback(proxy_via_fallback::<I>)
         .with_state(api_impl)
@@ -2031,6 +2038,61 @@ mod tests {
         let payload: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(payload["path"], "/");
         assert_eq!(payload["query"], "foo=bar");
+    }
+
+    #[tokio::test]
+    async fn proxy_root_with_trailing_slash_forwards_to_upstream_root_path() {
+        let upstream_addr = start_upstream_server().await;
+        let sandbox_id = SandboxId::new();
+        let app = proxy_app_for_sandbox(&sandbox_id).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/proxy/?foo=bar")
+                    .header("x-api-key", "test-key")
+                    .header(SANDBOX_ID_HEADER, sandbox_id.to_string())
+                    .header(TARGET_PORT_HEADER, upstream_addr.port().to_string())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["path"], "/");
+        assert_eq!(payload["query"], "foo=bar");
+    }
+
+    #[tokio::test]
+    async fn proxy_preserves_trailing_slash_in_wildcard_path() {
+        let upstream_addr = start_upstream_server().await;
+        let sandbox_id = SandboxId::new();
+        let app = proxy_app_for_sandbox(&sandbox_id).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/proxy/api/")
+                    .header("x-api-key", "test-key")
+                    .header(SANDBOX_ID_HEADER, sandbox_id.to_string())
+                    .header(TARGET_PORT_HEADER, upstream_addr.port().to_string())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["path"], "/api/");
     }
 
     #[tokio::test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -464,7 +464,7 @@ async fn proxy_http_request(
         }
     };
 
-    map_upstream_response(upstream_response)
+    map_upstream_response(upstream_response, &upstream_uri_for_log)
 }
 
 fn track_request_body_activity(body: Body) -> (Body, watch::Receiver<()>) {
@@ -592,7 +592,7 @@ async fn proxy_websocket_request(
         Ok(Err(err)) => match err {
             tungstenite::Error::Http(response) => {
                 info!(sandbox_id = %sandbox_id, status = %response.status(), "upstream websocket handshake rejected");
-                return map_websocket_handshake_rejection_response(*response);
+                return map_websocket_handshake_rejection_response(*response, &upstream_uri);
             }
             err => {
                 warn!(sandbox_id = %sandbox_id, error = %err, "upstream websocket handshake failed");
@@ -650,9 +650,11 @@ async fn proxy_websocket_request(
 
 fn map_websocket_handshake_rejection_response(
     response: http::Response<Option<Vec<u8>>>,
+    upstream_uri: &Uri,
 ) -> Response<Body> {
     let (mut parts, body) = response.into_parts();
     remove_hop_by_hop_headers(&mut parts.headers);
+    rewrite_upstream_self_references(&mut parts.headers, upstream_uri);
     let body = body.map_or_else(Body::empty, Body::from);
     Response::from_parts(parts, body)
 }
@@ -1088,12 +1090,103 @@ fn remove_hop_by_hop_headers(headers: &mut HeaderMap) {
     headers.remove(HeaderName::from_static("keep-alive"));
 }
 
-fn map_upstream_response(response: Response<Incoming>) -> Response<Body> {
+fn map_upstream_response(response: Response<Incoming>, upstream_uri: &Uri) -> Response<Body> {
     let (mut parts, body) = response.into_parts();
     // Mirror the request-side filtering on the way back so connection-scoped
     // headers from the upstream do not leak through this proxy hop.
     remove_hop_by_hop_headers(&mut parts.headers);
+    rewrite_upstream_self_references(&mut parts.headers, upstream_uri);
     Response::from_parts(parts, Body::new(body.map_err(axum::Error::new)))
+}
+
+/// Turns redirect targets that point back at the sandbox's own address into
+/// path-relative ones.
+///
+/// The upstream authority is an internal runtime address (`10.x.y.z:5173`):
+/// it is reachable from this node only, and the request carries it to the
+/// upstream in `Host`, so applications that build absolute URLs from `Host`
+/// hand it right back in `Location`. Passing that through both leaks the
+/// sandbox network layout to the client and points the client's next request
+/// at an address it cannot reach — a redirect loop that looks like the
+/// application misbehaving.
+///
+/// Only self-references are rewritten: an absolute URL to any other host is the
+/// application's own business (an OAuth hop, a CDN) and must survive verbatim.
+fn rewrite_upstream_self_references(headers: &mut HeaderMap, upstream_uri: &Uri) {
+    for name in [header::LOCATION, header::CONTENT_LOCATION] {
+        let Some(rewritten) = headers
+            .get(&name)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| relative_self_reference(value, upstream_uri))
+            .and_then(|rewritten| HeaderValue::from_str(&rewritten).ok())
+        else {
+            continue;
+        };
+
+        headers.insert(name, rewritten);
+    }
+}
+
+/// Returns the path-relative form of `value` when it addresses the sandbox
+/// itself, or `None` when the value must be left untouched.
+fn relative_self_reference(value: &str, upstream_uri: &Uri) -> Option<String> {
+    // `Uri` parses fragments away, so keep the fragment out of the parse and
+    // append it verbatim afterwards instead of dropping it.
+    let (absolute, fragment) = match value.split_once('#') {
+        Some((absolute, fragment)) => (absolute, Some(fragment)),
+        None => (value, None),
+    };
+
+    // A scheme-relative reference (`//host/path`) names an authority too, so
+    // borrow the upstream scheme to parse it as the absolute URL it stands for.
+    let target = match absolute.strip_prefix("//") {
+        Some(scheme_relative) => {
+            format!("{}://{scheme_relative}", upstream_uri.scheme_str()?).parse::<Uri>()
+        }
+        None => absolute.parse::<Uri>(),
+    }
+    .ok()?;
+
+    if !points_at_same_endpoint(&target, upstream_uri) {
+        return None;
+    }
+
+    // `path()` is `/` for an empty path, which keeps a query-only URL an
+    // absolute-path reference instead of a query-relative one that would leave
+    // the client on its current path.
+    let mut relative = target.path().to_owned();
+    if let Some(query) = target.query() {
+        relative.push('?');
+        relative.push_str(query);
+    }
+    if let Some(fragment) = fragment {
+        relative.push('#');
+        relative.push_str(fragment);
+    }
+
+    Some(relative)
+}
+
+/// Compares two URLs by host and effective port rather than by authority text,
+/// so a self-reference that omits the scheme's default port still matches.
+///
+/// The upstream URL always carries an explicit port, so a target whose port
+/// cannot be determined never compares equal.
+fn points_at_same_endpoint(target: &Uri, upstream_uri: &Uri) -> bool {
+    let (Some(target_host), Some(upstream_host)) = (target.host(), upstream_uri.host()) else {
+        return false;
+    };
+
+    target_host.eq_ignore_ascii_case(upstream_host)
+        && effective_port(target) == effective_port(upstream_uri)
+}
+
+fn effective_port(uri: &Uri) -> Option<u16> {
+    uri.port_u16().or_else(|| match uri.scheme_str() {
+        Some("http") | Some("ws") => Some(80),
+        Some("https") | Some("wss") => Some(443),
+        _ => None,
+    })
 }
 
 async fn bridge_websocket_streams(
@@ -2093,6 +2186,122 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let payload: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(payload["path"], "/api/");
+    }
+
+    async fn start_redirecting_upstream() -> SocketAddr {
+        async fn redirect_handler(headers: HeaderMap, uri: Uri) -> Response<Body> {
+            // Mirror what a dev server does: build the absolute URL out of the
+            // Host header it was handed, which is the sandbox's own address.
+            let host = headers
+                .get(HOST)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            let location = match uri.path() {
+                "/external" => "https://example.invalid/elsewhere".to_owned(),
+                "/relative" => "/already-relative".to_owned(),
+                "/fragment" => format!("http://{host}/next?a=1#section"),
+                "/query-only" => format!("http://{host}?x=1"),
+                _ => format!("http://{host}/next?x=1"),
+            };
+
+            Response::builder()
+                .status(StatusCode::TEMPORARY_REDIRECT)
+                .header(header::LOCATION, location)
+                .body(Body::empty())
+                .expect("redirect response is valid")
+        }
+
+        spawn_upstream(
+            axum::Router::new()
+                .route("/", any(redirect_handler))
+                .route("/{*path}", any(redirect_handler)),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn proxy_rewrites_redirects_that_point_back_at_the_sandbox() {
+        let upstream_addr = start_redirecting_upstream().await;
+        let sandbox_id = SandboxId::new();
+
+        for (path, expected) in [
+            // Self-reference: the internal ip:port must not reach the client.
+            ("/proxy/", "/next?x=1"),
+            // A fragment survives the rewrite.
+            ("/proxy/fragment", "/next?a=1#section"),
+            // A query-only self-reference stays an absolute-path reference.
+            ("/proxy/query-only", "/?x=1"),
+            // Anything else is the application's own business.
+            ("/proxy/external", "https://example.invalid/elsewhere"),
+            ("/proxy/relative", "/already-relative"),
+        ] {
+            let app = proxy_app_for_sandbox(&sandbox_id).await;
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .method(Method::GET)
+                        .uri(path)
+                        .header("x-api-key", "test-key")
+                        .header(SANDBOX_ID_HEADER, sandbox_id.to_string())
+                        .header(TARGET_PORT_HEADER, upstream_addr.port().to_string())
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::TEMPORARY_REDIRECT);
+            assert_eq!(
+                response
+                    .headers()
+                    .get(header::LOCATION)
+                    .and_then(|value| value.to_str().ok()),
+                Some(expected),
+                "unexpected Location for {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn relative_self_reference_matches_the_sandbox_endpoint_not_the_authority_text() {
+        let upstream: Uri = "http://10.0.0.1:5173/current".parse().unwrap();
+
+        for (value, expected) in [
+            ("http://10.0.0.1:5173/next", Some("/next")),
+            // A query-only URL must not become a query-relative reference.
+            ("http://10.0.0.1:5173?x=1", Some("/?x=1")),
+            // Fragments are preserved verbatim.
+            ("http://10.0.0.1:5173/next#section", Some("/next#section")),
+            // Scheme-relative references name the same endpoint.
+            ("//10.0.0.1:5173/next", Some("/next")),
+            // Other hosts, other ports, and relative values stay untouched.
+            ("https://example.invalid/next", None),
+            ("http://10.0.0.2:5173/next", None),
+            ("http://10.0.0.1:5174/next", None),
+            ("/already-relative", None),
+        ] {
+            assert_eq!(
+                relative_self_reference(value, &upstream).as_deref(),
+                expected,
+                "unexpected rewrite for {value}"
+            );
+        }
+
+        // An application that drops the scheme's default port still points at
+        // the sandbox.
+        let upstream: Uri = "http://10.0.0.1:80/current".parse().unwrap();
+        assert_eq!(
+            relative_self_reference("http://10.0.0.1/next", &upstream).as_deref(),
+            Some("/next")
+        );
+
+        // Hosts compare case-insensitively.
+        let upstream: Uri = "http://sandbox.invalid:5173/current".parse().unwrap();
+        assert_eq!(
+            relative_self_reference("http://SANDBOX.INVALID:5173/next", &upstream).as_deref(),
+            Some("/next")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Two fixes on the sandbox proxy hop in `src/api/proxy.rs`, both about internal proxy details reaching the client:

1. `/proxy/` — the prefix with nothing after it — matched neither prefix route, fell through to the header-routed fallback, and was forwarded to the sandbox unmodified, so the sandbox saw `/proxy/` instead of `/`.
2. `Location` / `Content-Location` values pointing back at the sandbox's internal `ip:port` were passed through to the client verbatim.

## Why

**Bare `/proxy/`.** The router matches `/proxy` exactly and `/proxy/{*proxy_path}` with a non-empty segment, so the empty-remainder shape reaches `proxy_via_fallback`, whose contract is to forward the path unchanged. The distributed gateway rewrites data-plane traffic to `"/proxy" + path` (`upstreamTargetPath`), so a client request for `/` always arrives at the node in exactly that shape. Consequences on a real deployment:

- applications without an SPA fallback answer their own home page with 404;
- dev servers normalize the trailing slash into `Location: /proxy`, which is relative, so it lands in the client's address bar and 404s on the next request;
- root-path websockets (Vite HMR) never reach the application.

Every non-root path was fine, which makes this look like an application bug rather than a proxy one. `sandbox_proxy_classifier` already treats `path == "/proxy" || path.starts_with("/proxy/")` as proxy traffic, so the classifier and the router disagreed about this one shape.

**Sandbox address in redirects.** Requests are forwarded with `Host` set to the upstream authority, so an application that builds absolute URLs from `Host` returns the sandbox's internal address in `Location`. Passing it through both exposes the sandbox network layout and points the client's next request at an address that is only reachable from that node.

## Related issue

None. Scope is small and obvious, submitted directly per CONTRIBUTING.

## Scope and non-goals

Included:

- one routing-table entry for `/proxy/`, reusing the existing `proxy_via_prefix` handler;
- rewriting self-referencing `Location` / `Content-Location` on the HTTP response path and on a rejected websocket handshake;
- three unit tests.

Not included:

- no change to request semantics, `Host` handling, or the fallback contract;
- response bodies are not rewritten — an application that writes absolute URLs into HTML still emits them, which is outside what a reverse proxy should do;
- host-based and header-based routing are otherwise untouched.

## Design and behavior changes

**Routing.** `.route("/proxy/", any(proxy_via_prefix::<I>))`. The handler is unchanged: `strip_proxy_prefix("/proxy/")` already yields `/`. The set of paths the gateway can produce is closed — `"/proxy" + <path starting with />` is either `/proxy/` or `/proxy/<non-empty>` — and only the first was unrouted. Trailing slashes are not the criterion: `/proxy/station/` (remainder `station/`) and `/proxy//` (remainder `/`) already matched the catch-all and keep their exact upstream paths.

**Responses.** `rewrite_upstream_self_references()` runs after hop-by-hop stripping in `map_upstream_response` and `map_websocket_handshake_rejection_response`. It rewrites a header only when the value parses as a URI whose authority equals the upstream authority, replacing it with `path_and_query` (`/` when absent). Relative values and absolute URLs to any other host — an OAuth hop, a CDN — are left untouched.

## Compatibility and operations

- Public API or generated protocol: N/A — no schema or generated code touched.
- Configuration or defaults: N/A.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: behavior-only, no persisted state; rolling back restores the previous behavior. A client that relied on receiving the sandbox's absolute address in `Location` now receives a path-relative value — that address was never reachable off-node.
- Host requirements, permissions, ports, or dependencies: N/A.
- Documentation: `docs/src/concepts/proxy.md` already documents `ANY /proxy` as forwarding to `/` inside the sandbox, so it describes the fixed behavior and needs no change.

## Validation

- [x] `make fmt`
- [x] `make clippy` — scoped to the changed package, see below
- [x] `make test-unit` — first command of the target only, see below
- [ ] Relevant Rust integration tests — not run: require root, `/dev/kvm` and network namespaces, unavailable in the container used for these checks
- [ ] `make -C services test` — N/A, no `services/` change
- [ ] Generated clients/server regenerated with the documented `make` target — N/A, no generated code touched
- [ ] Documentation updated — N/A, see above
- [ ] Benchmarks or performance comparison completed — N/A, no performance-sensitive change

Commands and results:

```text
$ cargo fmt --all -- --check
FMT_STATUS=0

$ cargo clippy -p agentenv --all-targets -- -D warnings
CLIPPY_STATUS=0   # no warnings from this package

$ cargo test -p agentenv --lib api::proxy
test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 692 filtered out

$ cargo test -p agentenv --lib          # with this branch
test result: FAILED. 718 passed; 6 failed; 4 ignored

$ cargo test -p agentenv --lib          # unpatched c0c6bbb, same container, for comparison
test result: FAILED. 715 passed; 6 failed; 4 ignored
```

The same six tests fail before and after the change (`privileges::tests::scoped_spawn_clears_child_capabilities_without_mutating_caller`, `sandbox::ublk::overlaybd::tests::compact_layers_mixed_input_and_configured_output`, two `snapshot::p2p::tests::local_overlaybd_layers_*`, `snapshot::repository::backends::common::acr::source_image::tests::plans_descriptorless_sparse_overlaybd_delta_for_dense_export`, `snapshot::repository::backends::posixfs::artifacts::tests::import_built_artifacts_preserves_zfile_memory_lower_bytes`). They need privileges and real devices that the unprivileged container does not provide; the delta of this branch is exactly the three new passing tests.

Skipped checks and reasons: integration tests and the capability-runner steps of `make test-unit` need root, `/dev/kvm` and netns; the environment available for these checks is an unprivileged container.

Beyond unit tests, both fixes were verified on a two-node k3s deployment (gateway + node DaemonSet, one microVM sandbox):

```text
# inside the sandbox: python3 -m http.server on 5173, which has no SPA fallback
client path                 sandbox access log        # after the fix
/                           GET /            200
/proxy                      GET /            200
/proxy/                     GET /            200      # was: GET /proxy/ 404
/proxy//                    GET //           200
/proxy/http.log             GET /http.log    200
/nope                       GET /nope        404      # fallback still forwards verbatim

# a Vite app behind the same gateway, seen from the browser
GET /    before: 307 Location: /proxy   ->  after: 200, application home page
GET /    websocket upgrade              ->  101 Switching Protocols, sec-websocket-protocol: vite-hmr
GET //   before: 308 Location: http://10.11.0.1:5173/  ->  after: 308 Location: /
```

## Risks and reviewer notes

- The new route only changes which handler serves `/proxy/`; a client that deliberately used header routing to reach a sandbox path literally named `/proxy/` now reaches `/` instead. That path was already unreachable through the explicit prefix form.
- The redirect rewrite compares authorities byte-wise. An application that echoes the same host in different case, or adds a default port, keeps its absolute URL — deliberately conservative, since a false negative leaks nothing that is not leaked today while a false positive would break a third-party redirect.
- Both commits touch `src/api/proxy.rs` only, and they are independent: happy to split them into separate pull requests if you prefer to review or revert them separately.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
