### PR TITLE
Support configurable S3 addressing style

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -237,6 +237,9 @@ p2p_enabled = true
 # endpoint = "https://oss-cn-beijing-internal.aliyuncs.com"
 # bucket = "agentenv-snapshots"
 # region = "cn-beijing"
+# Bucket addressing style: "virtual" or "path". Leave unset to use
+# endpoint-based auto-detection.
+# addressing_style = "virtual" # or "path"
 # prefix = "snapshots/"
 # credential_process = "/usr/local/bin/get-oss-credentials"
 # access_key_id = "..."

--- a/crates/e2e-tests/tests/snapshot_oss_e2e_test.rs
+++ b/crates/e2e-tests/tests/snapshot_oss_e2e_test.rs
@@ -123,6 +123,7 @@ fn test_oss_config(fixture: &MinioFixture, prefix: &str) -> OssBackendConfig {
         access_key_secret: Some(MINIO_PASS.to_string()),
         security_token: None,
         region: Some(fixture.region.clone()),
+        addressing_style: None,
         cache_max_size_gb: Some(1),
     }
 }

--- a/crates/object-store-operator/src/operator.rs
+++ b/crates/object-store-operator/src/operator.rs
@@ -14,7 +14,7 @@ pub const DEFAULT_MAX_RETRIES: usize = 3;
 
 pub type ObjectStoreOperatorResult<T> = std::result::Result<T, ObjectStoreOperatorError>;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AddressingStyle {
     Virtual,
     Path,

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -422,6 +422,7 @@ OSS-backed snapshot repository configuration. This section is required when `sna
 | `access_key_secret` | string | unset | Static OSS access key secret. Required when `credential_process` is not set |
 | `security_token` | string | unset | Optional session token paired with static access key credentials |
 | `region` | string | none | Region passed to the S3-compatible object-store client; required for current OSS backend |
+| `addressing_style` | string | auto-detect | Bucket addressing style, `"virtual"` or `"path"`. When unset, the backend auto-detects: Alibaba OSS and bucket-in-endpoint hosts use virtual-host style, other endpoints default to path style. Set either value when a provider's required or preferred style differs from the detected default |
 | `cache_max_size_gb` | integer | `10` | Maximum size of the node-local OSS artifact cache in GiB |
 
 Notes:
@@ -429,6 +430,18 @@ Notes:
 - `credential_process` and static access key settings are mutually exclusive in practice; when `credential_process` is set, the backend ignores static credential fields.
 - `credential_process` should be written as a portable argv-style command line. Avoid `$VAR`, backticks, `$(...)`, pipes, and shell builtins.
 - Although the config section is still named `oss`, the runtime path is implemented via a shared S3-compatible client, so `region` must be configured.
+- Leave `addressing_style` unset when endpoint-based detection is correct. Set it to `"virtual"` or `"path"` when the provider's required or preferred style differs from the detected default; for example, some Tigris or Cloudflare R2 deployments use virtual-host addressing.
+- The setting covers both halves of the data path: the snapshot repository client (metadata and artifact upload/download) and the generated OverlayBD runtime config (`ossConfig.defaultAddressingStyle`), which the runtime uses when reading remote managed snapshot layers during sandbox restore.
+
+For an S3-compatible provider where virtual-host addressing is required or preferred — for example [Tigris](https://www.tigrisdata.com/docs/) — set `addressing_style` explicitly:
+
+```toml
+[backend.oss]
+endpoint = "https://t3.storage.dev"
+bucket = "agentenv-snapshots"
+region = "auto"
+addressing_style = "virtual"
+```
 
 Other path override:
 

--- a/docs/src/getting-started/on-demand-loading.md
+++ b/docs/src/getting-started/on-demand-loading.md
@@ -67,6 +67,11 @@ access_key_secret = "YOUR_ACCESS_KEY_SECRET"
 max_size_gb = 100
 ```
 
+If your provider requires or prefers virtual-host bucket addressing — for
+example [Tigris](https://www.tigrisdata.com/docs/) or a Cloudflare R2
+deployment — also set `addressing_style = "virtual"`; see the
+[configuration reference](../configuration/reference.md#backendoss) for details.
+
 ## 3. Apply the configuration
 
 If AgentENV is running as a systemd service, restart it:

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -348,6 +348,19 @@ pub struct SnapshotImagePublishConfig {
     pub enabled: bool,
 }
 
+/// Bucket addressing style for the S3-compatible snapshot backend.
+///
+/// When unset, the backend auto-detects the style: Alibaba OSS and
+/// bucket-in-endpoint hosts use virtual-host addressing, and everything else
+/// falls back to path style. Set this explicitly when a provider's required
+/// or preferred style differs from that default.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OssAddressingStyle {
+    Path,
+    Virtual,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct OssBackendConfig {
     pub endpoint: String,
@@ -359,6 +372,8 @@ pub struct OssBackendConfig {
     pub access_key_secret: Option<String>,
     pub security_token: Option<String>,
     pub region: Option<String>,
+    #[serde(alias = "addressingStyle", alias = "addressing-style")]
+    pub addressing_style: Option<OssAddressingStyle>,
     pub cache_max_size_gb: Option<u64>,
 }
 

--- a/src/setup/deps.rs
+++ b/src/setup/deps.rs
@@ -11,8 +11,8 @@ use serde::Deserialize;
 use tracing::{debug, info};
 
 use crate::cfg::{
-    AppConfig, OssBackendConfig, OverlaybdDependencyConfig, ResolvedImageCacheConfig,
-    SnapshotRepositoryBackendKind,
+    AppConfig, OssAddressingStyle, OssBackendConfig, OverlaybdDependencyConfig,
+    ResolvedImageCacheConfig, SnapshotRepositoryBackendKind,
 };
 use crate::digest::FileDigest;
 use crate::virtualization::VirtualizationMode;
@@ -744,11 +744,19 @@ fn overlaybd_runtime_oss_config(oss: &OssBackendConfig) -> Result<serde_json::Va
         .filter(|region| !region.is_empty())
         .context("backend.oss.region must be set when generating overlaybd OSS config")?;
     let endpoint = oss.endpoint.trim();
+    let addressing_style = match oss.addressing_style {
+        Some(OssAddressingStyle::Path) => "path",
+        Some(OssAddressingStyle::Virtual) => "virtual",
+        None => "",
+    };
 
     let mut config = serde_json::json!({
         "enable": true,
         "defaultRegion": region,
         "defaultEndpoint": endpoint,
+        // Empty string means the overlaybd runtime auto-detects the style per
+        // endpoint, matching the snapshot repository client's behavior.
+        "defaultAddressingStyle": addressing_style,
     });
 
     match credential_source {
@@ -810,6 +818,7 @@ mod tests {
             access_key_secret: Some(" sk ".to_string()),
             security_token: Some(" token ".to_string()),
             region: Some(" cn-hangzhou ".to_string()),
+            addressing_style: None,
             cache_max_size_gb: Some(4),
         }
     }
@@ -863,6 +872,18 @@ mod tests {
             config["defaultEndpoint"],
             "https://oss-cn-hangzhou.aliyuncs.com"
         );
+        assert_eq!(config["defaultAddressingStyle"], "");
+    }
+
+    #[test]
+    fn overlaybd_runtime_oss_config_propagates_addressing_style() {
+        use crate::cfg::OssAddressingStyle;
+
+        let mut oss = sample_oss_config();
+        oss.addressing_style = Some(OssAddressingStyle::Virtual);
+
+        let config = overlaybd_runtime_oss_config(&oss).expect("derive overlaybd oss config");
+        assert_eq!(config["defaultAddressingStyle"], "virtual");
     }
 
     #[test]

--- a/src/snapshot/image_export/service.rs
+++ b/src/snapshot/image_export/service.rs
@@ -87,6 +87,7 @@ impl SnapshotImageService {
                         config.region().to_string(),
                         config.prefix().to_string(),
                         config.credential_source(),
+                        config.addressing_style(),
                     )?);
                     let repository = Arc::new(oss::OssSnapshotRepository::new(
                         Arc::clone(&client),

--- a/src/snapshot/repository/backends/oss/client.rs
+++ b/src/snapshot/repository/backends/oss/client.rs
@@ -64,10 +64,15 @@ impl OssClient {
         region: String,
         prefix: String,
         credential_source: CredentialSource,
+        addressing_override: Option<AddressingStyle>,
     ) -> Result<Self> {
+        // Detection also validates the endpoint URL, so it always runs; an
+        // explicit config override then wins over the detected style.
+        let detected_style = detect_addressing_style(&endpoint, &bucket)?;
+        let addressing_style = addressing_override.unwrap_or(detected_style);
         Ok(Self {
             operator_config: ObjectStoreOperatorConfig {
-                addressing_style: detect_addressing_style(&endpoint, &bucket)?,
+                addressing_style,
                 bucket,
                 endpoint,
                 region,
@@ -446,4 +451,54 @@ async fn upload_file_to_operator(
 
 fn io_error_to_opendal(error: std::io::Error, message: &'static str) -> OpenDalError {
     OpenDalError::new(OpenDalErrorKind::Unexpected, message).set_source(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OssClient;
+    use object_store_operator::{AddressingStyle, CredentialSource};
+
+    #[test]
+    fn explicit_override_takes_precedence_over_detection() {
+        let detected = OssClient::new(
+            "snapshots".to_string(),
+            "https://t3.storage.dev".to_string(),
+            "auto".to_string(),
+            String::new(),
+            CredentialSource::Anonymous,
+            None,
+        )
+        .expect("build client with detected style");
+        assert_eq!(
+            detected.operator_config.addressing_style,
+            AddressingStyle::Path
+        );
+
+        let overridden = OssClient::new(
+            "snapshots".to_string(),
+            "https://t3.storage.dev".to_string(),
+            "auto".to_string(),
+            String::new(),
+            CredentialSource::Anonymous,
+            Some(AddressingStyle::Virtual),
+        )
+        .expect("build client with override");
+        assert_eq!(
+            overridden.operator_config.addressing_style,
+            AddressingStyle::Virtual
+        );
+    }
+
+    #[test]
+    fn explicit_override_still_validates_endpoint() {
+        OssClient::new(
+            "snapshots".to_string(),
+            "not a valid endpoint".to_string(),
+            "auto".to_string(),
+            String::new(),
+            CredentialSource::Anonymous,
+            Some(AddressingStyle::Virtual),
+        )
+        .expect_err("malformed endpoint must fail even with an explicit override");
+    }
 }

--- a/src/snapshot/repository/backends/oss/config.rs
+++ b/src/snapshot/repository/backends/oss/config.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use object_store_operator::{
-    credential_source_from_fields, normalized_credential, CredentialFields, CredentialSource,
-    CredentialSourceOptions,
+    credential_source_from_fields, normalized_credential, AddressingStyle, CredentialFields,
+    CredentialSource, CredentialSourceOptions,
 };
 
-use crate::cfg::{OssBackendConfig, SnapshotImageStoragePolicy};
+use crate::cfg::{OssAddressingStyle, OssBackendConfig, SnapshotImageStoragePolicy};
 
 #[derive(Debug, Clone)]
 pub(crate) struct NormalizedOssConfig {
@@ -14,6 +14,7 @@ pub(crate) struct NormalizedOssConfig {
     prefix: String,
     credential_source: CredentialSource,
     snapshot_image_storage: SnapshotImageStoragePolicy,
+    addressing_style: Option<AddressingStyle>,
 }
 
 impl NormalizedOssConfig {
@@ -54,6 +55,10 @@ impl NormalizedOssConfig {
                 required_secret_access_key_label: "backend.oss.access_key_secret",
             },
         )?;
+        let addressing_style = config.addressing_style.map(|style| match style {
+            OssAddressingStyle::Path => AddressingStyle::Path,
+            OssAddressingStyle::Virtual => AddressingStyle::Virtual,
+        });
         Ok(Self {
             bucket,
             endpoint,
@@ -61,6 +66,7 @@ impl NormalizedOssConfig {
             prefix,
             credential_source,
             snapshot_image_storage,
+            addressing_style,
         })
     }
 
@@ -78,6 +84,12 @@ impl NormalizedOssConfig {
 
     pub(crate) fn region(&self) -> &str {
         &self.region
+    }
+
+    /// Explicit bucket addressing style override, if configured. `None` means
+    /// the client should fall back to endpoint-based auto-detection.
+    pub(crate) fn addressing_style(&self) -> Option<AddressingStyle> {
+        self.addressing_style
     }
 
     pub(crate) fn credential_source(&self) -> CredentialSource {
@@ -114,6 +126,7 @@ mod tests {
             access_key_secret: Some(" sk ".to_string()),
             security_token: Some(" token ".to_string()),
             region: Some(" cn-hangzhou ".to_string()),
+            addressing_style: None,
             cache_max_size_gb: Some(8),
         }
     }

--- a/src/snapshot/repository/backends/oss/mod.rs
+++ b/src/snapshot/repository/backends/oss/mod.rs
@@ -65,6 +65,7 @@ impl OssBackend {
             config.region().to_string(),
             config.prefix().to_string(),
             config.credential_source(),
+            config.addressing_style(),
         )?);
 
         let repository: Arc<dyn SnapshotRepository> = Arc::new(OssSnapshotRepository::new(

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -1232,6 +1232,7 @@ mod tests {
             "region".to_string(),
             "prefix".to_string(),
             CredentialSource::Anonymous,
+            None,
         )
         .expect("oss client");
         OssSnapshotRepository::new(Arc::new(client), SnapshotImageStoragePolicy::ObjectStorage)

--- a/storage/overlaybd/src/backend/oss.rs
+++ b/storage/overlaybd/src/backend/oss.rs
@@ -31,6 +31,7 @@ struct OssBackendInner {
     credentials: CachedCredentialSource,
     default_region: String,
     default_endpoint: String,
+    addressing_override: Option<AddressingStyle>,
     timeout: Duration,
     retry_count: u32,
     cached_operators: RwLock<HashMap<OperatorCacheKey, OperatorWithCredential>>,
@@ -63,6 +64,7 @@ struct OperatorCacheKey {
 impl OssBackend {
     pub fn new(config: &OssConfig) -> Result<Self> {
         let credential_source = credential_source_from_config(config)?;
+        let addressing_override = parse_addressing_style(&config.default_addressing_style)?;
         let timeout = if config.timeout_secs == 0 {
             DEFAULT_TIMEOUT
         } else {
@@ -79,6 +81,7 @@ impl OssBackend {
                 credentials: CachedCredentialSource::new(credential_source),
                 default_region: config.default_region.clone(),
                 default_endpoint: config.default_endpoint.clone(),
+                addressing_override,
                 timeout,
                 retry_count,
                 cached_operators: RwLock::new(HashMap::new()),
@@ -95,6 +98,7 @@ impl OssBackend {
             url.as_ref(),
             &self.inner.default_endpoint,
             &self.inner.default_region,
+            self.inner.addressing_override,
         )?;
 
         Ok(Arc::new(OssFile {
@@ -125,6 +129,7 @@ impl OssBackend {
             url.as_ref(),
             &self.inner.default_endpoint,
             &self.inner.default_region,
+            self.inner.addressing_override,
         )?;
         let key = location.key.clone();
 
@@ -143,7 +148,12 @@ impl OssBackend {
 }
 
 impl ParsedOssUrl {
-    fn parse(raw: &str, default_endpoint: &str, default_region: &str) -> Result<Self> {
+    fn parse(
+        raw: &str,
+        default_endpoint: &str,
+        default_region: &str,
+        addressing_override: Option<AddressingStyle>,
+    ) -> Result<Self> {
         let url = Url::parse(raw).context(format!("invalid oss url {raw}"))?;
         ensure!(
             matches!(url.scheme(), "s3" | "oss"),
@@ -187,7 +197,10 @@ impl ParsedOssUrl {
                 }
             })
             .ok_or_else(|| anyhow::anyhow!("oss region is missing"))?;
-        let addressing_style = detect_addressing_style(&endpoint, &bucket)?;
+        // Detection also validates the endpoint URL, so it always runs; an
+        // explicit override from the config then wins over the detected style.
+        let detected_style = detect_addressing_style(&endpoint, &bucket)?;
+        let addressing_style = addressing_override.unwrap_or(detected_style);
 
         Ok(Self {
             bucket,
@@ -203,7 +216,7 @@ impl ParsedOssUrl {
             bucket: self.bucket.clone(),
             region: self.region.clone(),
             endpoint: self.endpoint.clone(),
-            addressing_style: self.addressing_style.clone(),
+            addressing_style: self.addressing_style,
         }
     }
 
@@ -212,7 +225,7 @@ impl ParsedOssUrl {
             bucket: self.bucket.clone(),
             endpoint: self.endpoint.clone(),
             region: self.region.clone(),
-            addressing_style: self.addressing_style.clone(),
+            addressing_style: self.addressing_style,
             timeout: Some(timeout),
             max_retries: Some(retry_count as usize),
         }
@@ -453,6 +466,19 @@ fn detect_addressing_style(endpoint: &str, bucket: &str) -> Result<AddressingSty
     Ok(AddressingStyle::Path)
 }
 
+/// Parse the config-level addressing style: `"virtual"`, `"path"`, or empty
+/// for `None` (auto-detect per URL).
+fn parse_addressing_style(value: &str) -> Result<Option<AddressingStyle>> {
+    match value.trim() {
+        "" => Ok(None),
+        "virtual" => Ok(Some(AddressingStyle::Virtual)),
+        "path" => Ok(Some(AddressingStyle::Path)),
+        other => bail!(
+            "invalid oss defaultAddressingStyle '{other}': expected 'virtual', 'path', or empty for auto-detection"
+        ),
+    }
+}
+
 fn credential_source_from_config(config: &OssConfig) -> Result<CredentialSource> {
     credential_source_from_fields(
         CredentialFields {
@@ -511,11 +537,27 @@ mod tests {
             credential_process: "echo '{}'".to_string(),
             default_region: "us-east-1".to_string(),
             default_endpoint: "https://s3.us-east-1.amazonaws.com".to_string(),
+            default_addressing_style: String::new(),
             timeout_secs: 30,
             retry_count: 3,
         };
 
         let err = credential_source_from_config(&config).expect_err("mixed source should fail");
         assert!(err.to_string().contains("credential_process"));
+    }
+
+    #[test]
+    fn test_parse_addressing_style_values() {
+        assert_eq!(parse_addressing_style("").expect("empty"), None);
+        assert_eq!(parse_addressing_style("  ").expect("blank"), None);
+        assert_eq!(
+            parse_addressing_style("virtual").expect("virtual"),
+            Some(AddressingStyle::Virtual)
+        );
+        assert_eq!(
+            parse_addressing_style("path").expect("path"),
+            Some(AddressingStyle::Path)
+        );
+        parse_addressing_style("bogus").expect_err("invalid style must be rejected");
     }
 }

--- a/storage/overlaybd/src/config.rs
+++ b/storage/overlaybd/src/config.rs
@@ -211,6 +211,9 @@ pub struct OssConfig {
     pub credential_process: String,
     pub default_region: String,
     pub default_endpoint: String,
+    /// Bucket addressing style: `"virtual"`, `"path"`, or empty to use
+    /// endpoint-based auto-detection.
+    pub default_addressing_style: String,
     /// Per-request timeout in seconds (connect + transfer). Default 30.
     pub timeout_secs: u64,
     /// Number of retries on transient failures. Default 3.
@@ -227,6 +230,7 @@ impl Default for OssConfig {
             credential_process: String::new(),
             default_region: String::new(),
             default_endpoint: String::new(),
+            default_addressing_style: String::new(),
             timeout_secs: 30,
             retry_count: 3,
         }
@@ -643,6 +647,14 @@ pub fn validate_global_config(cfg: &GlobalConfig) -> Result<()> {
                 || (!cfg.oss_config.access_key_id.is_empty()
                     && !cfg.oss_config.secret_access_key.is_empty()),
             "ossConfig.securityToken requires accessKeyId and secretAccessKey"
+        );
+        ensure!(
+            matches!(
+                cfg.oss_config.default_addressing_style.trim(),
+                "" | "virtual" | "path"
+            ),
+            "ossConfig.defaultAddressingStyle must be 'virtual', 'path', or empty for auto-detection, got '{}'",
+            cfg.oss_config.default_addressing_style
         );
     }
 

--- a/storage/overlaybd/tests/oss_addressing_style.rs
+++ b/storage/overlaybd/tests/oss_addressing_style.rs
@@ -1,0 +1,93 @@
+//! Wire-level proof that `ossConfig.defaultAddressingStyle` propagates from the
+//! backend config all the way into the HTTP requests issued for remote layer
+//! reads. No docker or DNS setup required.
+//!
+//! The setup is chosen so that auto-detection and the explicit override
+//! disagree: with endpoint `http://test-bucket.localhost:{port}` and bucket
+//! `test-bucket`, auto-detection picks virtual-host style. An explicit `"path"`
+//! override must strip the bucket prefix from the endpoint and send
+//! `GET /test-bucket/<key>` to `localhost`. If the override were dropped, the
+//! client would instead target the bucket-qualified host and the request
+//! assertions would fail.
+
+use overlaybd::backend::oss::OssBackend;
+use overlaybd::config::OssConfig;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Accept one connection, capture the request head, and answer with a valid
+/// four-byte range response.
+async fn record_one_request(listener: TcpListener) -> String {
+    let (mut socket, _) = listener.accept().await.expect("accept recorder connection");
+    let mut buf = vec![0u8; 8192];
+    // A single read may return a partial head, so keep reading until the
+    // header terminator, EOF, or the buffer limit.
+    let mut n = 0;
+    while n < buf.len() && !buf[..n].windows(4).any(|window| window == b"\r\n\r\n") {
+        let read = socket.read(&mut buf[n..]).await.expect("read request head");
+        if read == 0 {
+            break;
+        }
+        n += read;
+    }
+    let head = String::from_utf8_lossy(&buf[..n]).into_owned();
+    socket
+        .write_all(
+            b"HTTP/1.1 206 Partial Content\r\ncontent-length: 4\r\ncontent-range: bytes 0-3/4\r\nconnection: close\r\n\r\ntest",
+        )
+        .await
+        .expect("write range response");
+    head
+}
+
+#[tokio::test]
+async fn explicit_path_override_reaches_the_wire() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind recorder listener");
+    let port = listener.local_addr().expect("recorder addr").port();
+    let recorder = tokio::spawn(record_one_request(listener));
+
+    let config = OssConfig {
+        enable: true,
+        access_key_id: "test-access-key".to_string(),
+        secret_access_key: "test-secret-key".to_string(),
+        default_region: "auto".to_string(),
+        default_endpoint: format!("http://test-bucket.localhost:{port}"),
+        default_addressing_style: "path".to_string(),
+        timeout_secs: 5,
+        retry_count: 1,
+        ..Default::default()
+    };
+    let backend = OssBackend::new(&config).expect("create oss backend");
+    let file = backend
+        .open_with_size_hint("s3://test-bucket/layers/explicit-style-object", Some(4))
+        .expect("open remote layer file");
+
+    // A successful response avoids coupling this propagation test to the S3
+    // client's retry behavior for synthetic error responses.
+    let (data, head) = tokio::time::timeout(Duration::from_secs(30), async {
+        let data = file.read_at(0, 4).await.expect("read recorded object");
+        let head = recorder.await.expect("recorder task");
+        (data, head)
+    })
+    .await
+    .expect("OSS request did not complete — was the addressing override dropped?");
+    assert_eq!(data.as_ref(), b"test");
+    let request_line = head.lines().next().unwrap_or_default();
+    assert!(
+        request_line.contains("/test-bucket/layers/explicit-style-object"),
+        "expected a path-style request for bucket 'test-bucket', got: {request_line}"
+    );
+    assert!(
+        request_line.starts_with("GET "),
+        "expected a range GET request, got: {request_line}"
+    );
+    let expected_host = format!("Host: localhost:{port}");
+    assert!(
+        head.lines()
+            .any(|line| line.eq_ignore_ascii_case(&expected_host)),
+        "expected the plain endpoint host, got request head: {head}"
+    );
+}

--- a/storage/overlaybd/tests/oss_backend_minio.rs
+++ b/storage/overlaybd/tests/oss_backend_minio.rs
@@ -14,6 +14,7 @@ fn backend(fixture: &MinioFixture) -> OssBackend {
         credential_process: String::new(),
         default_region: fixture.region.clone(),
         default_endpoint: fixture.endpoint.clone(),
+        default_addressing_style: String::new(),
         timeout_secs: 30,
         retry_count: 3,
     };
@@ -29,6 +30,7 @@ fn backend_with_bad_credentials(fixture: &MinioFixture) -> OssBackend {
         credential_process: String::new(),
         default_region: fixture.region.clone(),
         default_endpoint: fixture.endpoint.clone(),
+        default_addressing_style: String::new(),
         timeout_secs: 10,
         retry_count: 0,
     };


### PR DESCRIPTION
## Summary

Add an optional OSS/S3 bucket addressing-style override and propagate it through both snapshot data paths.

## Motivation

The existing OSS backend chooses the addressing style from the endpoint:

- Alibaba OSS endpoints and bucket-in-endpoint hosts use virtual-host style.
- Other endpoints fall back to path style.

Some S3-compatible providers require or prefer virtual-host addressing but cannot be identified reliably by the endpoint heuristic. Without an explicit override, those providers may generate invalid requests.

This change allows users to explicitly select the required addressing style.

## Changes

- Add the optional `backend.oss.addressing_style` configuration:
  - `virtual`
  - `path`
  - unset for the existing endpoint-based auto-detection
- Propagate the setting to the snapshot OSS client.
- Propagate the setting to the generated OverlayBD runtime configuration as `ossConfig.defaultAddressingStyle`.
- Apply the setting to OverlayBD remote managed-layer reads as well as snapshot repository operations and image export.
- Reject unsupported addressing-style values.
- Document the configuration and preserve the existing default behavior.
- Add a wire-level regression test that verifies the actual HTTP method, request path, and `Host` header.
- Keep the implementation focused by removing tests that only duplicated internal enum mappings or parser implementation details.

## Configuration example

```toml
[backend.oss]
endpoint = "https://t3.storage.dev"
bucket = "agentenv-snapshots"
region = "auto"
addressing_style = "virtual"
```

When `addressing_style` is omitted, the existing endpoint-based detection remains unchanged.

## Backward compatibility

Existing configurations do not require any migration.

The default behavior is preserved:

- recognized Alibaba/bucket-host endpoints continue to use virtual-host addressing;
- other endpoints continue to use path-style addressing unless explicitly overridden.

This change does not modify Prometheus metrics or the `/metrics` endpoints.

## Validation

The following checks pass locally:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p object-store-operator`
- `cargo clippy -p object-store-operator --all-targets -- -D warnings`

The full AgentENV and OverlayBD test suites require a Linux environment. They could not be run locally on macOS because the workspace's `io-uring` dependency uses Linux-only libc symbols. Linux CI is required for the full workspace verification.

## Relationship to #23

This PR supersedes #23.

The original requirement and initial implementation were proposed by @davidmyriel in #23. Thank you for that work and for the original motivation behind the change.

This PR carries the same behavior forward on top of the current `main` branch, with a refreshed implementation, focused regression tests, and updated documentation. The current implementation was reorganized to fit the latest codebase while preserving the original user-facing intent.