### PR TITLE
fix: support dnf and yum in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,8 +93,16 @@ if ((${#missing_packages[@]} > 0)); then
         echo "Installing required commands: ${missing_packages[*]} ..."
         sudo apt-get update
         sudo apt-get install -y "${missing_packages[@]}"
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "Installing required commands: ${missing_packages[*]} ..."
+        sudo dnf install -y "${missing_packages[@]}"
+    elif command -v yum >/dev/null 2>&1; then
+        echo "Installing required commands: ${missing_packages[*]} ..."
+        sudo yum install -y "${missing_packages[@]}"
     else
-        echo "error: missing required commands and apt-get is unavailable: ${missing_packages[*]}" >&2
+        echo \
+            "error: missing required commands and no supported package manager is available: ${missing_packages[*]}" \
+            >&2
         exit 1
     fi
 fi


### PR DESCRIPTION
## What

- Add `dnf` and `yum` fallbacks to the dependency bootstrap in `scripts/install.sh`.
- Keep the package-manager priority `apt-get`, then `dnf`, then `yum`.
- Preserve the existing post-install command checks and failure behavior.

## Why

`scripts/install.sh` currently assumes `apt-get` when required commands such as `jq` are missing. On openEuler, `dnf`/`yum` is available instead, so a fresh installation exits before downloading AgentENV.

This aligns the server installer with the Linux package-manager fallbacks already used by `scripts/install-cli.sh`, without adding distribution- or architecture-specific branches.

## Related issue

N/A — small, focused installer compatibility fix.

## Scope and non-goals

In scope:

- Bootstrap missing `curl`, `jq`, `sha256sum`, and `realpath` through apt, dnf, or yum.
- Preserve the existing post-install command checks and failure behavior.

Out of scope:

- Changing root/sudo behavior.
- Adding other package managers such as zypper or pacman.
- Changing runtime dependency setup or detecting distributions through `/etc/os-release`.

## Design and behavior changes

When required commands are missing, the installer selects the first available package manager in this order:

1. `apt-get`
2. `dnf`
3. `yum`

If none is available, it reports the missing commands and exits.

## Compatibility and operations

- Public API or generated protocol: N/A; installer-only change.
- Configuration or defaults: N/A.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: no impact; reverting restores the previous apt-only behavior.
- Host requirements, permissions, ports, or dependencies: adds dnf/yum bootstrap support; no permission or port changes.
- Debian/Ubuntu behavior is unchanged because `apt-get` remains the first choice.
- The logic is architecture-neutral. The issue was reproduced and the fix validated on openEuler aarch64.

## Validation

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
git diff --check
bash -n scripts/install.sh
bash -n scripts/tests/verify-install-service.sh
bash scripts/tests/verify-install-service.sh
```

All commands above passed.

Fresh openEuler 24.03 LTS-SP3 aarch64 container validation:

- Started without `jq`.
- Installed `jq` through the new `dnf` path.
- A second dependency-bootstrap run completed without reinstalling packages.

Skipped checks and reasons:

- Rust, service, generated-code, documentation, and benchmark checks were skipped because this change is limited to Bash installer dependency selection.
- `shellcheck` was not run because it is not installed in the validation environment.
- No regression test file was changed; package-manager behavior was validated manually in a fresh openEuler container.

## Risks and reviewer notes

Risk is low. The change only affects the existing missing-command bootstrap path. Systems where all required commands are already present do not execute the new branches, and apt-based systems retain their previous behavior.

The most relevant file is:

- `scripts/install.sh`

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
