### PR TITLE
fix(snapshot): parallelize OSS layer uploads and skip publish-time re-hash

### DIFF
--- a/src/sandbox/firecracker/overlaybd_snapshot.rs
+++ b/src/sandbox/firecracker/overlaybd_snapshot.rs
@@ -28,7 +28,7 @@ use super::sandbox::managed_snapshot_base;
 use crate::cfg::ConfigManager;
 use crate::sandbox::ublk::UblkDevice;
 use crate::sandbox::ublk::{
-    compact_layers, create_commit_args, OverlaybdCompactOutput, UblkDeviceManager,
+    compact_layers, create_commit_args_with_digest, OverlaybdCompactOutput, UblkDeviceManager,
 };
 use crate::sandbox::SandboxCaptureError;
 
@@ -66,6 +66,7 @@ fn into_terminal_snapshot_failure(err: anyhow::Error) -> anyhow::Error {
     SandboxCaptureError::terminal(err).into()
 }
 
+#[cfg(test)]
 fn local_layer_config(path: &Path) -> LayerConfig {
     local_layer_config_with_descriptor(path, None)
 }
@@ -432,14 +433,17 @@ async fn rewrite_lowers_with_runtime_roots(
         if runtime_suffix.iter().any(|lower| lower.file.is_empty()) {
             anyhow::bail!("cannot compact runtime-owned overlaybd suffix with remote lowers");
         }
-        if let Some(compacted_path) = compact_layers(
+        if let Some((compacted_path, compacted_descriptor)) = compact_layers(
             &runtime_suffix,
             &output_dir.join(compaction_output_name),
             compaction_output,
         )
         .await?
         {
-            lowers.push(local_layer_config(&compacted_path));
+            lowers.push(local_layer_config_with_descriptor(
+                &compacted_path,
+                compacted_descriptor.as_ref(),
+            ));
         }
         return Ok(lowers);
     }
@@ -559,12 +563,13 @@ async fn capture_live_overlaybd_snapshot(
 pub(super) async fn build_mem_snapshot_image_config(
     resume_mem_image_config_path: Option<&Path>,
     new_layer_path: &Path,
+    new_layer_descriptor: Option<&overlaybd::LayerDescriptor>,
     output_dir: &Path,
     memory_output: OverlaybdCompactOutput,
 ) -> Result<ImageConfig> {
     let inherited_image_config =
         load_existing_image_config(resume_mem_image_config_path, "memory snapshot")?;
-    let new_layer = local_layer_config(new_layer_path);
+    let new_layer = local_layer_config_with_descriptor(new_layer_path, new_layer_descriptor);
     let lowers = rewrite_lowers_with_owned_runtime_suffix(
         inherited_image_config.lowers,
         output_dir,
@@ -636,7 +641,7 @@ async fn publish_memory_overlaybd_layer(
     output_path: &Path,
     mode: OverlaybdCompactOutput,
     concurrency: usize,
-) -> Result<()> {
+) -> Result<Option<overlaybd::LayerDescriptor>> {
     let lower_tmp = output_path.with_extension("commit.tmp");
     let build_result = async {
         let io_ring = shared_transient_io_ring();
@@ -645,7 +650,8 @@ async fn publish_memory_overlaybd_layer(
                 .await
                 .with_context(|| format!("create temp lower failed: {}", lower_tmp.display()))?,
         );
-        let commit_args = create_commit_args(output_file, mode, concurrency).await?;
+        let (commit_args, digest_tracker) =
+            create_commit_args_with_digest(output_file, mode, concurrency).await?;
         compact_to(src_layers, mappings, virtual_size, commit_args)
             .await
             .context("compact memory layer")?;
@@ -657,7 +663,7 @@ async fn publish_memory_overlaybd_layer(
                     output_path.display()
                 )
             })?;
-        Ok(())
+        Ok(digest_tracker.descriptor())
     }
     .await;
 
@@ -757,7 +763,7 @@ pub(crate) async fn convert_dirty_memory_to_overlaybd(
     dirty_ranges: &DirtyMemoryRanges,
     output_dir: &Path,
     mode: OverlaybdCompactOutput,
-) -> Result<(PathBuf, u64)> {
+) -> Result<(PathBuf, u64, Option<overlaybd::LayerDescriptor>)> {
     tokio::fs::create_dir_all(output_dir)
         .await
         .with_context(|| format!("create mem overlaybd dir: {}", output_dir.display()))?;
@@ -766,7 +772,7 @@ pub(crate) async fn convert_dirty_memory_to_overlaybd(
     let (mappings, memory_size) = dirty_ranges_to_segment_mappings(dirty_ranges)?;
     let source_file: Arc<dyn VirtualFile> = Arc::new(ProcessVmReader::new(firecracker_pid));
     let src_layers = vec![source_file];
-    publish_memory_overlaybd_layer(
+    let descriptor = publish_memory_overlaybd_layer(
         &src_layers,
         &mappings,
         memory_size,
@@ -777,7 +783,7 @@ pub(crate) async fn convert_dirty_memory_to_overlaybd(
     .await
     .context("compact dirty memory ranges as overlaybd layer")?;
 
-    Ok((data_path, memory_size))
+    Ok((data_path, memory_size, descriptor))
 }
 
 #[cfg(test)]
@@ -1071,6 +1077,7 @@ mod tests {
         let image_config = build_mem_snapshot_image_config(
             Some(&parent_config_path),
             &new_layer,
+            None,
             temp.path(),
             OverlaybdCompactOutput::Raw,
         )

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -681,7 +681,7 @@ impl FirecrackerSandbox {
         let memory_output = OverlaybdCompactOutput::from_memory_snapshot_config(
             &ConfigManager::global_config().memory_snapshot,
         );
-        let (mem_layer_path, mem_virtual_size) = self
+        let (mem_layer_path, mem_virtual_size, mem_layer_descriptor) = self
             .snapshot_memory_to_overlaybd(&vm_state_path, snapshot_dir, memory_output)
             .await?;
 
@@ -697,6 +697,7 @@ impl FirecrackerSandbox {
         let mem_image_config = build_mem_snapshot_image_config(
             resume_mem_image_config_path,
             &mem_layer_path,
+            mem_layer_descriptor.as_ref(),
             snapshot_dir,
             memory_output,
         )
@@ -820,7 +821,7 @@ impl FirecrackerSandbox {
         vm_state_path: &Path,
         snapshot_dir: &Path,
         memory_output: OverlaybdCompactOutput,
-    ) -> Result<(PathBuf, u64)> {
+    ) -> Result<(PathBuf, u64, Option<overlaybd::LayerDescriptor>)> {
         let mem_overlaybd_dir = snapshot_dir.join("mem_overlaybd");
         let firecracker_pid = self.fc_instance.pid()?;
         self.fc_instance

--- a/src/sandbox/ublk/mod.rs
+++ b/src/sandbox/ublk/mod.rs
@@ -5,5 +5,5 @@ pub(crate) use device::{SharedMemDevice, UblkCreateSpec, UblkDevice};
 pub use device::{UblkBackend, UblkConfig, UblkDaemonConfig, UblkDeviceManager};
 pub use overlaybd::OverlaybdConfig;
 pub(crate) use overlaybd::{
-    compact_layers, create_commit_args, OverlaybdCompactOutput, OverlaybdRuntimeHandle,
+    compact_layers, create_commit_args_with_digest, OverlaybdCompactOutput, OverlaybdRuntimeHandle,
 };

--- a/src/sandbox/ublk/overlaybd.rs
+++ b/src/sandbox/ublk/overlaybd.rs
@@ -4,9 +4,10 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use overlaybd::backend::local::LocalFile;
 use overlaybd::config::{LayerConfig, UpperMode};
-use overlaybd::index_file::{merge_files_ro, CommitArgs};
+use overlaybd::index_file::{merge_files_ro, CommitArgs, DigestTrackingFile, OrderedWriter};
 use overlaybd::virtual_file::VirtualFile;
 use overlaybd::zfile::{CompressArgs, CompressOptions, ZFileCompactWriter};
+use overlaybd::LayerDescriptor;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use uuid::Uuid;
@@ -69,6 +70,20 @@ pub(crate) async fn create_commit_args(
     Ok(args)
 }
 
+/// Like [`create_commit_args`], but tracks a content descriptor (streaming
+/// sha256 + size) of the sealed output at no extra I/O cost. The descriptor
+/// is `None` when writes were not strictly ordered.
+pub(crate) async fn create_commit_args_with_digest(
+    output: Arc<dyn VirtualFile>,
+    mode: OverlaybdCompactOutput,
+    concurrency: usize,
+) -> Result<(CommitArgs, Arc<DigestTrackingFile>)> {
+    let tracker = Arc::new(DigestTrackingFile::new(output));
+    let mut args = create_commit_args(tracker.clone(), mode, concurrency).await?;
+    args.writer = Arc::new(OrderedWriter::new(args.writer.clone()));
+    Ok((args, tracker))
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OverlaybdConfig {
     pub image_config_path: PathBuf,
@@ -99,7 +114,7 @@ pub(crate) async fn compact_layers(
     layers: &[LayerConfig],
     output_path: &Path,
     mode: OverlaybdCompactOutput,
-) -> Result<Option<PathBuf>> {
+) -> Result<Option<(PathBuf, Option<LayerDescriptor>)>> {
     if layers.is_empty() {
         return Ok(None);
     }
@@ -126,13 +141,14 @@ pub(crate) async fn compact_layers(
     }
 
     let lower_tmp = output_path.with_extension(format!("commit.{}.tmp", Uuid::now_v7()));
-    let build_result: Result<()> = async {
+    let build_result: Result<Option<LayerDescriptor>> = async {
         let output_file: Arc<dyn VirtualFile> = Arc::new(
             LocalFile::new(&lower_tmp, io_ring)
                 .await
                 .context("create compacted layer output file")?,
         );
-        let commit_args = create_commit_args(output_file, mode, 32).await?;
+        let (commit_args, digest_tracker) =
+            create_commit_args_with_digest(output_file, mode, 32).await?;
         merge_files_ro(&src_files, commit_args)
             .await
             .context("merge layers")?;
@@ -144,21 +160,21 @@ pub(crate) async fn compact_layers(
                     output_path.display()
                 )
             })?;
-        Ok(())
+        Ok(digest_tracker.descriptor())
     }
     .await;
 
     if build_result.is_err() {
         let _ = tokio::fs::remove_file(&lower_tmp).await;
     }
-    build_result?;
+    let descriptor = build_result?;
 
     debug!(
         output = %output_path.display(),
         input_layers = layers.len(),
         "compacted overlaybd layers"
     );
-    Ok(Some(output_path.to_path_buf()))
+    Ok(Some((output_path.to_path_buf(), descriptor)))
 }
 
 #[cfg(test)]
@@ -316,11 +332,22 @@ mod tests {
             ),
         ] {
             let output_path = temp.path().join(format!("compacted-{name}.commit"));
-            let published = compact_layers(&layers, &output_path, mode)
+            let (published, descriptor) = compact_layers(&layers, &output_path, mode)
                 .await
-                .expect("compact mixed raw/lz4/zstd layers");
-            assert_eq!(published.as_deref(), Some(output_path.as_path()));
+                .expect("compact mixed raw/lz4/zstd layers")
+                .expect("compaction produces an output");
+            assert_eq!(published, output_path);
             assert!(!output_path.with_extension("commit.tmp").exists());
+
+            // The streamed digest must match a plain sha256 of the output file.
+            let descriptor = descriptor.expect("digest descriptor for compacted layer");
+            let file_bytes = std::fs::read(&output_path).expect("read compacted output");
+            assert_eq!(descriptor.size, file_bytes.len() as u64, "mode {name}");
+            assert_eq!(
+                descriptor.digest,
+                crate::digest::sha256_digest(&file_bytes),
+                "mode {name}"
+            );
 
             let (zfile_flag, data) = read_sealed_layer(&output_path, vsize as usize).await;
             assert_eq!(zfile_flag, expected_zfile, "mode {name}");

--- a/src/snapshot/repository/backends/oss/client.rs
+++ b/src/snapshot/repository/backends/oss/client.rs
@@ -17,7 +17,16 @@ use url::Url;
 
 use crate::observability::prometheus::MetricGuard;
 
-const CHUNK_SIZE: usize = 8 * 1024 * 1024;
+/// Multipart part size for streaming file uploads. S3/OSS caps a multipart
+/// upload at 10,000 parts, so this bounds the largest uploadable object
+/// (~625 GiB at 64 MiB). Must be passed explicitly to opendal via
+/// `writer_with().chunk()`: without it opendal falls back to the service's
+/// minimum multipart part size (5 MiB), capping uploads at ~50 GiB.
+const CHUNK_SIZE: usize = 64 * 1024 * 1024;
+/// Number of multipart parts uploaded concurrently per file. A single
+/// sequential stream tops out at roughly 100 MB/s to the OSS internal
+/// endpoint; concurrent parts multiply effective throughput.
+const UPLOAD_CONCURRENCY: usize = 8;
 const OSS_OPERATION_DURATION: &str = "agentenv_snapshot_oss_operation_duration_seconds";
 
 /// Snapshot artifacts uploaded to OSS. Used as the `artifact` label on upload
@@ -425,7 +434,11 @@ async fn upload_file_to_operator(
     key: &str,
     path: &Path,
 ) -> opendal::Result<()> {
-    let mut writer = operator.writer(key).await?;
+    let mut writer = operator
+        .writer_with(key)
+        .chunk(CHUNK_SIZE)
+        .concurrent(UPLOAD_CONCURRENCY)
+        .await?;
     let mut file = tokio::fs::File::open(path)
         .await
         .map_err(|err| io_error_to_opendal(err, "open upload source file"))?;

--- a/storage/overlaybd/src/lsmt/file/digest_tracking.rs
+++ b/storage/overlaybd/src/lsmt/file/digest_tracking.rs
@@ -1,0 +1,171 @@
+//! Write-path decorators used to attach a content descriptor to compacted or
+//! committed output.
+//!
+//! [`DigestTrackingFile`] is a [`VirtualFile`] decorator that streams a
+//! sha256 over every `write_at` payload in file order, letting a sealed layer
+//! carry its content descriptor (digest + size) without a post-write re-read.
+//! Writes landing out of order poison the tracker so it yields no descriptor;
+//! callers then fall back to hashing the output file explicitly.
+//!
+//! [`OrderedWriter`] is a [`CompactWriter`] decorator that forces the ordered
+//! compaction path (sequential, in-order writes) so the digest tracked at the
+//! output-file level is well-defined. The raw `VirtualFileWriter` would
+//! otherwise let `compact_to` issue out-of-order concurrent chunk writes.
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use bytes::Bytes;
+use sha2::{Digest, Sha256};
+use storage_util::compact_writer::{CompactBuffer, CompactWriter};
+
+use super::types::LayerDescriptor;
+use crate::io::virtual_file::VirtualFile;
+
+pub struct DigestTrackingFile {
+    inner: Arc<dyn VirtualFile>,
+    state: Mutex<DigestTrackingState>,
+}
+
+struct DigestTrackingState {
+    hasher: Sha256,
+    expected_offset: u64,
+    poisoned: bool,
+}
+
+impl DigestTrackingFile {
+    pub fn new(inner: Arc<dyn VirtualFile>) -> Self {
+        Self {
+            inner,
+            state: Mutex::new(DigestTrackingState {
+                hasher: Sha256::new(),
+                expected_offset: 0,
+                poisoned: false,
+            }),
+        }
+    }
+
+    /// Content descriptor of everything written so far, or `None` when writes
+    /// were not strictly ordered (the digest is then meaningless).
+    pub fn descriptor(&self) -> Option<LayerDescriptor> {
+        let state = self.state.lock().expect("digest tracker lock");
+        if state.poisoned {
+            return None;
+        }
+        Some(LayerDescriptor {
+            digest: format!("sha256:{:x}", state.hasher.clone().finalize()),
+            size: state.expected_offset,
+        })
+    }
+
+    fn absorb(&self, offset: u64, data: &[u8]) {
+        let mut state = self.state.lock().expect("digest tracker lock");
+        if offset != state.expected_offset {
+            state.poisoned = true;
+            return;
+        }
+        state.hasher.update(data);
+        state.expected_offset += data.len() as u64;
+    }
+}
+
+#[async_trait::async_trait]
+impl VirtualFile for DigestTrackingFile {
+    async fn read_at(&self, offset: u64, len: usize) -> Result<Bytes> {
+        self.inner.read_at(offset, len).await
+    }
+
+    async fn write_at(&self, offset: u64, data: &[u8]) -> Result<usize> {
+        let written = self.inner.write_at(offset, data).await?;
+        self.absorb(offset, &data[..written]);
+        Ok(written)
+    }
+
+    // `as_any` is intentionally not overridden: fast paths that downcast to
+    // the inner concrete file must not bypass digest tracking.
+
+    async fn size(&self) -> Result<u64> {
+        self.inner.size().await
+    }
+
+    async fn truncate(&self, size: u64) -> Result<()> {
+        self.inner.truncate(size).await
+    }
+
+    async fn sync(&self) -> Result<()> {
+        self.inner.sync().await
+    }
+
+    async fn seek_data(&self, offset: u64) -> Result<Option<u64>> {
+        self.inner.seek_data(offset).await
+    }
+
+    async fn seek_hole(&self, offset: u64) -> Result<Option<u64>> {
+        self.inner.seek_hole(offset).await
+    }
+
+    async fn discard(&self, offset: u64, len: u64) -> Result<()> {
+        self.inner.discard(offset, len).await
+    }
+
+    async fn evict_range(&self, offset: u64, len: u64) -> Result<()> {
+        self.inner.evict_range(offset, len).await
+    }
+
+    async fn evict_all(&self) -> Result<()> {
+        self.inner.evict_all().await
+    }
+
+    async fn fgetxattr(&self, name: &str) -> Result<Vec<u8>> {
+        self.inner.fgetxattr(name).await
+    }
+
+    async fn flistxattr(&self) -> Result<Vec<String>> {
+        self.inner.flistxattr().await
+    }
+
+    async fn fsetxattr(&self, name: &str, value: &[u8], flags: i32) -> Result<()> {
+        self.inner.fsetxattr(name, value, flags).await
+    }
+
+    async fn fremovexattr(&self, name: &str) -> Result<()> {
+        self.inner.fremovexattr(name).await
+    }
+}
+
+pub struct OrderedWriter {
+    inner: Arc<dyn CompactWriter>,
+}
+
+impl OrderedWriter {
+    pub fn new(inner: Arc<dyn CompactWriter>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl CompactWriter for OrderedWriter {
+    async fn alloc_buffer(&self) -> Result<Box<dyn CompactBuffer>> {
+        self.inner.alloc_buffer().await
+    }
+
+    fn buffer_size(&self) -> usize {
+        self.inner.buffer_size()
+    }
+
+    fn requires_ordered_writes(&self) -> bool {
+        true
+    }
+
+    async fn write(&self, buf: Box<dyn CompactBuffer>, offset: u64, len: usize) -> Result<()> {
+        self.inner.write(buf, offset, len).await
+    }
+
+    async fn write_all_at(&self, data: &[u8], offset: u64) -> Result<()> {
+        self.inner.write_all_at(data, offset).await
+    }
+
+    async fn finalize(&self) -> Result<()> {
+        self.inner.finalize().await
+    }
+}

--- a/storage/overlaybd/src/lsmt/file/mod.rs
+++ b/storage/overlaybd/src/lsmt/file/mod.rs
@@ -1,9 +1,11 @@
+mod digest_tracking;
 mod helper;
 mod readonly;
 mod readwrite;
 mod stack;
 mod types;
 
+pub use digest_tracking::{DigestTrackingFile, OrderedWriter};
 pub(crate) use helper::initialize_file_rw_paths;
 pub use helper::{compact_to, create_mappings_from_sparse, validate_rw_header_pair_paths};
 pub use readonly::LSMTReadOnlyFile;


### PR DESCRIPTION
## What

Speed up OSS snapshot layer uploads and remove a redundant full-file hash from the publish path:

- Upload layers with an explicit 64 MiB multipart part size and up to 8 concurrent parts per file (previously the default writer: service-minimum part size, strictly serial).
- Attach sha256/size descriptors to freshly compacted layers at write time (streaming, zero extra I/O) so publish can register them by descriptor instead of re-reading the whole layer to hash it.

## Why

Production snapshot publishes of large sandboxes could not finish within client deadlines: single-stream multipart uploads to the OSS internal endpoint top out at ~100 MB/s, so a ~215 GiB rootfs layer needs ~37 min of pure upload, plus a full 215 GiB re-read for hashing before every upload. Retrying on every 30 min client timeout made the failure deterministic. Measured against an isolated OSS validation bucket with an 8 GiB object: serial default 64.6 MiB/s, serial 64 MiB chunk 80.8 MiB/s, 64 MiB chunk x8 concurrent 697-800 MiB/s (~10x).

## Related issue

N/A (no tracking issue; root-caused from production incident analysis)

## Scope and non-goals

Included:
- `oss/client.rs`: 64 MiB `CHUNK_SIZE` via `writer_with().chunk()`, `UPLOAD_CONCURRENCY=8`.
- `create_commit_args_with_digest()` + `compact_layers` / memory-snapshot layer builder: record the descriptor in the staged `image.json` lowers (rootfs compaction and memory layer), so publish uses `import_managed_layer_with_descriptor` (HEAD existence check).
- `lsmt/file/digest_tracking.rs` (new): `DigestTrackingFile` (file-order streaming sha256 over `write_at`) and `OrderedWriter` (forces ordered compaction writes), exported via `overlaybd::index_file`.

Excluded (follow-ups, intentionally not here):
- Moving the >32-layer runtime-suffix compaction out of the snapshot hot path.
- Cancellation-safe publish on client disconnect; memory-layer compression; Firecracker discard support.

## Design and behavior changes

- Multipart part size is now explicit (64 MiB), keeping a single object under the 10,000-part S3 limit up to ~625 GiB; parts upload up to 8-way concurrently (bounded by opendal's concurrent task queue; worst-case extra memory is concurrency x part size per in-flight upload).
- Digest correctness: `DigestTrackingFile` hashes only strictly in-order writes; any out-of-order write poisons the tracker and yields no descriptor, in which case publish falls back to the previous explicit file hash. `OrderedWriter` forces compact_to's ordered branch (reads stay 32-way concurrent, writes serialize) so raw outputs also hash correctly. The zfile path required file-level (not CompactWriter-level) hashing because CompactWriter sees pre-compression bytes.
- Staged `image.json` lowers for locally produced layers now carry non-empty `digest`/`size` when they could be computed inline; previously always empty for these entries.

## Compatibility and operations

- Public API or generated protocol: N/A (no API/OpenAPI changes).
- Configuration or defaults: N/A (part size and concurrency are compile-time constants).
- Snapshot manifest, artifact layout, or storage format: staged `image.json` lower entries gain `digest`/`size` values; consumers already tolerate them (descriptor-aware import path existed and is used for restacked layers today). OSS object keys remain content-addressed by the same sha256 convention.
- Upgrade and rollback: safe in either direction; descriptor absence only means the old explicit-hash path is used. Rollback loses the upload speedup only.
- Host requirements, permissions, ports, or dependencies: N/A.

## Validation

- [x] `make fmt` (cargo fmt --all -- --check)
- [x] `make clippy` (cargo clippy -p overlaybd -p agentenv --all-targets -- -D warnings)
- [x] `make test-unit` equivalent: cargo test -p overlaybd --lib; cargo test -p agentenv --lib (see notes)
- [ ] Relevant Rust integration tests (not run: require KVM/ublk host changes beyond this patch)
- [x] Benchmarks or performance comparison completed

Commands and results:

```text
cargo test -p overlaybd --lib
  → 310 passed; 0 failed
cargo test -p agentenv --lib compact_layers
  → 1 passed (raw/lz4/zstd digest == sha256(output file))
cargo test -p agentenv --lib overlaybd_snapshot
  → 9 passed; 0 failed
cargo clippy -p overlaybd -p agentenv --all-targets -- -D warnings
  → clean
cargo test -p agentenv --lib
  → 723 passed; 2 failed (both pre-existing environment issues:
     privileges capability test, acr docker-credential-helper test;
     unrelated to this change)

Upload benchmark (temporary harness, not committed; isolated OSS
validation bucket, 8 GiB object):
  writer() default                 64.6 MiB/s
  writer_with().chunk(64MiB)       80.8 MiB/s
  + .concurrent(8)                799.8 / 697.6 MiB/s (two runs)
```

Skipped checks and reasons:
- `make -C services test`: no `services/` changes.
- Generated clients/server: no generated-code changes.
- Documentation: no user-facing docs affected.

## Risks and reviewer notes

- Multipart part-size change affects only new uploads; in-flight or previously uploaded objects are unaffected. Concurrent part uploads use more memory (<= 8 x 64 MiB in-flight per upload).
- Ordered-write forcing removes out-of-order concurrent chunk writes for the digest-enabled compaction paths; reads remain parallel, and unordered behavior elsewhere is unchanged.
- Digest poisoning path is exercised implicitly by falling back to explicit hashing; reviewers may want to double-check `lsmt/file/digest_tracking.rs` absorb-order logic and the zfile write-order assumption (validated by the lz4/zstd compact_layers test).
- `local_layer_config` in overlaybd_snapshot.rs is now test-only (`#[cfg(test)]`) since all production call sites use the descriptor variant.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
