### PR TITLE
fix: atomically claim expired sandboxes

### DIFF
--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -968,23 +968,6 @@ where
         self.delete_sandbox_impl(sandbox_id, previous_state).await
     }
 
-    async fn delete_expired_sandbox_inner(
-        self: &Arc<Self>,
-        sandbox_id: SandboxId,
-        cutoff: SystemTime,
-    ) -> Result<bool> {
-        if !self
-            .claim_expired_running_sandbox(sandbox_id, cutoff, SandboxState::Killing)
-            .await?
-        {
-            return Ok(false);
-        }
-
-        self.delete_sandbox_impl(sandbox_id, SandboxState::Running)
-            .await?;
-        Ok(true)
-    }
-
     async fn claim_expired_running_sandbox(
         &self,
         sandbox_id: SandboxId,
@@ -1154,22 +1137,6 @@ where
         }
 
         self.pause_sandbox_impl(sandbox_id).await
-    }
-
-    async fn pause_expired_sandbox_inner(
-        self: &Arc<Self>,
-        sandbox_id: SandboxId,
-        cutoff: SystemTime,
-    ) -> Result<bool> {
-        if !self
-            .claim_expired_running_sandbox(sandbox_id, cutoff, SandboxState::Pausing)
-            .await?
-        {
-            return Ok(false);
-        }
-
-        self.pause_sandbox_impl(sandbox_id).await?;
-        Ok(true)
     }
 
     async fn pause_sandbox_impl(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
@@ -1953,15 +1920,24 @@ where
             if metadata.state != SandboxState::Running {
                 continue;
             }
-            let result = match metadata.timeout_action {
-                SandboxTimeoutAction::Pause => {
-                    self.pause_expired_sandbox_inner(metadata.id, eviction_cutoff)
-                        .await
+            let claimed_state = match metadata.timeout_action {
+                SandboxTimeoutAction::Pause => SandboxState::Pausing,
+                SandboxTimeoutAction::Delete => SandboxState::Killing,
+            };
+            let result = match self
+                .claim_expired_running_sandbox(metadata.id, eviction_cutoff, claimed_state)
+                .await
+            {
+                Ok(true) => match metadata.timeout_action {
+                    SandboxTimeoutAction::Pause => self.pause_sandbox_impl(metadata.id).await,
+                    SandboxTimeoutAction::Delete => {
+                        self.delete_sandbox_impl(metadata.id, SandboxState::Running)
+                            .await
+                    }
                 }
-                SandboxTimeoutAction::Delete => {
-                    self.delete_expired_sandbox_inner(metadata.id, eviction_cutoff)
-                        .await
-                }
+                .map(|_| true),
+                Ok(false) => Ok(false),
+                Err(err) => Err(err),
             };
             match result {
                 Ok(true) => evicted_ids.push(metadata.id),

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -965,8 +965,7 @@ where
             }
         };
 
-        self.delete_sandbox_after_claim(sandbox_id, previous_state)
-            .await
+        self.delete_sandbox_impl(sandbox_id, previous_state).await
     }
 
     async fn delete_expired_sandbox_inner(
@@ -981,7 +980,7 @@ where
             return Ok(false);
         }
 
-        self.delete_sandbox_after_claim(sandbox_id, SandboxState::Running)
+        self.delete_sandbox_impl(sandbox_id, SandboxState::Running)
             .await?;
         Ok(true)
     }
@@ -1025,7 +1024,7 @@ where
         }
     }
 
-    async fn delete_sandbox_after_claim(
+    async fn delete_sandbox_impl(
         self: &Arc<Self>,
         sandbox_id: SandboxId,
         previous_state: SandboxState,
@@ -1154,7 +1153,7 @@ where
             Err(err) => return Err(OrchestratorError::from(err)),
         }
 
-        self.pause_sandbox_after_claim(sandbox_id).await
+        self.pause_sandbox_impl(sandbox_id).await
     }
 
     async fn pause_expired_sandbox_inner(
@@ -1169,11 +1168,11 @@ where
             return Ok(false);
         }
 
