### PR TITLE
chore(release): bump version to v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aenv"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "agentenv"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agentenv-observability",
  "agentenv_http_server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
## What

- Bump the shared workspace package version from `0.1.2` to `0.1.3`.
- Update the `aenv` and `agentenv` package entries in `Cargo.lock`.

## Why

Prepare the workspace for the `v0.1.3` release.

## Scope and non-goals

This PR changes release metadata only. It does not alter runtime behavior, APIs, dependencies, or generated code.

## Compatibility and operations

- Public API or generated protocol: N/A
- Configuration or defaults: N/A
- Snapshot manifest, artifact layout, or storage format: N/A
- Upgrade and rollback: N/A
- Host requirements, permissions, ports, or dependencies: N/A

After merge, pushing the `v0.1.3` tag will trigger the release workflow.

## Risks and reviewer notes

Low risk. Confirm this PR is merged before creating the `v0.1.3` tag.