### PR TITLE
fix(network): tighten sandbox host isolation and egress handling

### DIFF
--- a/src/sandbox/network/manager.rs
+++ b/src/sandbox/network/manager.rs
@@ -563,21 +563,39 @@ impl NetworkManager {
 
 fn global_host_iptables_commands(
     host_interaction_cidr: Ipv4Network,
-) -> [IptablesRestoreCommand; 3] {
+) -> [IptablesRestoreCommand; 5] {
     let cidr = host_interaction_cidr.to_string();
     [
+        // Guest replies to host-initiated proxy/envd connections must remain
+        // reachable, while all other guest-to-host traffic is rejected below.
+        IptablesRestoreCommand::Insert {
+            table: "filter",
+            chain: "INPUT",
+            position: 1,
+            rule: format!(
+                "-i {HOST_VETH_PREFIX}+ -s {cidr} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT"
+            ),
+        },
+        IptablesRestoreCommand::Insert {
+            table: "filter",
+            chain: "INPUT",
+            position: 2,
+            rule: format!("-i {HOST_VETH_PREFIX}+ -s {cidr} -j REJECT"),
+        },
         // Packets are SNATted to the host interaction CIDR inside the sandbox namespace before
         // they enter the host FORWARD chain, so hosts with a DROP FORWARD policy
         // need to accept this post-SNAT source range.
         IptablesRestoreCommand::Append {
             table: "filter",
             chain: "FORWARD",
-            rule: format!("-s {cidr} -j ACCEPT"),
+            rule: format!("-i {HOST_VETH_PREFIX}+ -s {cidr} -j ACCEPT"),
         },
         IptablesRestoreCommand::Append {
             table: "filter",
             chain: "FORWARD",
-            rule: format!("-d {cidr} -m state --state RELATED,ESTABLISHED -j ACCEPT"),
+            rule: format!(
+                "-o {HOST_VETH_PREFIX}+ -d {cidr} -m state --state RELATED,ESTABLISHED -j ACCEPT"
+            ),
         },
         IptablesRestoreCommand::Append {
             table: "nat",
@@ -589,18 +607,32 @@ fn global_host_iptables_commands(
 
 fn global_host_iptables_delete_commands(
     host_interaction_cidr: Ipv4Network,
-) -> [IptablesRestoreCommand; 3] {
+) -> [IptablesRestoreCommand; 5] {
     let cidr = host_interaction_cidr.to_string();
     [
         IptablesRestoreCommand::Delete {
             table: "filter",
-            chain: "FORWARD",
-            rule: format!("-s {cidr} -j ACCEPT"),
+            chain: "INPUT",
+            rule: format!(
+                "-i {HOST_VETH_PREFIX}+ -s {cidr} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT"
+            ),
+        },
+        IptablesRestoreCommand::Delete {
+            table: "filter",
+            chain: "INPUT",
+            rule: format!("-i {HOST_VETH_PREFIX}+ -s {cidr} -j REJECT"),
         },
         IptablesRestoreCommand::Delete {
             table: "filter",
             chain: "FORWARD",
-            rule: format!("-d {cidr} -m state --state RELATED,ESTABLISHED -j ACCEPT"),
+            rule: format!("-i {HOST_VETH_PREFIX}+ -s {cidr} -j ACCEPT"),
+        },
+        IptablesRestoreCommand::Delete {
+            table: "filter",
+            chain: "FORWARD",
+            rule: format!(
+                "-o {HOST_VETH_PREFIX}+ -d {cidr} -m state --state RELATED,ESTABLISHED -j ACCEPT"
+            ),
         },
         IptablesRestoreCommand::Delete {
             table: "nat",

--- a/src/sandbox/network/policy.rs
+++ b/src/sandbox/network/policy.rs
@@ -127,7 +127,6 @@ fn configured_always_denied_cidrs() -> &'static [String] {
 }
 
 pub(super) fn initialize_namespace_egress_chain(
-    veth_host_ip: Ipv4Addr,
     guest_dns_ip: Ipv4Addr,
     internal_egress_denied_cidrs: &[String],
 ) -> Result<()> {
@@ -152,7 +151,6 @@ pub(super) fn initialize_namespace_egress_chain(
         },
     ];
     commands.extend(build_static_egress_commands(
-        veth_host_ip,
         guest_dns_ip,
         internal_egress_denied_cidrs,
         configured_always_denied_cidrs(),
@@ -163,16 +161,22 @@ pub(super) fn initialize_namespace_egress_chain(
 }
 
 fn build_static_egress_commands(
-    veth_host_ip: Ipv4Addr,
     guest_dns_ip: Ipv4Addr,
     internal_egress_denied_cidrs: &[String],
     node_always_denied_cidrs: &[String],
 ) -> Vec<IptablesRestoreCommand> {
     let mut commands = Vec::new();
 
-    for cidr in [format!("{veth_host_ip}/32"), format!("{guest_dns_ip}/32")] {
+    // Host-initiated proxy/envd connections return through this chain after the
+    // namespace SNATs the guest response to its host interaction address.
+    commands.push(append_egress_command(
+        "-i tap0 -o vpeer -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT".to_string(),
+    ));
+
+    // Allow DNS traffic to the guest DNS server.
+    for protocol in ["udp", "tcp"] {
         commands.push(append_egress_command(format!(
-            "-i tap0 -o vpeer -d {cidr} -j ACCEPT"
+            "-i tap0 -o vpeer -d {guest_dns_ip}/32 -p {protocol} --dport 53 -j ACCEPT"
         )));
     }
 
@@ -416,27 +420,56 @@ mod tests {
         let denied_cidrs = NetworkConfig::default().egress.always_denied_cidrs;
         let internal_egress_denied_cidrs = Vec::new();
         let commands = build_static_egress_commands(
-            Ipv4Addr::new(10, 12, 0, 2),
             Ipv4Addr::new(10, 1, 2, 1),
             &internal_egress_denied_cidrs,
             &denied_cidrs,
         );
 
-        let host_allow_pos = commands
+        assert_eq!(
+            append_rule(&commands[0]),
+            Some("-i tap0 -o vpeer -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
+        );
+        let established_pos = commands
             .iter()
             .position(|command| {
-                append_rule(command) == Some("-i tap0 -o vpeer -d 10.12.0.2/32 -j ACCEPT")
+                append_rule(command)
+                    == Some("-i tap0 -o vpeer -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
             })
             .unwrap();
-        assert!(commands.iter().any(
-            |command| append_rule(command) == Some("-i tap0 -o vpeer -d 10.1.2.1/32 -j ACCEPT")
-        ));
+        let dns_udp_pos = commands
+            .iter()
+            .position(|command| {
+                append_rule(command)
+                    == Some("-i tap0 -o vpeer -d 10.1.2.1/32 -p udp --dport 53 -j ACCEPT")
+            })
+            .unwrap();
+        let dns_tcp_pos = commands
+            .iter()
+            .position(|command| {
+                append_rule(command)
+                    == Some("-i tap0 -o vpeer -d 10.1.2.1/32 -p tcp --dport 53 -j ACCEPT")
+            })
+            .unwrap();
+        assert!(commands.iter().any(|command| {
+            append_rule(command)
+                == Some("-i tap0 -o vpeer -d 10.1.2.1/32 -p udp --dport 53 -j ACCEPT")
+        }));
+        assert!(commands.iter().any(|command| {
+            append_rule(command)
+                == Some("-i tap0 -o vpeer -d 10.1.2.1/32 -p tcp --dport 53 -j ACCEPT")
+        }));
+        assert!(!commands.iter().any(|command| {
+            append_rule(command) == Some("-i tap0 -o vpeer -d 10.12.0.2/32 -j ACCEPT")
+        }));
         let hard_deny_pos = commands
             .iter()
             .position(|command| {
                 append_rule(command) == Some("-i tap0 -o vpeer -d 10.0.0.0/8 -j REJECT")
             })
             .unwrap();
+        assert!(established_pos < hard_deny_pos);
+        assert!(dns_udp_pos < hard_deny_pos);
+        assert!(dns_tcp_pos < hard_deny_pos);
         let shared_deny_pos = commands
             .iter()
             .position(|command| {
@@ -450,7 +483,6 @@ mod tests {
             })
             .unwrap();
 
-        assert!(host_allow_pos < hard_deny_pos);
         assert!(hard_deny_pos < shared_deny_pos);
         assert!(hard_deny_pos < user_chain_pos);
         assert!(shared_deny_pos < user_chain_pos);
@@ -461,7 +493,6 @@ mod tests {
         let denied_cidrs = vec!["203.0.113.0/24".to_string()];
         let internal_egress_denied_cidrs = Vec::new();
         let commands = build_static_egress_commands(
-            Ipv4Addr::new(10, 12, 0, 2),
             Ipv4Addr::new(10, 1, 2, 1),
             &internal_egress_denied_cidrs,
             &denied_cidrs,

--- a/src/sandbox/network/slot.rs
+++ b/src/sandbox/network/slot.rs
@@ -263,7 +263,6 @@ impl Slot {
         // IPTables Setup
         Self::configure_namespace_iptables_rules(
             host_interaction_ip,
-            veth_host_ip,
             address_plan.vm_ip(),
             &address_plan.internal_egress_denied_cidrs(),
         )
@@ -486,10 +485,9 @@ impl Slot {
     /// - Enabling IP forwarding so the namespace can route between tap0 and vpeer.
     /// - FORWARD rules to permit traffic between the VM (tap0) and the host veth (vpeer).
     /// - SNAT/DNAT for host<->VM communication via host_interaction_ip.
-    #[tracing::instrument(fields(vm_ip = %vm_ip, host_interaction_ip = %host_interaction_ip, veth_host_ip = %veth_host_ip))]
+    #[tracing::instrument(fields(vm_ip = %vm_ip, host_interaction_ip = %host_interaction_ip))]
     fn configure_namespace_iptables_rules(
         host_interaction_ip: Ipv4Addr,
-        veth_host_ip: Ipv4Addr,
         vm_ip: Ipv4Addr,
         internal_egress_denied_cidrs: &[String],
     ) -> Result<()> {
@@ -524,11 +522,7 @@ impl Slot {
         ];
 
         apply_iptables_commands(&commands, OpenFailurePolicy::ReturnErr)?;
-        initialize_namespace_egress_chain(
-            veth_host_ip,
-            resolve_guest_dns_server(),
-            internal_egress_denied_cidrs,
-        )
+        initialize_namespace_egress_chain(resolve_guest_dns_server(), internal_egress_denied_cidrs)
     }
 
     fn tune_neigh_retrans_time_ms(interface: &str) {

--- a/src/sandbox/network/slot.rs
+++ b/src/sandbox/network/slot.rs
@@ -60,6 +60,10 @@ pub(crate) struct Slot {
     address_plan: NetworkAddressPlan,
     netns_dir: PathBuf,
     cleanup_armed: AtomicBool,
+    /// Whether this namespace's user egress chain currently contains rules.
+    /// Warm-pool reuse preserves the namespace, so the next tenant may need to
+    /// clear rules left by the previous tenant.
+    user_egress_rules_present: AtomicBool,
 }
 
 struct NamespaceSetup {
@@ -104,6 +108,7 @@ impl Slot {
             address_plan,
             netns_dir,
             cleanup_armed: AtomicBool::new(false),
+            user_egress_rules_present: AtomicBool::new(false),
         })
     }
 
@@ -449,6 +454,11 @@ impl Slot {
     }
 
     pub(crate) fn set_egress_policy(&self, policy: Option<&SandboxNetworkPolicy>) -> Result<()> {
+        let wants_rules = policy.is_some_and(SandboxNetworkPolicy::has_runtime_egress_rules);
+        if !wants_rules && !self.user_egress_rules_present.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
         let netns_path = self.namespace_path();
         let policy = policy.cloned();
         let handle = thread::spawn(move || -> Result<()> {
@@ -460,10 +470,15 @@ impl Slot {
             set_namespace_egress_policy(policy.as_ref())
         });
 
-        match handle.join() {
+        let result = match handle.join() {
             Ok(result) => result,
             Err(e) => Err(anyhow!("egress policy setup thread panicked: {:?}", e)),
+        };
+        if result.is_ok() {
+            self.user_egress_rules_present
+                .store(wants_rules, Ordering::Release);
         }
+        result
     }
 
     /// Configures iptables rules inside the namespace for VM traffic routing.
@@ -1058,6 +1073,41 @@ mod tests {
             parse_nameserver_ipv4(conf),
             Some(Ipv4Addr::new(10, 1, 2, 1))
         );
+    }
+
+    #[test]
+    fn empty_egress_policy_skips_known_clean_slot() {
+        let slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
+        let empty_policy = SandboxNetworkPolicy::default();
+
+        slot.set_egress_policy(None).unwrap();
+        slot.set_egress_policy(Some(&empty_policy)).unwrap();
+
+        assert!(!slot.user_egress_rules_present.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn failed_egress_cleanup_keeps_slot_marked_dirty() {
+        let slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
+        slot.user_egress_rules_present
+            .store(true, Ordering::Release);
+
+        assert!(slot.set_egress_policy(None).is_err());
+
+        assert!(slot.user_egress_rules_present.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn failed_egress_apply_keeps_clean_slot_marked_clean() {
+        let slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
+        let policy = SandboxNetworkPolicy::new(
+            crate::sandbox::network::BaseSandboxNetworkPolicy::Deny,
+            crate::sandbox::network::SandboxNetworkEgressPolicy::default(),
+        );
+
+        assert!(slot.set_egress_policy(Some(&policy)).is_err());
+
+        assert!(!slot.user_egress_rules_present.load(Ordering::Acquire));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Tighten host iptables rules so sandbox traffic is accepted only on AgentENV veth interfaces and unsolicited guest-to-host traffic is rejected.
- Narrow the namespace egress baseline to established reply traffic and DNS over TCP/UDP port 53 instead of allowing all traffic to host-side addresses.
- Track whether a warm network slot contains user egress rules and skip no-op policy cleanup for slots known to be clean.

## Why

The previous host and namespace rules were broader than required for sandbox operation. A sandbox could reach host-side addresses through the baseline egress allow rules, and the global host forwarding rules matched the full host-interaction CIDR without constraining the AgentENV interface. In addition, every sandbox without runtime egress rules still entered its network namespace and reprogrammed an empty user chain, including clean warm-pool slots.

This change reduces the reachable host surface while preserving host-initiated proxy/envd reply traffic and avoids unnecessary namespace/iptables work on the common no-policy path.

## Related issue

N/A - no linked issue was provided.

## Scope and non-goals

Included:

- Host INPUT and FORWARD rules for AgentENV sandbox veth interfaces.
- Static namespace egress allow/deny ordering.
- Warm-slot bookkeeping for user egress rules, including failure-state handling.
- Focused unit coverage for rule construction and clean/dirty slot transitions.

Not included:

- Public network-policy API or schema changes.
- New egress policy capabilities or TCP proxy support.
- Changes to network address allocation, NAT layout, DNS selection, or warm-pool sizing.
- Changes outside the Rust sandbox network subsystem.

## Design and behavior changes

- Global host INPUT rules first accept `ESTABLISHED,RELATED` replies from AgentENV veth interfaces, then reject other guest-to-host traffic from the host-interaction CIDR.
- Global FORWARD rules now match the AgentENV ingress or egress veth interface in addition to the host-interaction CIDR.
- The namespace static egress chain allows established host-initiated replies and DNS to the configured guest DNS server on TCP/UDP port 53 before internal-network rejects. It no longer grants an unrestricted allow to the host-side veth address.
- `Slot` records whether user egress rules were successfully installed. Empty policy updates return immediately for known-clean slots; failed apply or cleanup attempts preserve the prior state so a later reuse does not incorrectly skip cleanup.

## Compatibility and operations

- Public API or generated protocol: N/A - no API schema or generated code changes.
- Configuration or defaults: N/A - existing network configuration and defaults are unchanged.
- Snapshot manifest, artifact layout, or storage format: N/A - no persistence format changes.
- Upgrade and rollback: Revised host rules take effect when the network manager installs them during process startup. Normal shutdown removes the matching rules.
- Host requirements, permissions, ports, or dependencies: No new requirements. The existing iptables and conntrack capabilities used by sandbox networking remain required.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
Unit test suite: passed (run by the author before PR creation)
Rust integration test suite: passed (run by the author before PR creation)
```

The exact command lines were not provided with the PR creation request.

Skipped checks and reasons:

- `make -C services test`: skipped because `services/` is unchanged.
- Code generation: not required because no source schema or generated code changed.
- Documentation: not required because the public API and configuration are unchanged.
- Benchmarks: not run; the optimization removes a no-op namespace/iptables update, and this PR does not claim a measured performance improvement.

## Risks and reviewer notes

- Correctness depends on iptables ordering: established replies and DNS must remain ahead of internal-network rejects, while the host INPUT reject must remain after the established-reply accept.
- The warm-slot flag is deliberately updated only after successful policy programming. Review the failure paths in `src/sandbox/network/slot.rs` together with warm-pool reuse.
- The most security-sensitive changes are the host rules in `src/sandbox/network/manager.rs` and the namespace baseline rules in `src/sandbox/network/policy.rs`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