-        self.pause_sandbox_after_claim(sandbox_id).await?;
+        self.pause_sandbox_impl(sandbox_id).await?;
         Ok(true)
     }
 
-    async fn pause_sandbox_after_claim(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
+    async fn pause_sandbox_impl(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         // Pin paused runtime artifacts before detaching from the running set.
         let runtime_artifacts = {
             let handle = self.sandboxes.read().await.get(&sandbox_id).cloned();

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -965,6 +965,71 @@ where
             }
         };
 
+        self.delete_sandbox_after_claim(sandbox_id, previous_state)
+            .await
+    }
+
+    async fn delete_expired_sandbox_inner(
+        self: &Arc<Self>,
+        sandbox_id: SandboxId,
+        cutoff: SystemTime,
+    ) -> Result<bool> {
+        if !self
+            .claim_expired_running_sandbox(sandbox_id, cutoff, SandboxState::Killing)
+            .await?
+        {
+            return Ok(false);
+        }
+
+        self.delete_sandbox_after_claim(sandbox_id, SandboxState::Running)
+            .await?;
+        Ok(true)
+    }
+
+    async fn claim_expired_running_sandbox(
+        &self,
+        sandbox_id: SandboxId,
+        cutoff: SystemTime,
+        claimed_state: SandboxState,
+    ) -> Result<bool> {
+        match self
+            .store
+            .update_if_state(&sandbox_id, &[SandboxState::Running], |metadata| {
+                if metadata.is_expired(cutoff) {
+                    metadata.state = claimed_state;
+                }
+            })
+            .await
+        {
+            Ok(update) if update.current.state == claimed_state => Ok(true),
+            Ok(update) => {
+                debug!(
+                    expires_at = ?update.current.expires_at,
+                    ?cutoff,
+                    "skipping auto-eviction because sandbox expiry was updated"
+                );
+                Ok(false)
+            }
+            Err(StoreError::StateConflict { actual_state, .. }) => {
+                debug!(
+                    state = ?actual_state,
+                    "skipping auto-eviction because sandbox state changed"
+                );
+                Ok(false)
+            }
+            Err(StoreError::SandboxNotFound { .. }) => {
+                debug!("skipping auto-eviction because sandbox no longer exists");
+                Ok(false)
+            }
+            Err(err) => Err(OrchestratorError::from(err)),
+        }
+    }
+
+    async fn delete_sandbox_after_claim(
+        self: &Arc<Self>,
+        sandbox_id: SandboxId,
+        previous_state: SandboxState,
+    ) -> Result<()> {
         let (handle, removed_route) = self.detach_sandbox_handle_and_route(&sandbox_id).await;
 
         // If the sandbox is still in memory, attempt to stop it.
@@ -1089,6 +1154,26 @@ where
             Err(err) => return Err(OrchestratorError::from(err)),
         }
 
