### PR TITLE
fix(k8s): bound agentenv preStop drain loop with retries and deadline

### DIFF
--- a/deploy/k8s/base/agentenv-daemonset.yaml
+++ b/deploy/k8s/base/agentenv-daemonset.yaml
@@ -75,20 +75,35 @@ spec:
                   - "-c"
                   - |
                     echo "preStop: waiting for sandboxes to drain..."
-                    while true; do
-                      count=$(curl -sf -H 'X-API-Key: preStop' http://localhost:8000/sandboxes | jq 'length') || count=""
+                    # Global deadline: give up well before
+                    # terminationGracePeriodSeconds so the kubelet still has
+                    # time to SIGTERM the agent and let it persist sandboxes.
+                    drain_timeout=240
+                    deadline=$(( $(date +%s) + drain_timeout ))
+                    failures=0
+                    max_failures=5
+                    while [ "$(date +%s)" -lt "$deadline" ]; do
+                      count=$(curl -sf --max-time 5 -H 'X-API-Key: preStop' http://localhost:8000/sandboxes | jq 'length') || count=""
                       if [ -z "$count" ]; then
-                        echo "preStop: failed to query sandbox count, retrying..."
-                        sleep 3
+                        failures=$((failures + 1))
+                        echo "preStop: failed to query sandbox count (attempt $failures/$max_failures)"
+                        if [ "$failures" -ge "$max_failures" ]; then
+                          echo "preStop: drain query unreachable; proceeding with termination"
+                          exit 0
+                        fi
+                        sleep $(( failures * 3 ))
                         continue
                       fi
+                      failures=0
                       echo "preStop: $count sandbox(es) remaining"
                       if [ "$count" = "0" ]; then
                         echo "preStop: all sandboxes drained, exiting"
-                        break
+                        exit 0
                       fi
                       sleep 3
                     done
+                    echo "preStop: drain deadline (${drain_timeout}s) reached; proceeding with termination"
+                    exit 0
             postStart:
               exec:
                 command:


### PR DESCRIPTION
## What

Bounds the `agentenv-node` DaemonSet `preStop` drain loop in `deploy/k8s/base/agentenv-daemonset.yaml`:

- At most 5 consecutive failures to query `GET /sandboxes` (with linear backoff), then the hook exits 0 — if the local API is gone there is nothing left to drain.
- A global 240s deadline, after which the hook exits 0 so the kubelet can SIGTERM the agent and let its graceful shutdown persist sandboxes.
- `curl --max-time 5` so a hung connection cannot stall the loop.

## Why

The hook polled the local API in an unbounded `while true` loop. When the endpoint was unreachable (or sandboxes never drained), the hook never exited and — with `terminationGracePeriodSeconds: 3600` — the pod stayed `Terminating` for up to an hour.

Observed in staging: one `agentenv-node` pod stuck in `Terminating`, recovered only via `kubectl delete pod --force --grace-period=0`. The force-delete then raced the replacement pod on the shared `hostPath` (`/var/lib/aenv`) state, contributing to the RocksDB `LOCK` contention addressed separately in the orphan-process/lock-retry PR.

## Scope and non-goals

- Included: bounded retries with backoff, global drain deadline, curl timeout in the vendored base DaemonSet manifest.
- Excluded: changing `terminationGracePeriodSeconds` or the graceful-shutdown semantics of the agent itself; the drain policy (who deletes sandboxes before termination) is unchanged.

## Compatibility and operations

- No API, config, or storage-format changes. Rollout only changes pod termination behavior: pods now terminate within minutes instead of hanging up to the full grace period.

## Validation

- [x] YAML parses (`yaml.safe_load`) and the embedded script passes `sh -n`
- [x] Scripted dry-run of all three paths with stubbed `curl`/`jq`: clean drain (exit 0 immediately), unreachable API (5 attempts with backoff, exit 0), never-draining API (global deadline, exit 0)
- [ ] `make test-unit` (N/A: manifest-only change, no Rust code touched)