+        self.pause_sandbox_after_claim(sandbox_id).await
+    }
+
+    async fn pause_expired_sandbox_inner(
+        self: &Arc<Self>,
+        sandbox_id: SandboxId,
+        cutoff: SystemTime,
+    ) -> Result<bool> {
+        if !self
+            .claim_expired_running_sandbox(sandbox_id, cutoff, SandboxState::Pausing)
+            .await?
+        {
+            return Ok(false);
+        }
+
+        self.pause_sandbox_after_claim(sandbox_id).await?;
+        Ok(true)
+    }
+
+    async fn pause_sandbox_after_claim(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         // Pin paused runtime artifacts before detaching from the running set.
         let runtime_artifacts = {
             let handle = self.sandboxes.read().await.get(&sandbox_id).cloned();
@@ -1861,26 +1946,34 @@ where
             return Ok(Vec::new());
         }
 
-        let expired = self.store.list_expired(SystemTime::now()).await?;
+        let eviction_cutoff = SystemTime::now();
+        let expired = self.store.list_expired(eviction_cutoff).await?;
         let mut evicted_ids = Vec::new();
 
         for metadata in expired {
             if metadata.state != SandboxState::Running {
                 continue;
             }
-            if let Err(err) = match metadata.timeout_action {
-                SandboxTimeoutAction::Pause => self.pause_sandbox_inner(metadata.id).await,
-                SandboxTimeoutAction::Delete => self.delete_sandbox_inner(metadata.id).await,
-            } {
-                warn!(
+            let result = match metadata.timeout_action {
+                SandboxTimeoutAction::Pause => {
+                    self.pause_expired_sandbox_inner(metadata.id, eviction_cutoff)
+                        .await
+                }
+                SandboxTimeoutAction::Delete => {
+                    self.delete_expired_sandbox_inner(metadata.id, eviction_cutoff)
+                        .await
+                }
+            };
+            match result {
+                Ok(true) => evicted_ids.push(metadata.id),
+                Ok(false) => continue,
+                Err(err) => warn!(
                     sandbox_id = %metadata.id,
                     action = ?metadata.timeout_action,
                     error = ?err,
                     "failed to auto-evict expired sandbox"
-                );
-                continue;
+                ),
             }
-            evicted_ids.push(metadata.id);
         }
 
         Ok(evicted_ids)

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -191,11 +191,11 @@ impl ScriptedStoreControl {
         *self.claim_gate.lock().expect("claim gate mutex poisoned") = Some(gate);
     }
 
-    fn claim_gate(&self) -> Option<StoreClaimGate> {
+    fn take_claim_gate(&self) -> Option<StoreClaimGate> {
         self.claim_gate
             .lock()
             .expect("claim gate mutex poisoned")
-            .clone()
+            .take()
     }
 
     fn set_list_gate(&self, gate: StoreListGate) {
@@ -293,7 +293,7 @@ impl MetadataStore for ScriptedStore {
                 SandboxState::Pausing | SandboxState::Killing
             )
         }) {
-            if let Some(gate) = self.control.claim_gate() {
+            if let Some(gate) = self.control.take_claim_gate() {
                 gate.claimed.wait().await;
                 gate.release.wait().await;
             }
@@ -3107,7 +3107,12 @@ async fn auto_evict_revalidates_later_candidate_after_prior_claim() -> Result<()
         assert_eq!(renewed_metadata.timeout, Some(Duration::from_secs(60)));
         assert!(!renewed_metadata.is_expired(std::time::SystemTime::now()));
         assert_proxy_ready(&orchestrator, &renewed.id).await?;
-        orchestrator.delete_sandbox(renewed.id).await?;
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            orchestrator.delete_sandbox(renewed.id),
+        )
+        .await
+        .expect("renewed sandbox cleanup should not block on the consumed claim gate")?;
     }
 
     Ok(())
@@ -3174,7 +3179,12 @@ async fn auto_evict_claim_prevents_late_keep_alive_success() -> Result<()> {
                     .await?
                     .expect("auto-paused sandbox metadata should remain");
                 assert_eq!(metadata.state, SandboxState::Paused);
-                orchestrator.delete_sandbox(sandbox_id).await?;
+                tokio::time::timeout(
+                    Duration::from_secs(5),
+                    orchestrator.delete_sandbox(sandbox_id),
+                )
+                .await
+                .expect("paused sandbox cleanup should not block on the consumed claim gate")?;
             }
             SandboxTimeoutAction::Delete => {
                 assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -129,11 +129,43 @@ enum StoreAction {
 type StoreHook = Arc<dyn Fn(&SandboxMetadata) + Send + Sync>;
 type StoreHookSlot = StdMutex<Option<StoreHook>>;
 
+#[derive(Clone)]
+struct StoreClaimGate {
+    claimed: Arc<tokio::sync::Barrier>,
+    release: Arc<tokio::sync::Barrier>,
+}
+
+impl StoreClaimGate {
+    fn new() -> Self {
+        Self {
+            claimed: Arc::new(tokio::sync::Barrier::new(2)),
+            release: Arc::new(tokio::sync::Barrier::new(2)),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct StoreListGate {
+    listed: Arc<tokio::sync::Barrier>,
+    release: Arc<tokio::sync::Barrier>,
+}
+
+impl StoreListGate {
+    fn new() -> Self {
+        Self {
+            listed: Arc::new(tokio::sync::Barrier::new(2)),
+            release: Arc::new(tokio::sync::Barrier::new(2)),
+        }
+    }
+}
+
 #[derive(Default)]
 struct ScriptedStoreControl {
     add_actions: StdMutex<VecDeque<StoreAction>>,
     update_if_state_actions: StdMutex<VecDeque<StoreAction>>,
     on_add: StoreHookSlot,
+    claim_gate: StdMutex<Option<StoreClaimGate>>,
+    list_gate: StdMutex<Option<StoreListGate>>,
 }
 
 impl ScriptedStoreControl {
@@ -153,6 +185,28 @@ impl ScriptedStoreControl {
 
     fn set_on_add(&self, hook: StoreHook) {
         *self.on_add.lock().expect("on_add mutex poisoned") = Some(hook);
+    }
+
+    fn set_claim_gate(&self, gate: StoreClaimGate) {
+        *self.claim_gate.lock().expect("claim gate mutex poisoned") = Some(gate);
+    }
+
+    fn claim_gate(&self) -> Option<StoreClaimGate> {
+        self.claim_gate
+            .lock()
+            .expect("claim gate mutex poisoned")
+            .clone()
+    }
+
+    fn set_list_gate(&self, gate: StoreListGate) {
+        *self.list_gate.lock().expect("list gate mutex poisoned") = Some(gate);
+    }
+
+    fn list_gate(&self) -> Option<StoreListGate> {
+        self.list_gate
+            .lock()
+            .expect("list gate mutex poisoned")
+            .clone()
     }
 
     fn take_action(queue: &StdMutex<VecDeque<StoreAction>>) -> StoreAction {
@@ -223,14 +277,29 @@ impl MetadataStore for ScriptedStore {
     where
         F: FnOnce(&mut SandboxMetadata) + Send,
     {
-        match ScriptedStoreControl::take_action(&self.control.update_if_state_actions) {
+        let result = match ScriptedStoreControl::take_action(&self.control.update_if_state_actions)
+        {
             StoreAction::Delegate => {
                 self.inner
                     .update_if_state(sandbox_id, expected_states, update)
                     .await
             }
             StoreAction::Fail(err) => Err(err),
+        };
+
+        if result.as_ref().is_ok_and(|update| {
+            matches!(
+                update.current.state,
+                SandboxState::Pausing | SandboxState::Killing
+            )
+        }) {
+            if let Some(gate) = self.control.claim_gate() {
+                gate.claimed.wait().await;
+                gate.release.wait().await;
+            }
         }
+
+        result
     }
 
     async fn get(&self, sandbox_id: &SandboxId) -> StdResult<Option<SandboxMetadata>, StoreError> {
@@ -266,7 +335,14 @@ impl MetadataStore for ScriptedStore {
         &self,
         now: std::time::SystemTime,
     ) -> StdResult<Vec<SandboxMetadata>, StoreError> {
-        self.inner.list_expired(now).await
+        let expired = self.inner.list_expired(now).await?;
+        if !expired.is_empty() {
+            if let Some(gate) = self.control.list_gate() {
+                gate.listed.wait().await;
+                gate.release.wait().await;
+            }
+        }
+        Ok(expired)
     }
 
     async fn list_ids(&self) -> StdResult<Vec<SandboxId>, StoreError> {
@@ -2849,6 +2925,262 @@ async fn auto_evict_sandboxes_skips_non_running_and_non_expired_and_continues_on
         .await?
         .expect("non-expired metadata should remain");
     assert_eq!(non_expired.state, SandboxState::Running);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn auto_evict_revalidates_expiry_after_listing() -> Result<()> {
+    setup();
+
+    for timeout_action in [SandboxTimeoutAction::Pause, SandboxTimeoutAction::Delete] {
+        let cutoff = std::time::SystemTime::now();
+        let sandbox_id = SandboxId::new();
+        // Inject a renewal immediately before auto-eviction's first metadata
+        // CAS. At that point list_expired has already returned its stale
+        // candidate, so the real eviction entry point must revalidate expiry.
+        let store = RaceBeforeUpdateStore::new(Duration::from_secs(60));
+        store
+            .add(SandboxMetadata {
+                id: sandbox_id,
+                state: SandboxState::Running,
+                created_at: cutoff,
+                timeout: Some(Duration::from_secs(1)),
+                expires_at: cutoff.checked_sub(Duration::from_secs(1)),
+                timeout_action,
+                ..Default::default()
+            })
+            .await?;
+
+        let orchestrator = make_orchestrator_without_background(store);
+        let evicted = orchestrator.evict_expired_sandboxes().await?;
+        assert!(
+            evicted.is_empty(),
+            "renewed sandbox must not be reported as evicted for {timeout_action:?}"
+        );
+
+        let metadata = orchestrator
+            .get_sandbox(&sandbox_id)
+            .await?
+            .expect("renewed sandbox metadata should remain");
+        assert_eq!(metadata.state, SandboxState::Running);
+        assert_eq!(metadata.timeout, Some(Duration::from_secs(60)));
+        assert!(!metadata.is_expired(std::time::SystemTime::now()));
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn keep_alive_success_wins_against_inflight_auto_evict() -> Result<()> {
+    setup();
+
+    let control = Arc::new(ScriptedStoreControl::default());
+    let orchestrator = make_orchestrator_without_background(ScriptedStore::new(control.clone()));
+    let mut sandbox_ids = Vec::new();
+
+    for timeout_action in [SandboxTimeoutAction::Pause, SandboxTimeoutAction::Delete] {
+        let mut request = create_request(Some(60), &[]);
+        request.timeout_action = timeout_action;
+        let created = orchestrator.create_sandbox(request).await?;
+        orchestrator
+            .store
+            .update_if_state(&created.id, &[SandboxState::Running], |metadata| {
+                metadata.timeout = Some(Duration::from_secs(1));
+                metadata.expires_at =
+                    std::time::SystemTime::now().checked_sub(Duration::from_secs(1));
+            })
+            .await?;
+        sandbox_ids.push(created.id);
+    }
+
+    let gate = StoreListGate::new();
+    control.set_list_gate(gate.clone());
+    let eviction = tokio::spawn({
+        let orchestrator = orchestrator.clone();
+        async move { orchestrator.evict_expired_sandboxes().await }
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), gate.listed.wait())
+        .await
+        .expect("auto-eviction should capture the expired metadata snapshot");
+
+    for sandbox_id in &sandbox_ids {
+        let renewed = orchestrator
+            .keep_alive_for(*sandbox_id, Some(Duration::from_secs(60)), true)
+            .await?
+            .expect("keep-alive should acknowledge the running sandbox renewal");
+        assert_eq!(renewed.state, SandboxState::Running);
+        assert!(!renewed.is_expired(std::time::SystemTime::now()));
+    }
+
+    tokio::time::timeout(Duration::from_secs(5), gate.release.wait())
+        .await
+        .expect("auto-eviction release barrier should complete");
+    let evicted = tokio::time::timeout(Duration::from_secs(5), eviction)
+        .await
+        .expect("auto-eviction should finish after release")
+        .expect("auto-eviction task should not panic")?;
+    assert!(
+        evicted.is_empty(),
+        "sandboxes renewed after listing must not be evicted"
+    );
+
+    for sandbox_id in sandbox_ids {
+        let metadata = orchestrator
+            .get_sandbox(&sandbox_id)
+            .await?
+            .expect("renewed sandbox metadata should remain");
+        assert_eq!(metadata.state, SandboxState::Running);
+        assert_eq!(metadata.timeout, Some(Duration::from_secs(60)));
+        assert!(!metadata.is_expired(std::time::SystemTime::now()));
+        assert_proxy_ready(&orchestrator, &sandbox_id).await?;
+        orchestrator.delete_sandbox(sandbox_id).await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn auto_evict_revalidates_later_candidate_after_prior_claim() -> Result<()> {
+    setup();
+
+    for renewed_action in [SandboxTimeoutAction::Pause, SandboxTimeoutAction::Delete] {
+        let control = Arc::new(ScriptedStoreControl::default());
+        let orchestrator =
+            make_orchestrator_without_background(ScriptedStore::new(control.clone()));
+
+        let mut first_request = create_request(Some(60), &[]);
+        first_request.timeout_action = SandboxTimeoutAction::Delete;
+        let first = orchestrator.create_sandbox(first_request).await?;
+
+        let mut renewed_request = create_request(Some(60), &[]);
+        renewed_request.timeout_action = renewed_action;
+        let renewed = orchestrator.create_sandbox(renewed_request).await?;
+
+        let cutoff = std::time::SystemTime::now();
+        for (sandbox_id, age) in [(first.id, 2), (renewed.id, 1)] {
+            orchestrator
+                .store
+                .update_if_state(&sandbox_id, &[SandboxState::Running], |metadata| {
+                    metadata.timeout = Some(Duration::from_secs(1));
+                    metadata.expires_at = cutoff.checked_sub(Duration::from_secs(age));
+                })
+                .await?;
+        }
+
+        let gate = StoreClaimGate::new();
+        control.set_claim_gate(gate.clone());
+        let eviction = tokio::spawn({
+            let orchestrator = orchestrator.clone();
+            async move { orchestrator.evict_expired_sandboxes().await }
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), gate.claimed.wait())
+            .await
+            .expect("auto-eviction should claim the first expired sandbox");
+        let first_metadata = orchestrator
+            .get_sandbox(&first.id)
+            .await?
+            .expect("first sandbox should still exist while delete is blocked");
+        assert_eq!(first_metadata.state, SandboxState::Killing);
+
+        orchestrator
+            .keep_alive_for(renewed.id, Some(Duration::from_secs(60)), true)
+            .await?
+            .expect("later stale candidate should be renewed while the first delete is blocked");
+
+        tokio::time::timeout(Duration::from_secs(5), gate.release.wait())
+            .await
+            .expect("first auto-eviction release barrier should complete");
+        let evicted = tokio::time::timeout(Duration::from_secs(5), eviction)
+            .await
+            .expect("auto-eviction batch should finish after release")
+            .expect("auto-eviction task should not panic")?;
+        assert_eq!(evicted, vec![first.id]);
+
+        let renewed_metadata = orchestrator
+            .get_sandbox(&renewed.id)
+            .await?
+            .expect("renewed later candidate should remain");
+        assert_eq!(renewed_metadata.state, SandboxState::Running);
+        assert_eq!(renewed_metadata.timeout, Some(Duration::from_secs(60)));
+        assert!(!renewed_metadata.is_expired(std::time::SystemTime::now()));
+        assert_proxy_ready(&orchestrator, &renewed.id).await?;
+        orchestrator.delete_sandbox(renewed.id).await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn auto_evict_claim_prevents_late_keep_alive_success() -> Result<()> {
+    setup();
+
+    for (timeout_action, claimed_state) in [
+        (SandboxTimeoutAction::Pause, SandboxState::Pausing),
+        (SandboxTimeoutAction::Delete, SandboxState::Killing),
+    ] {
+        let control = Arc::new(ScriptedStoreControl::default());
+        let orchestrator =
+            make_orchestrator_without_background(ScriptedStore::new(control.clone()));
+        let mut request = create_request(Some(60), &[]);
+        request.timeout_action = timeout_action;
+        let created = orchestrator.create_sandbox(request).await?;
+        let sandbox_id = created.id;
+
+        orchestrator
+            .store
+            .update_if_state(&sandbox_id, &[SandboxState::Running], |metadata| {
+                metadata.timeout = Some(Duration::from_secs(1));
+                metadata.expires_at =
+                    std::time::SystemTime::now().checked_sub(Duration::from_secs(1));
+            })
+            .await?;
+
+        let gate = StoreClaimGate::new();
+        control.set_claim_gate(gate.clone());
+        let eviction = tokio::spawn({
+            let orchestrator = orchestrator.clone();
+            async move { orchestrator.evict_expired_sandboxes().await }
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), gate.claimed.wait())
+            .await
+            .expect("auto-eviction should atomically claim the expired sandbox");
+
+        let error = orchestrator
+            .keep_alive_for(sandbox_id, Some(Duration::from_secs(60)), true)
+            .await
+            .expect_err("keep-alive must not succeed after auto-eviction has claimed the sandbox");
+        assert!(matches!(
+            error,
+            OrchestratorError::InvalidSandboxState { state, .. } if state == claimed_state
+        ));
+
+        tokio::time::timeout(Duration::from_secs(5), gate.release.wait())
+            .await
+            .expect("auto-eviction release barrier should complete");
+        let evicted = tokio::time::timeout(Duration::from_secs(5), eviction)
+            .await
+            .expect("auto-eviction should finish after release")
+            .expect("auto-eviction task should not panic")?;
+        assert_eq!(evicted, vec![sandbox_id]);
+
+        match timeout_action {
+            SandboxTimeoutAction::Pause => {
+                let metadata = orchestrator
+                    .get_sandbox(&sandbox_id)
+                    .await?
+                    .expect("auto-paused sandbox metadata should remain");
+                assert_eq!(metadata.state, SandboxState::Paused);
+                orchestrator.delete_sandbox(sandbox_id).await?;
+            }
+            SandboxTimeoutAction::Delete => {
+                assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
+            }
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- revalidate sandbox expiry atomically while claiming it for auto-eviction
- ensure a successful keep-alive and an auto-eviction claim cannot both win
- apply the same arbitration to both `Pause` and `Delete` timeout actions
- preserve the existing pause/delete execution and rollback behavior
- add deterministic regression coverage for both arbitration orders and stale batched snapshots

Fixes #165

## Root cause

`evict_expired_sandboxes` acted on metadata returned by an earlier `list_expired` snapshot. A keep-alive could update `expires_at` and return success while the eviction loop later transitioned the still-`Running` sandbox to `Pausing` or `Killing` based on that stale snapshot.

The fix evaluates the expiry predicate and performs the state transition in the same `update_if_state` critical section. If renewal wins, eviction observes the new deadline and skips the sandbox. If eviction wins, keep-alive observes the transitional state and cannot report a successful renewal.

## Red/green verification

The same test selection was run against the parent commit and the fix:

```text
cargo test -q -p agentenv --lib auto_evict
```

- before the fix (`547c1a8`, tests-only patch): 3 passed, 4 failed
- after the fix: 7 passed, 0 failed

The four pre-fix failures cover both `Pause` and `Delete`, including the key invalid outcome where keep-alive reports success and stale auto-eviction still proceeds.

## Test coverage

New deterministic cases cover:

- renewal after expiry listing but before the eviction claim
- successful in-flight keep-alive winning against auto-eviction
- revalidation of a later candidate after an earlier candidate is claimed
- eviction claim winning first and preventing a later keep-alive success

## Validation

- `make fmt`
- `cargo clippy -p agentenv --lib --tests -- -D warnings`
- `cargo test -q -p agentenv --lib orchestrator::service::tests::` — 91 passed
- `cargo test -q -p agentenv --lib auto_evict` — 7 passed
- auto-eviction suite repeated 10 times — 70 passed
- full library suite excluding the known environment capability assertion — 748 passed, 4 ignored, 1 filtered

