### PR TITLE
feat(network): support domain-based egress control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "futures",
  "headers",
  "hex",
+ "hickory-resolver",
  "hmac",
  "http 1.4.0",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "hmac",
  "http 1.4.0",
  "http-body-util",
+ "httparse",
  "hyper 1.9.0",
  "hyper-util",
  "index-set",
@@ -153,6 +154,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "time",
+ "tls-parser",
  "tokio",
  "tokio-tungstenite",
  "toml",
@@ -4904,6 +4906,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff943d68b88d0b87a6e0d58615e8fa07f9fd5a1319fa0a72efc1f62275c79a7"
+dependencies = [
+ "nom",
+ "nom-derive-impl",
+ "rustversion",
+]
+
+[[package]]
+name = "nom-derive-impl"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b9a93a84b0d3ec3e70e02d332dc33ac6dfac9cde63e17fcb77172dededa62"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "noq"
 version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7717,6 +7741,20 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-parser"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c36249c6082584b1f224e70f6bdadf5102197be6cfa92b353efe605d9ac741"
+dependencies = [
+ "nom",
+ "nom-derive",
+ "num_enum",
+ "phf",
+ "phf_codegen",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,6 +3771,9 @@ name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ opendal = { version = "0.55.0", features = ["services-s3"] }
 object-store-operator = { path = "crates/object-store-operator" }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
+httparse = "1.10"
+tls-parser = "0.12.2"
 http-body-util = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ libc = "0.2"
 rtnetlink = "0.20"
 netlink-packet-route = "0.28"
 ipnetwork = { version = "0.21", features = ["serde"] }
+hickory-resolver = "0.26.1"
 futures = "0.3"
 tonic = "0.14.2"
 tonic-prost = "0.14.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ nix = { version = "0.31", features = ["sched", "mount", "fs", "signal", "user", 
 libc = "0.2"
 rtnetlink = "0.20"
 netlink-packet-route = "0.28"
-ipnetwork = "0.21"
+ipnetwork = { version = "0.21", features = ["serde"] }
 futures = "0.3"
 tonic = "0.14.2"
 tonic-prost = "0.14.2"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -52,6 +52,7 @@
 # Developer Internals
 
 - [System Architecture](./internals/architecture.md)
+- [Sandbox Network Architecture](./internals/networking.md)
 - [Sandbox Internals and Testing](./internals/sandbox-testing.md)
 - [Template Builder and Testing](./internals/template-builder-testing.md)
 - [Persistence Artifact Inventory](./internals/persistence-artifact-inventory.md)

--- a/docs/src/concepts/sandboxes.md
+++ b/docs/src/concepts/sandboxes.md
@@ -169,7 +169,7 @@ curl -X POST \
 
 For fine-grained egress control, pass a `network` object when creating the sandbox. Within user-configured egress rules, traffic is allow-by-default, and `allowOut` entries take precedence over matching `denyOut` entries. `allowOut` by itself does not create an allowlist: destinations that do not match a deny rule remain reachable.
 
-- `allowOut` — CIDR or IP. Domain patterns are currently not supported.
+- `allowOut` — CIDR, IP, or domain pattern. Domain patterns apply to new TCP connections on ports 80 and 443 and require `denyOut: ["0.0.0.0/0"]`. Exact names, `*.example.com`, and `*` are supported; a wildcard does not match the apex domain.
 - `denyOut` — CIDR or IP
 
 The following diagram illustrates how the rules are evaluated:
@@ -214,6 +214,10 @@ curl -X PUT \
 ```
 
 Omitting both fields clears all per-sandbox egress rules and restores the default allow behavior.
+
+Updating a policy primarily affects new connections; existing connections are not actively terminated. During replacement, the previous policy remains active until the new namespace rules are committed.
+
+For domain rules, the proxy matches the inspected Host/SNI and re-resolves the hostname using the host-side trusted resolver before connecting; the guest's DNS answer and original destination IP are not authoritative for domain policy.
 
 ---
 

--- a/docs/src/internals/architecture.md
+++ b/docs/src/internals/architecture.md
@@ -123,16 +123,7 @@ PVM currently requires x86_64 and the `kvm_pvm` host module.
 
 ### Sandbox Networking
 
-Sandbox networking is managed by a process-wide `NetworkManager` (`src/sandbox/network/manager.rs`) plus per-slot `Slot` objects (`src/sandbox/network/slot.rs`).
-
-- Each slot owns a stable index-derived address bundle from `[network.internal]` (defaulting to `10.11.0.0/16` and `10.12.0.0/16`) plus the fixed VM tap link `169.254.0.20/30`, together with the host veth name, namespace path, and iptables rules for one sandbox network namespace.
-- Network policy supports base allow/deny plus explicit egress rules. The `/sandboxes/{sandboxID}/network` endpoint replaces per-sandbox `allowOut` (CIDR/IP/domain patterns) and `denyOut` (CIDR/IP only) rules at runtime; allow rules always take precedence.
-- `allocate_any()` first tries a warm-slot pool and falls back to creating a new namespace/veth/tap/iptables setup on demand.
-- Warm-pool maintenance uses a single Condvar-driven background worker with low/high watermarks.
-- `release()` enqueues slots back to the warm pool; when maintenance is enabled, even releases above high watermark are first enqueued and then drained asynchronously by the worker.
-- `[pool]` provides shared watermarks and `[pool.network].maintenance_enabled` controls network worker behavior.
-- Because the manager is a process-wide singleton, orchestrator shutdown explicitly calls `NetworkManager::shutdown()` after deleting remaining sandboxes so cached slots are drained and no new allocations race with teardown.
-- Although calling `NetworkManager::shutdown()` on exit is recommended for clean teardown, the manager also has a `Drop` and `libc::atexit` handler to best-effort cleanup of any remaining namespaces and veth interfaces on unexpected shutdown and during testing.
+The network subsystem is managed by a process-wide `NetworkManager` and per-slot `Slot` objects. See [Sandbox Network Architecture](./networking.md) for the namespace topology, address plan, packet paths, firewall ordering, egress proxy, policy replacement, warm-pool behavior, and verification steps.
 
 Snapshot resume can also use `[pool.firecracker]` to pre-spawn `(network slot, Firecracker process)` pairs. A warm entry transfers its network slot, process, and Firecracker CWD to the resumed sandbox, which avoids the spawn and API-socket wait in the resume critical path. `[pool.block]` controls the ublk daemon's overlaybd warm-device pool; it shares the same top-level watermarks but performs async refill from request paths because reusable block devices are image/size-specific.
 

--- a/docs/src/internals/networking.md
+++ b/docs/src/internals/networking.md
@@ -1,0 +1,194 @@
+# Sandbox Network Architecture
+
+This document describes the network data plane for one AgentENV node. It covers the Linux network namespaces used by Firecracker sandboxes, host and namespace iptables, runtime egress policy updates, and the namespace-local egress proxy.
+
+The user-facing policy contract is documented in [Sandbox Network Access](../concepts/sandboxes.md#network-access). This page explains how that contract is implemented.
+
+## Topology
+
+Each running sandbox has a dedicated network namespace. The Firecracker VM is connected to the namespace through a TAP device. The namespace is connected to the host through a veth pair; the namespace side is named `vpeer` and the host side is named `veth-{slot}`.
+
+```mermaid
+flowchart LR
+    subgraph sandbox["Sandbox network namespace"]
+        direction LR
+        subgraph vm["Firecracker VM"]
+            direction LR
+            eth0["eth0\n169.254.0.21"]
+        end
+        tap["tap0\n169.254.0.22"]
+        vpeer["vpeer\nveth pool 10.12.0.0/16\n/31 per slot"]
+        proxy["EgressProxy listener\n0.0.0.0:15000"]
+        eth0 <--> tap
+        tap <--> vpeer
+        tap -. "TCP 80/443 REDIRECT" .-> proxy
+        proxy --> vpeer
+    end
+    style sandbox fill:transparent,stroke:gray
+
+    subgraph host["Host network namespace"]
+        direction LR
+        veth["veth-{slot}\n10.12.0.0/16\n/31 per slot"]
+        host-interaction["Host interaction IP\n10.11.0.0/16\n/31 per slot"]
+        internet["Internet"]
+        veth <-- "Host routing" --> host-interaction
+        veth -- "Host routing" --> internet
+    end
+    style host fill:transparent,stroke:gray
+
+    vpeer <--> veth
+```
+
+The process contains one global `NetworkManager` and one global `EgressProxy` registry. The registry is shared for lifecycle and policy bookkeeping, but each namespace that uses proxy-backed policy has its own listener socket and listener thread. The fixed port `15000` is therefore reusable across namespaces without a host-port collision.
+
+## Ownership
+
+| Owner | Source | Responsibility |
+| --- | --- | --- |
+| `NetworkManager` | `src/sandbox/network/manager.rs` | Process-wide slot bitmap, warm pool, global host iptables, proxy registry, shutdown |
+| `Slot` | `src/sandbox/network/slot.rs` | One namespace, veth/TAP setup, address plan, namespace iptables, policy application, cleanup |
+| Address plan | `src/sandbox/network/address_plan.rs` | Slot-derived host interaction, veth, and VM-link addresses and internal deny ranges |
+| Policy | `src/sandbox/network/policy.rs` | API-normalized base/allow/deny semantics, absolute deny checks, proxy interception ports |
+| Egress proxy | `src/sandbox/network/egress_proxy.rs` | Namespace-local listener, original-destination inspection, Host/SNI parsing, relay, staged policy state |
+| Host resolver | `src/sandbox/network/resolver.rs` | Process-wide long-lived host-netns DNS worker used for trusted domain resolution |
+| Firecracker backend | `src/sandbox/firecracker/sandbox.rs` | Allocates/releases slots and applies the launch or updated policy at VM lifecycle boundaries |
+| Orchestrator/API | `src/orchestrator/`, `src/api/impls/sandbox.rs` | Validates requests, persists policy, and replaces the running sandbox policy |
+
+## Address Plan
+
+`NetworkAddressPlan` derives addresses from `[network.internal]` and allocates them from the slot index:
+
+- `host_interaction_ip`: one address per slot from `host_interaction_cidr`. Host routes use this address to reach the VM through the namespace.
+- `veth_host_ip` and `veth_vm_ip`: the two endpoints of the slot's `/31` veth link. The host endpoint is assigned to `veth-{slot}` and the namespace endpoint is assigned to `vpeer`.
+- `vm_ip` and `tap_ip`: fixed endpoints of the VM link on `vm_link_cidr`. The VM receives `vm_ip`; the namespace TAP interface receives `tap_ip`.
+
+The namespace adds a default route through `veth_host_ip`. Firecracker receives an `ip=` boot argument containing the VM address, TAP link, netmask, and the guest DNS server selected from the host resolver configuration.
+
+The complete internal pools are denied before user egress rules. This prevents a sandbox from reaching another slot's host-interaction address, veth link, or VM link even when a user policy otherwise allows the destination.
+
+## Namespace Setup
+
+`Slot::create_network()` performs namespace setup on a dedicated thread because network namespace membership is thread-local:
+
+1. Create and bind-mount a persistent namespace file under the configured runtime `netns` directory.
+2. Unshare `CLONE_NEWNET` and create the veth pair.
+3. Move the host endpoint to the process's baseline host namespace.
+4. Configure `lo`, `vpeer`, `tap0`, addresses, link state, and the namespace default route.
+5. Enable namespace IPv4 forwarding and configure namespace NAT/filter rules.
+6. Configure the host veth address and a host route for the slot's `host_interaction_ip`.
+
+The baseline namespace rules are installed once during setup. Per-sandbox user rules and proxy redirects are replaced later by `set_egress_policy()`.
+
+## Packet Paths
+
+```mermaid
+flowchart TB
+    vm["Firecracker VM"] --> tap["tap0"]
+    tap --> prerouting["namespace nat/PREROUTING"]
+    prerouting -. "TCP 80/443 REDIRECT" .-> proxy["Namespace-local\nEgressProxy"]
+    prerouting --> forward["namespace filter/FORWARD\nAGENTENV-EGRESS"]
+    proxy --> upstream_proxy["Proxy upstream connection"]
+    forward --> nsnat["namespace POSTROUTING\nSNAT to host_interaction_ip"]
+    upstream_proxy --> nsnat
+    nsnat --> vpeer["vpeer / veth"]
+    vpeer --> host["Host FORWARD + POSTROUTING\nMASQUERADE"]
+    host --> internet["External destination"]
+    internet -. "return traffic" .-> host
+    host -. "ESTABLISHED,RELATED" .-> vpeer
+    vpeer -. "return traffic" .-> tap
+    tap -. "return traffic" .-> vm
+```
+
+### Sandbox-originated internet traffic
+
+1. The VM sends a packet through `eth0` to `tap0`.
+2. The namespace NAT `PREROUTING` chain may redirect TCP ports 80 and 443 to the namespace-local proxy.
+3. Packets that continue as routed traffic traverse `filter/FORWARD` from `tap0` to `vpeer`, entering `AGENTENV-EGRESS`.
+4. The namespace `POSTROUTING` chain SNATs VM-originated traffic to the slot's `host_interaction_ip`. Proxy-originated upstream connections are SNATed from the namespace `vpeer` address to the same slot identity.
+5. The host `FORWARD` and `POSTROUTING` rules accept the slot source range and MASQUERADE it for the external route.
+
+### Return traffic
+
+Return packets are classified as `ESTABLISHED,RELATED` and are accepted before the user egress chain in the namespace. The host also accepts established traffic returning to `veth-{slot}`. This preserves host/envd/proxy responses and existing outbound flows while policy rules are replaced.
+
+### Host-to-VM traffic
+
+Host-side proxy and envd traffic targets the slot's `host_interaction_ip`. Namespace `PREROUTING` on `vpeer` DNATs that address to the VM's fixed `vm_ip`. The corresponding return path is accepted by the established/related rules.
+
+## Host Firewall
+
+`NetworkManager` installs one process-wide set of host rules for the configured host interaction CIDR. The rules are inserted/appended symmetrically and removed during manager shutdown:
+
+```text
+INPUT      -i veth-+ -s <host_interaction_cidr> -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+INPUT      -i veth-+ -s <host_interaction_cidr> -j REJECT
+FORWARD    -i veth-+ -s <host_interaction_cidr> -j ACCEPT
+FORWARD    -o veth-+ -d <host_interaction_cidr> --state ESTABLISHED,RELATED -j ACCEPT
+POSTROUTING -s <host_interaction_cidr> -j MASQUERADE
+```
+
+The `INPUT` pair prevents guest-originated new connections from reaching arbitrary host services while preserving established host-originated traffic. The `FORWARD` and `MASQUERADE` rules handle namespace-to-internet forwarding after namespace SNAT.
+
+## Namespace Firewall
+
+Each namespace has three managed chains:
+
+- `AGENTENV-EGRESS` is the static chain reached from `FORWARD` for guest traffic.
+- `AGENTENV-USER-EGRESS` contains the replaceable user policy.
+- `AGENTENV-EGRESS-PROXY` is the replaceable NAT chain reached from `nat/PREROUTING` for proxy-backed traffic.
+
+The static filter chain is ordered as follows:
+
+1. Accept `ESTABLISHED,RELATED` traffic from `tap0` to `vpeer`.
+2. Allow UDP/TCP DNS traffic to the configured guest DNS address on port 53.
+3. Reject the complete internal address pools and configured `always_denied_cidrs`.
+4. Jump to `AGENTENV-USER-EGRESS`.
+
+The user chain is rendered in this order:
+
+1. Explicit `allowOut` CIDR/IP rules (`ACCEPT`).
+2. Explicit `denyOut` CIDR/IP rules (`REJECT`).
+3. A `0.0.0.0/0` reject when the base policy is `Deny`.
+
+This ordering gives user allow rules precedence over overlapping user denies, while static internal/platform denies remain non-overridable.
+
+## Egress Proxy
+
+The egress proxy is namespace-local and transparent. It does not terminate TLS or rewrite HTTP. A policy that requires proxy mediation redirects only TCP ports 80 and 443 to `0.0.0.0:15000` inside that namespace.
+
+### Connection flow
+
+1. `EgressProxy::ensure_listener()` enters the target namespace with `setns`, binds the listener, and starts a nonblocking accept loop.
+2. The listener accepts a connection and copies the active policy for that connection.
+3. The connection handler reads `SO_ORIGINAL_DST` to recover the destination altered by `REDIRECT`.
+4. It buffers the initial request/handshake up to 64 KiB and extracts HTTP `Host` or TLS ClientHello SNI. TLS handshake bytes are accumulated across record boundaries.
+5. A domain match is sent to the process-wide resolver worker, which remains in the host network namespace. Each candidate IPv4 address is checked by `SandboxNetworkPolicy::is_domain_allowed`, including absolute platform and internal-range denies, before it is selected.
+6. A domain connection is dialed to the selected trusted address. An IP/CIDR connection uses the original destination after `is_ip_allowed`.
+7. The buffered preface is written to the upstream and both directions are relayed with half-close handling.
+
+An empty or unrecognized hostname cannot fall back to the base allow policy when a domain allowlist is present. This keeps domain policies fail-closed. Domain allow rules require the API request to include an explicit `denyOut: ["0.0.0.0/0"]`.
+
+### Policy replacement
+
+The running policy update is a replacement operation:
+
+1. Stage the new policy in the proxy's `pending` map.
+2. Ensure the namespace listener exists when proxy mediation is required.
+3. Apply the filter and NAT chain replacement as one `iptables-restore` batch.
+4. When an active proxy policy already exists, activate the pending policy only after the namespace batch succeeds.
+5. When proxy mediation is being enabled for a namespace with no active proxy policy, activate the prepared policy before installing the redirect. This preserves the namespace's previous default-allow behavior until the atomic iptables batch has completed; no connection can reach the listener through `REDIRECT` before that batch succeeds.
+6. If an update fails while an active proxy policy exists, discard the pending policy and retain the previous active policy.
+
+Each accepted connection holds a copy of the active policy selected at accept time. Therefore updates primarily affect new connections; existing relays are not proactively terminated. Removing a policy or a slot closes tracked handler sockets and joins their threads before namespace resources are removed.
+
+### Namespace ownership
+
+The process-global registry is keyed by `host_interaction_ip`, but listeners are not shared between namespaces. Every namespace has its own listener thread and socket. When a policy no longer requires proxy mediation, the listener and active/pending policy are removed. Full slot cleanup stops the listener before deleting the veth and unmounting the namespace.
+
+## Lifecycle and Warm Pool
+
+`NetworkManager::allocate_any()` first acquires a warm `Slot`. If none is available it allocates a new slot index and creates the namespace/veth/TAP resources. The Firecracker backend then applies the launch policy before boot or resume continues.
+
+On stop, a slot may return to the warm pool. The namespace and baseline networking remain available for reuse; `user_egress_rules_present` tracks whether the next tenant needs a user-chain replacement. The next policy application clears or replaces stale user rules and removes stale proxy policy as appropriate. Slots drained from the pool are fully cleaned up.
+
+On shutdown, the manager stops pool maintenance, drains warm slots, stops all proxy listeners, removes global host rules, and removes namespace/veth state. An `atexit` hook and `Drop` path provide best-effort cleanup for abnormal exits.

--- a/src/api/impls/sandbox.rs
+++ b/src/api/impls/sandbox.rs
@@ -151,11 +151,17 @@ impl From<&SandboxNetworkPolicy> for models::SandboxNetworkConfig {
                     egress
                         .allowed_cidrs
                         .iter()
-                        .chain(egress.allowed_domains.iter())
-                        .cloned()
+                        .map(ToString::to_string)
+                        .chain(egress.allowed_domains.iter().cloned())
                         .collect()
                 }),
-            deny_out: (!egress.denied_cidrs.is_empty()).then(|| egress.denied_cidrs.clone()),
+            deny_out: (!egress.denied_cidrs.is_empty()).then(|| {
+                egress
+                    .denied_cidrs
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect()
+            }),
             mask_request_host: None,
         }
     }
@@ -373,6 +379,7 @@ fn network_policy_from_create(
         .and_then(|network| network.allow_public_traffic)
         .unwrap_or(true);
     let policy = SandboxNetworkPolicy::new(allow_public_traffic, base_policy, egress);
+    validate_ipv4_cidrs(&policy)?;
     validate_domain_allowlist(&policy)?;
     Ok(policy)
 }
@@ -386,8 +393,22 @@ fn network_policy_from_update(
         base_policy_from_allow_internet_access(body.allow_internet_access),
         policy,
     );
+    validate_ipv4_cidrs(&policy)?;
     validate_domain_allowlist(&policy)?;
     Ok(policy)
+}
+
+fn validate_ipv4_cidrs(policy: &SandboxNetworkPolicy) -> anyhow::Result<()> {
+    if policy
+        .egress
+        .allowed_cidrs
+        .iter()
+        .chain(policy.egress.denied_cidrs.iter())
+        .any(|cidr| matches!(cidr, ipnetwork::IpNetwork::V6(_)))
+    {
+        anyhow::bail!("IPv6 CIDRs are not supported by the sandbox network API");
+    }
+    Ok(())
 }
 
 fn validate_domain_allowlist(policy: &SandboxNetworkPolicy) -> anyhow::Result<()> {
@@ -401,7 +422,7 @@ fn validate_domain_allowlist(policy: &SandboxNetworkPolicy) -> anyhow::Result<()
             .egress
             .denied_cidrs
             .iter()
-            .any(|cidr| cidr == ALL_INTERNET_TRAFFIC_CIDR)
+            .any(|cidr| cidr == &ALL_INTERNET_TRAFFIC_CIDR)
     {
         anyhow::bail!("allowOut contains domains but denyOut is missing {ALL_INTERNET_TRAFFIC_CIDR} (ALL_TRAFFIC)");
     }
@@ -1519,8 +1540,14 @@ mod tests {
         let policy = network_policy_from_update(&body).unwrap();
 
         assert_eq!(policy.base_policy, BaseSandboxNetworkPolicy::Deny);
-        assert_eq!(policy.egress.allowed_cidrs, ["8.8.8.8/32"]);
-        assert_eq!(policy.egress.denied_cidrs, ["203.0.113.0/24"]);
+        assert_eq!(
+            policy.egress.allowed_cidrs,
+            vec!["8.8.8.8/32".parse().unwrap()]
+        );
+        assert_eq!(
+            policy.egress.denied_cidrs,
+            vec!["203.0.113.0/24".parse().unwrap()]
+        );
     }
 
     #[test]
@@ -1555,7 +1582,21 @@ mod tests {
 
         let policy = network_policy_from_create(None, Some(&network)).unwrap();
         assert_eq!(policy.egress.allowed_domains, ["example.com"]);
-        assert_eq!(policy.egress.denied_cidrs, ["0.0.0.0/0"]);
+        assert_eq!(
+            policy.egress.denied_cidrs,
+            vec!["0.0.0.0/0".parse().unwrap()]
+        );
+    }
+
+    #[test]
+    fn network_create_rejects_ipv6_cidrs() {
+        let network = models::SandboxNetworkConfig {
+            allow_out: Some(vec!["2001:db8::/32".to_string()]),
+            ..models::SandboxNetworkConfig::new()
+        };
+
+        let error = network_policy_from_create(None, Some(&network)).unwrap_err();
+        assert!(error.to_string().contains("IPv6 CIDRs"));
     }
 
     #[test]
@@ -1578,7 +1619,22 @@ mod tests {
         };
         let policy = network_policy_from_update(&body).unwrap();
         assert_eq!(policy.egress.allowed_domains, ["example.com"]);
-        assert_eq!(policy.egress.denied_cidrs, ["0.0.0.0/0"]);
+        assert_eq!(
+            policy.egress.denied_cidrs,
+            vec!["0.0.0.0/0".parse().unwrap()]
+        );
+    }
+
+    #[test]
+    fn network_update_rejects_ipv6_cidrs() {
+        let body = models::SandboxNetworkUpdateConfig {
+            allow_out: Some(vec!["2001:db8::/32".to_string()]),
+            deny_out: None,
+            allow_internet_access: None,
+        };
+
+        let error = network_policy_from_update(&body).unwrap_err();
+        assert!(error.to_string().contains("IPv6 CIDRs"));
     }
 
     #[test]

--- a/src/api/impls/sandbox.rs
+++ b/src/api/impls/sandbox.rs
@@ -373,11 +373,7 @@ fn network_policy_from_create(
         .and_then(|network| network.allow_public_traffic)
         .unwrap_or(true);
     let policy = SandboxNetworkPolicy::new(allow_public_traffic, base_policy, egress);
-    if policy.has_domain_allow_rules() {
-        anyhow::bail!(
-            "domain entries in allowOut are not supported until TCP egress proxy is enabled"
-        );
-    }
+    validate_domain_allowlist(&policy)?;
     Ok(policy)
 }
 
@@ -385,16 +381,31 @@ fn network_policy_from_update(
     body: &models::SandboxNetworkUpdateConfig,
 ) -> anyhow::Result<SandboxNetworkPolicy> {
     let policy = SandboxNetworkEgressPolicy::new(body.allow_out.clone(), body.deny_out.clone())?;
-    if policy.has_domain_allow_rules() {
-        anyhow::bail!(
-            "domain entries in allowOut are not supported until TCP egress proxy is enabled"
-        );
-    }
-    Ok(SandboxNetworkPolicy::new(
+    let policy = SandboxNetworkPolicy::new(
         true,
         base_policy_from_allow_internet_access(body.allow_internet_access),
         policy,
-    ))
+    );
+    validate_domain_allowlist(&policy)?;
+    Ok(policy)
+}
+
+fn validate_domain_allowlist(policy: &SandboxNetworkPolicy) -> anyhow::Result<()> {
+    use crate::sandbox::ALL_INTERNET_TRAFFIC_CIDR;
+
+    // E2B's domain inspection applies to HTTP/HTTPS (TCP 80/443); other TCP
+    // ports remain CIDR-only. Do not reject a mixed domain/CIDR policy here:
+    // the runtime still honors its explicit CIDR grants on every port.
+    if policy.has_domain_allow_rules()
+        && !policy
+            .egress
+            .denied_cidrs
+            .iter()
+            .any(|cidr| cidr == ALL_INTERNET_TRAFFIC_CIDR)
+    {
+        anyhow::bail!("allowOut contains domains but denyOut is missing {ALL_INTERNET_TRAFFIC_CIDR} (ALL_TRAFFIC)");
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -1532,5 +1543,52 @@ mod tests {
             .expect("empty update should be valid");
 
         assert_eq!(policy, SandboxNetworkPolicy::default());
+    }
+
+    #[test]
+    fn network_create_accepts_domain_allowlist_with_explicit_deny_all() {
+        let network = models::SandboxNetworkConfig {
+            allow_out: Some(vec!["example.com".to_string()]),
+            deny_out: Some(vec!["0.0.0.0/0".to_string()]),
+            ..models::SandboxNetworkConfig::new()
+        };
+
+        let policy = network_policy_from_create(None, Some(&network)).unwrap();
+        assert_eq!(policy.egress.allowed_domains, ["example.com"]);
+        assert_eq!(policy.egress.denied_cidrs, ["0.0.0.0/0"]);
+    }
+
+    #[test]
+    fn network_create_rejects_domain_allowlist_without_explicit_deny_all() {
+        let network = models::SandboxNetworkConfig {
+            allow_out: Some(vec!["example.com".to_string()]),
+            ..models::SandboxNetworkConfig::new()
+        };
+
+        let error = network_policy_from_create(None, Some(&network)).unwrap_err();
+        assert!(error.to_string().contains("0.0.0.0/0"));
+    }
+
+    #[test]
+    fn network_update_accepts_domain_allowlist_with_explicit_deny_all() {
+        let body = models::SandboxNetworkUpdateConfig {
+            allow_out: Some(vec!["example.com".to_string()]),
+            deny_out: Some(vec!["0.0.0.0/0".to_string()]),
+            allow_internet_access: None,
+        };
+        let policy = network_policy_from_update(&body).unwrap();
+        assert_eq!(policy.egress.allowed_domains, ["example.com"]);
+        assert_eq!(policy.egress.denied_cidrs, ["0.0.0.0/0"]);
+    }
+
+    #[test]
+    fn network_update_rejects_domain_allowlist_without_explicit_deny_all() {
+        let body = models::SandboxNetworkUpdateConfig {
+            allow_out: Some(vec!["example.com".to_string()]),
+            deny_out: None,
+            allow_internet_access: None,
+        };
+        let error = network_policy_from_update(&body).unwrap_err();
+        assert!(error.to_string().contains("0.0.0.0/0"));
     }
 }

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -424,7 +424,7 @@ impl SandboxBackend for FirecrackerSandbox {
     }
 
     async fn update_network_policy(&mut self, policy: Option<SandboxNetworkPolicy>) -> Result<()> {
-        if let Some(slot) = self.network_slot.as_ref() {
+        if let Some(slot) = self.network_slot.as_mut() {
             slot.set_egress_policy(policy.as_ref())
                 .context("configure sandbox network policy")?;
             self.current_network_policy = policy;
@@ -1303,7 +1303,7 @@ impl FirecrackerSandbox {
         let netns = slot.namespace_path();
         self.network_slot = Some(slot);
         self.network_slot
-            .as_ref()
+            .as_mut()
             .expect("network slot was just assigned")
             .set_egress_policy(config.common.network_policy.as_ref())
             .context("Failed to configure sandbox egress policy")?;
@@ -1507,7 +1507,7 @@ impl FirecrackerSandbox {
 
             interaction_ip
         };
-        if let Some(slot) = self.network_slot.as_ref() {
+        if let Some(slot) = self.network_slot.as_mut() {
             slot.set_egress_policy(config.common.network_policy.as_ref())
                 .context("Failed to configure sandbox egress policy for resume")?;
         }

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -35,7 +35,10 @@ pub use firecracker::{
     FirecrackerSandboxFactory, FirecrackerSnapshotConfig, FirecrackerSnapshotManifest,
 };
 pub(crate) use network::{prepare_runtime as prepare_network_runtime, NetworkManager};
-pub use network::{BaseSandboxNetworkPolicy, SandboxNetworkEgressPolicy, SandboxNetworkPolicy};
+pub use network::{
+    BaseSandboxNetworkPolicy, SandboxNetworkEgressPolicy, SandboxNetworkPolicy,
+    ALL_INTERNET_TRAFFIC_CIDR,
+};
 pub use process::{Executor, ProcessHandle, ProcessOpts, ProcessOutput};
 pub use ublk::{OverlaybdConfig, UblkBackend, UblkConfig, UblkDaemonConfig, UblkDeviceManager};
 

--- a/src/sandbox/network/egress_proxy.rs
+++ b/src/sandbox/network/egress_proxy.rs
@@ -1,0 +1,1076 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::os::fd::{AsFd, AsRawFd};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex, RwLock};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use httparse::Status;
+use nix::sched::{setns, CloneFlags};
+use tls_parser::{parse_tls_handshake_msg_client_hello, parse_tls_raw_record, TlsRecordType};
+use tracing::{debug, warn};
+
+use super::resolver::HostNetResolver;
+use super::SandboxNetworkPolicy;
+
+const MAX_PREFACE_BYTES: usize = 64 * 1024;
+const PREFACE_TIMEOUT: Duration = Duration::from_secs(10);
+const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(30);
+const EGRESS_PROXY_PORT: u16 = 15000;
+// Bound resource use without imposing an idle timeout on established streams;
+// E2B permits long-lived application connections.
+const MAX_CONNECTIONS_PER_PROXY: usize = 256;
+const SO_ORIGINAL_DST: libc::c_int = 80;
+
+struct ListenerHandle {
+    stop: mpsc::Sender<()>,
+    join: JoinHandle<()>,
+}
+
+enum UpstreamDecision {
+    Forward(Vec<SocketAddr>),
+    Deny,
+    Unavailable,
+}
+
+#[derive(Clone)]
+struct ActiveEgressPolicy {
+    policy: SandboxNetworkPolicy,
+}
+
+struct ConnectionSockets {
+    client: TcpStream,
+    upstream: Option<TcpStream>,
+    cancel: Arc<AtomicBool>,
+    closed: bool,
+}
+
+struct ConnectionState {
+    sockets: HashMap<usize, Arc<Mutex<ConnectionSockets>>>,
+    joins: HashMap<usize, JoinHandle<()>>,
+}
+
+/// Namespace-local transparent proxy for egress capabilities that require
+/// connection inspection or mediation.
+pub(crate) struct EgressProxy {
+    active: RwLock<HashMap<Ipv4Addr, ActiveEgressPolicy>>,
+    pending: Mutex<HashMap<Ipv4Addr, ActiveEgressPolicy>>,
+    listeners: Mutex<HashMap<Ipv4Addr, ListenerHandle>>,
+    listener_start: Mutex<()>,
+    next_connection_id: AtomicUsize,
+    connections: Mutex<HashMap<Ipv4Addr, ConnectionState>>,
+    resolver: HostNetResolver,
+}
+
+impl fmt::Debug for EgressProxy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let active_policy_count = self
+            .active
+            .read()
+            .map(|policies| policies.len())
+            .unwrap_or(0);
+        let pending_policy_count = self
+            .pending
+            .lock()
+            .map(|policies| policies.len())
+            .unwrap_or(0);
+        let listener_count = self
+            .listeners
+            .lock()
+            .map(|listeners| listeners.len())
+            .unwrap_or(0);
+
+        formatter
+            .debug_struct("EgressProxy")
+            .field("port", &EGRESS_PROXY_PORT)
+            .field("active_policy_count", &active_policy_count)
+            .field("pending_policy_count", &pending_policy_count)
+            .field("listener_count", &listener_count)
+            .finish()
+    }
+}
+
+impl EgressProxy {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            active: RwLock::new(HashMap::new()),
+            pending: Mutex::new(HashMap::new()),
+            listeners: Mutex::new(HashMap::new()),
+            listener_start: Mutex::new(()),
+            next_connection_id: AtomicUsize::new(0),
+            connections: Mutex::new(HashMap::new()),
+            resolver: HostNetResolver::new(),
+        })
+    }
+
+    pub(crate) fn port(&self) -> u16 {
+        EGRESS_PROXY_PORT
+    }
+
+    /// Ensure that a listener is running in the sandbox namespace for the given host interaction IP.
+    pub(crate) fn ensure_listener(
+        self: &Arc<Self>,
+        host_interaction_ip: Ipv4Addr,
+        netns_path: &Path,
+    ) -> Result<()> {
+        let _startup_guard = self
+            .listener_start
+            .lock()
+            .expect("egress proxy listener startup lock poisoned");
+        if self
+            .listeners
+            .lock()
+            .expect("egress proxy listener lock poisoned")
+            .contains_key(&host_interaction_ip)
+        {
+            return Ok(());
+        }
+
+        let netns = File::open(netns_path)
+            .with_context(|| format!("open egress proxy namespace {}", netns_path.display()))?;
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let proxy = Arc::clone(self);
+        let join = thread::Builder::new()
+            .name(format!("agentenv-egress-proxy-{host_interaction_ip}"))
+            .spawn(move || {
+                if let Err(error) = setns(netns.as_fd(), CloneFlags::CLONE_NEWNET) {
+                    let _ = ready_tx.send(Err(format!("enter egress proxy namespace: {error}")));
+                    return;
+                }
+                let listener = match TcpListener::bind((Ipv4Addr::UNSPECIFIED, EGRESS_PROXY_PORT)) {
+                    Ok(listener) => listener,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(format!("bind egress proxy port: {error}")));
+                        return;
+                    }
+                };
+                if let Err(error) = listener.set_nonblocking(true) {
+                    let _ = ready_tx.send(Err(format!("set egress proxy nonblocking: {error}")));
+                    return;
+                }
+                let _ = ready_tx.send(Ok(()));
+                run_namespace_listener(listener, stop_rx, proxy, host_interaction_ip);
+            })
+            .context("spawn egress proxy namespace listener")?;
+
+        match ready_rx.recv() {
+            Ok(Ok(())) => {
+                self.listeners
+                    .lock()
+                    .expect("egress proxy listener lock poisoned")
+                    .insert(
+                        host_interaction_ip,
+                        ListenerHandle {
+                            stop: stop_tx,
+                            join,
+                        },
+                    );
+                Ok(())
+            }
+            Ok(Err(error)) => {
+                let _ = join.join();
+                Err(anyhow::anyhow!(error))
+            }
+            Err(error) => {
+                let _ = join.join();
+                Err(anyhow::anyhow!(
+                    "egress proxy listener startup channel: {error}"
+                ))
+            }
+        }
+    }
+
+    /// Stage a policy without making it visible to new connections. This lets
+    /// callers update the namespace redirect first and then activate the new
+    /// policy, preserving the old policy throughout the transition.
+    pub(crate) fn prepare(&self, host_interaction_ip: Ipv4Addr, policy: &SandboxNetworkPolicy) {
+        self.pending
+            .lock()
+            .expect("egress proxy pending lock poisoned")
+            .insert(
+                host_interaction_ip,
+                ActiveEgressPolicy {
+                    policy: policy.clone(),
+                },
+            );
+    }
+
+    pub(crate) fn activate(&self, host_interaction_ip: Ipv4Addr) {
+        let pending = self
+            .pending
+            .lock()
+            .expect("egress proxy pending lock poisoned")
+            .remove(&host_interaction_ip);
+        if let Some(policy) = pending {
+            self.active
+                .write()
+                .expect("egress proxy active lock poisoned")
+                .insert(host_interaction_ip, policy);
+        }
+    }
+
+    pub(crate) fn discard_pending(&self, host_interaction_ip: Ipv4Addr) {
+        self.pending
+            .lock()
+            .expect("egress proxy pending lock poisoned")
+            .remove(&host_interaction_ip);
+    }
+
+    /// Stop accepting new proxy connections while allowing existing relays to
+    /// continue using the policy snapshot captured when they were admitted.
+    pub(crate) fn deactivate(&self, host_interaction_ip: Ipv4Addr) {
+        self.pending
+            .lock()
+            .expect("egress proxy pending lock poisoned")
+            .remove(&host_interaction_ip);
+        self.active
+            .write()
+            .expect("egress proxy active lock poisoned")
+            .remove(&host_interaction_ip);
+        self.stop_listener(host_interaction_ip);
+    }
+
+    /// Tear down all proxy state for a sandbox network slot.
+    pub(crate) fn teardown(&self, host_interaction_ip: Ipv4Addr) {
+        self.deactivate(host_interaction_ip);
+        self.stop_connections(host_interaction_ip);
+    }
+
+    pub(crate) fn has_active(&self, host_interaction_ip: Ipv4Addr) -> bool {
+        self.active
+            .read()
+            .expect("egress proxy active lock poisoned")
+            .contains_key(&host_interaction_ip)
+    }
+
+    pub(crate) fn shutdown(&self) {
+        let listeners = std::mem::take(
+            &mut *self
+                .listeners
+                .lock()
+                .expect("egress proxy listener lock poisoned"),
+        );
+        for (_, listener) in listeners {
+            let _ = listener.stop.send(());
+            let _ = listener.join.join();
+        }
+        let hosts = self
+            .connections
+            .lock()
+            .expect("egress proxy connection lock poisoned")
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        for host_interaction_ip in hosts {
+            self.teardown(host_interaction_ip);
+        }
+        self.resolver.shutdown();
+    }
+
+    fn stop_listener(&self, host_interaction_ip: Ipv4Addr) {
+        if let Some(listener) = self
+            .listeners
+            .lock()
+            .expect("egress proxy listener lock poisoned")
+            .remove(&host_interaction_ip)
+        {
+            let _ = listener.stop.send(());
+            let _ = listener.join.join();
+        }
+    }
+
+    fn active_policy(&self, host_interaction_ip: Ipv4Addr) -> Option<ActiveEgressPolicy> {
+        self.active
+            .read()
+            .expect("egress proxy active lock poisoned")
+            .get(&host_interaction_ip)
+            .cloned()
+    }
+
+    fn register_connection(
+        &self,
+        host_interaction_ip: Ipv4Addr,
+        client: &TcpStream,
+    ) -> std::io::Result<Option<(usize, Arc<AtomicBool>)>> {
+        let mut connections = self
+            .connections
+            .lock()
+            .expect("egress proxy connection lock poisoned");
+        let state = connections
+            .entry(host_interaction_ip)
+            .or_insert_with(|| ConnectionState {
+                sockets: HashMap::new(),
+                joins: HashMap::new(),
+            });
+        if state.sockets.len() >= MAX_CONNECTIONS_PER_PROXY {
+            return Ok(None);
+        }
+
+        let id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let sockets = Arc::new(Mutex::new(ConnectionSockets {
+            client: client.try_clone()?,
+            upstream: None,
+            cancel: Arc::clone(&cancel),
+            closed: false,
+        }));
+        state.sockets.insert(id, sockets);
+        Ok(Some((id, cancel)))
+    }
+
+    fn register_join(
+        &self,
+        host_interaction_ip: Ipv4Addr,
+        id: usize,
+        join: JoinHandle<()>,
+    ) -> Option<JoinHandle<()>> {
+        let mut connections = self
+            .connections
+            .lock()
+            .expect("egress proxy connection lock poisoned");
+        let Some(state) = connections.get_mut(&host_interaction_ip) else {
+            return Some(join);
+        };
+        state.joins.insert(id, join);
+        None
+    }
+
+    fn set_upstream_connection(
+        &self,
+        host_interaction_ip: Ipv4Addr,
+        id: usize,
+        upstream: &TcpStream,
+    ) {
+        let entry = self.connections.lock().ok().and_then(|connections| {
+            connections
+                .get(&host_interaction_ip)?
+                .sockets
+                .get(&id)
+                .cloned()
+        });
+        let Some(entry) = entry else { return };
+        let Ok(upstream) = upstream.try_clone() else {
+            return;
+        };
+        let Ok(mut sockets) = entry.lock() else {
+            return;
+        };
+        if sockets.closed {
+            let _ = upstream.shutdown(Shutdown::Both);
+        } else {
+            sockets.upstream = Some(upstream);
+        }
+    }
+
+    fn unregister_connection(&self, host_interaction_ip: Ipv4Addr, id: usize) {
+        if let Ok(mut connections) = self.connections.lock() {
+            if let Some(state) = connections.get_mut(&host_interaction_ip) {
+                state.sockets.remove(&id);
+            }
+        }
+    }
+
+    fn reap_finished(&self, host_interaction_ip: Ipv4Addr) {
+        let joins = self
+            .connections
+            .lock()
+            .ok()
+            .and_then(|mut connections| {
+                let state = connections.get_mut(&host_interaction_ip)?;
+                let finished = state
+                    .joins
+                    .iter()
+                    .filter_map(|(id, join)| join.is_finished().then_some(*id))
+                    .collect::<Vec<_>>();
+                Some(
+                    finished
+                        .into_iter()
+                        .filter_map(|id| state.joins.remove(&id))
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .unwrap_or_default();
+        for join in joins {
+            let _ = join.join();
+        }
+    }
+
+    fn stop_connections(&self, host_interaction_ip: Ipv4Addr) {
+        let state = self
+            .connections
+            .lock()
+            .expect("egress proxy connection lock poisoned")
+            .remove(&host_interaction_ip);
+        let Some(state) = state else { return };
+        for sockets in state.sockets.values() {
+            if let Ok(mut sockets) = sockets.lock() {
+                sockets.closed = true;
+                sockets.cancel.store(true, Ordering::Release);
+                let _ = sockets.client.shutdown(Shutdown::Both);
+                if let Some(upstream) = sockets.upstream.as_ref() {
+                    let _ = upstream.shutdown(Shutdown::Both);
+                }
+            }
+        }
+        for join in state.joins.into_values() {
+            let _ = join.join();
+        }
+    }
+}
+
+impl Drop for EgressProxy {
+    fn drop(&mut self) {
+        let listeners = std::mem::take(
+            self.listeners
+                .get_mut()
+                .expect("egress proxy listener lock poisoned"),
+        );
+        for (_, listener) in listeners {
+            let _ = listener.stop.send(());
+            let _ = listener.join.join();
+        }
+        let hosts = self
+            .connections
+            .get_mut()
+            .expect("egress proxy connection lock poisoned")
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        for host_interaction_ip in hosts {
+            self.stop_connections(host_interaction_ip);
+        }
+    }
+}
+
+fn run_namespace_listener(
+    listener: TcpListener,
+    stop_rx: mpsc::Receiver<()>,
+    proxy: Arc<EgressProxy>,
+    host_interaction_ip: Ipv4Addr,
+) {
+    loop {
+        proxy.reap_finished(host_interaction_ip);
+        if stop_rx.try_recv().is_ok() {
+            break;
+        }
+        match listener.accept() {
+            Ok((stream, _peer)) => {
+                let Some((connection_id, cancel)) = (match proxy
+                    .register_connection(host_interaction_ip, &stream)
+                {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        warn!(%host_interaction_ip, %error, "clone egress proxy connection failed");
+                        drop(stream);
+                        continue;
+                    }
+                }) else {
+                    warn!(%host_interaction_ip, "egress proxy connection limit reached");
+                    drop(stream);
+                    continue;
+                };
+                let handler_proxy = Arc::clone(&proxy);
+                let join = thread::Builder::new()
+                    .name("agentenv-egress-proxy-conn".to_string())
+                    .spawn(move || {
+                        handle_connection(
+                            stream,
+                            host_interaction_ip,
+                            connection_id,
+                            cancel,
+                            handler_proxy,
+                        );
+                    });
+                match join {
+                    Ok(join) => {
+                        if let Some(join) =
+                            proxy.register_join(host_interaction_ip, connection_id, join)
+                        {
+                            let _ = join.join();
+                        }
+                    }
+                    Err(error) => {
+                        proxy.unregister_connection(host_interaction_ip, connection_id);
+                        warn!(%host_interaction_ip, %error, "spawn egress proxy connection handler failed");
+                        // Dropping the stream rejects this connection and
+                        // unregistering it makes the bounded handler count recover.
+                    }
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => {
+                warn!(error = %error, "egress proxy accept failed");
+                thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+fn handle_connection(
+    mut client: TcpStream,
+    host_interaction_ip: Ipv4Addr,
+    connection_id: usize,
+    cancel: Arc<AtomicBool>,
+    proxy: Arc<EgressProxy>,
+) {
+    let _registration = ConnectionRegistration {
+        proxy: Arc::clone(&proxy),
+        host_interaction_ip,
+        connection_id,
+    };
+    let Some(active_policy) = proxy.active_policy(host_interaction_ip) else {
+        return;
+    };
+    if cancel.load(Ordering::Acquire) {
+        return;
+    }
+
+    let preface_deadline = Instant::now() + PREFACE_TIMEOUT;
+    let mut preface = Vec::with_capacity(4096);
+    let mut scratch = [0_u8; 4096];
+    let (original_ip, original_port) = match original_destination(&client) {
+        Ok(destination) => destination,
+        Err(error) => {
+            debug!(error = %error, %host_interaction_ip, "egress proxy could not read original destination");
+            return;
+        }
+    };
+    let original_addr = SocketAddr::new(IpAddr::V4(original_ip), original_port);
+
+    // E2B keeps an explicit CIDR grant usable even when the same policy also
+    // has domain rules. Connect directly to that original destination; only
+    // the domain branch needs protocol inspection and trusted DNS resolution.
+    let (hostname, upstreams) = if active_policy.policy.is_ip_allowed(original_ip) {
+        (None, vec![original_addr])
+    } else {
+        let hostname = loop {
+            match parse_protocol_host(&preface, original_port) {
+                Ok(Some(host)) => break host,
+                Ok(None) if preface.len() >= MAX_PREFACE_BYTES => return,
+                Ok(None) => {}
+                Err(error) => {
+                    debug!(%error, %host_interaction_ip, "egress proxy could not inspect connection");
+                    return;
+                }
+            }
+            let remaining = preface_deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() || client.set_read_timeout(Some(remaining)).is_err() {
+                return;
+            }
+            match client.read(&mut scratch) {
+                Ok(0) => return,
+                Ok(read) => preface.extend_from_slice(&scratch[..read]),
+                Err(_) => return,
+            }
+        };
+        let upstreams = match select_upstream(
+            &active_policy.policy,
+            &proxy.resolver,
+            &hostname,
+            original_addr,
+            Some(&cancel),
+        ) {
+            UpstreamDecision::Forward(upstreams) => upstreams,
+            UpstreamDecision::Deny => {
+                debug!(
+                    %host_interaction_ip,
+                    hostname = %hostname,
+                    original_ip = %original_ip,
+                    original_port,
+                    "egress proxy denied connection"
+                );
+                return;
+            }
+            UpstreamDecision::Unavailable => {
+                debug!(
+                    %host_interaction_ip,
+                    hostname = %hostname,
+                    original_ip = %original_ip,
+                    original_port,
+                    "egress proxy could not select an eligible upstream"
+                );
+                return;
+            }
+        };
+        (Some(hostname), upstreams)
+    };
+    if cancel.load(Ordering::Acquire) {
+        return;
+    }
+
+    let mut selected_upstream = None;
+    let mut upstream_stream = None;
+    for upstream in upstreams {
+        if cancel.load(Ordering::Acquire) {
+            return;
+        }
+        match TcpStream::connect_timeout(&upstream, UPSTREAM_TIMEOUT) {
+            Ok(stream) => {
+                selected_upstream = Some(upstream);
+                upstream_stream = Some(stream);
+                break;
+            }
+            Err(error) => {
+                debug!(
+                    %host_interaction_ip,
+                    ?hostname,
+                    %upstream,
+                    %error,
+                    "egress proxy upstream connect failed; trying next address"
+                );
+            }
+        }
+    }
+    let (upstream, mut upstream_stream) = match selected_upstream.zip(upstream_stream) {
+        Some(selected) => selected,
+        None => return,
+    };
+    if cancel.load(Ordering::Acquire) {
+        let _ = upstream_stream.shutdown(Shutdown::Both);
+        return;
+    }
+    proxy.set_upstream_connection(host_interaction_ip, connection_id, &upstream_stream);
+    let _ = upstream_stream.set_read_timeout(None);
+    let _ = client.set_read_timeout(None);
+    if let Err(error) = upstream_stream.write_all(&preface) {
+        debug!(
+            %host_interaction_ip,
+            ?hostname,
+            %upstream,
+            %error,
+            "egress proxy upstream preface write failed"
+        );
+        return;
+    }
+    relay(client, upstream_stream);
+}
+
+struct ConnectionRegistration {
+    proxy: Arc<EgressProxy>,
+    host_interaction_ip: Ipv4Addr,
+    connection_id: usize,
+}
+
+impl Drop for ConnectionRegistration {
+    fn drop(&mut self) {
+        self.proxy
+            .unregister_connection(self.host_interaction_ip, self.connection_id);
+    }
+}
+
+/// Applies the proxy-backed capabilities in the active policy and selects the
+/// upstream connection. Domain matches are resolved in the host namespace and
+/// connected to the selected trusted address, matching E2B's trusted-resolution
+/// semantics. IP/CIDR matches continue to use the guest's original destination.
+fn select_upstream(
+    policy: &SandboxNetworkPolicy,
+    resolver: &HostNetResolver,
+    hostname: &str,
+    original_destination: SocketAddr,
+    cancel: Option<&AtomicBool>,
+) -> UpstreamDecision {
+    let SocketAddr::V4(original_destination) = original_destination else {
+        return UpstreamDecision::Unavailable;
+    };
+    // E2B treats allowOut entries additively: an explicitly allowed CIDR is
+    // still valid when domain interception is enabled. Check that grant before
+    // requiring a Host/SNI value, which also supports direct-IP HTTPS.
+    if policy.is_ip_allowed(*original_destination.ip()) {
+        return UpstreamDecision::Forward(vec![SocketAddr::V4(original_destination)]);
+    }
+    if policy.has_domain_allow_rules() {
+        if hostname.is_empty() {
+            return UpstreamDecision::Deny;
+        }
+        if !policy.is_domain_allowed(hostname, None) {
+            return UpstreamDecision::Deny;
+        }
+        return resolve_trusted_upstream(
+            policy,
+            resolver,
+            hostname,
+            original_destination.port(),
+            cancel,
+        )
+        .map_or(UpstreamDecision::Unavailable, UpstreamDecision::Forward);
+    }
+    UpstreamDecision::Deny
+}
+
+fn resolve_trusted_upstream(
+    policy: &SandboxNetworkPolicy,
+    resolver: &HostNetResolver,
+    hostname: &str,
+    port: u16,
+    cancel: Option<&AtomicBool>,
+) -> Option<Vec<SocketAddr>> {
+    // The resolver worker stays in the host namespace, so guest-controlled
+    // /etc/hosts, DNS configuration, and routes cannot redirect this lookup.
+    let addresses = resolver
+        .resolve(hostname, port, cancel)?
+        .into_iter()
+        .filter(|address| {
+            matches!(address, SocketAddr::V4(address)
+            if policy.is_domain_allowed(hostname, Some(*address.ip())))
+        })
+        .collect::<Vec<_>>();
+    (!addresses.is_empty()).then_some(addresses)
+}
+
+fn relay(mut client: TcpStream, mut upstream: TcpStream) {
+    let mut client_reader = match client.try_clone() {
+        Ok(reader) => reader,
+        Err(_) => return,
+    };
+    let mut upstream_writer = match upstream.try_clone() {
+        Ok(writer) => writer,
+        Err(_) => return,
+    };
+    let forward = thread::spawn(move || {
+        let _ = std::io::copy(&mut client_reader, &mut upstream_writer);
+        let _ = upstream_writer.shutdown(Shutdown::Write);
+    });
+    let _ = std::io::copy(&mut upstream, &mut client);
+    // Match the stream-copy contract used by mature async proxy runtimes:
+    // close only the completed direction so a peer can still drain data in
+    // the opposite direction before the relay exits.
+    let _ = client.shutdown(Shutdown::Write);
+    let _ = upstream.shutdown(Shutdown::Read);
+    let _ = forward.join();
+}
+
+fn parse_protocol_host(preface: &[u8], original_port: u16) -> Result<Option<String>> {
+    if original_port == 443 || preface.first() == Some(&22) {
+        return parse_tls_sni(preface);
+    }
+    parse_http_host(preface)
+}
+
+fn parse_http_host(preface: &[u8]) -> Result<Option<String>> {
+    let mut headers = [httparse::EMPTY_HEADER; 64];
+    let mut request = httparse::Request::new(&mut headers);
+    match request.parse(preface).context("parse HTTP request")? {
+        Status::Partial => Ok(None),
+        Status::Complete(_) => Ok(request.headers.iter().find_map(|header| {
+            (header.name.eq_ignore_ascii_case("host")).then(|| normalize_host(header.value))
+        })),
+    }
+}
+
+fn normalize_host(value: &[u8]) -> String {
+    let value = String::from_utf8_lossy(value);
+    let host = value.trim().trim_end_matches('.');
+    // The current sandbox dataplane is IPv4-only: bracketed IPv6 literals do
+    // not identify a domain allowlist entry and must fail closed here until
+    // matching IPv6 routing, ip6tables, and proxy support exists end to end.
+    if host.starts_with('[') {
+        return String::new();
+    }
+    host.rsplit_once(':')
+        .filter(|(host, port)| !host.contains(']') && port.parse::<u16>().is_ok())
+        .map_or_else(
+            || host.to_ascii_lowercase(),
+            |(host, _)| host.to_ascii_lowercase(),
+        )
+}
+
+fn parse_tls_sni(preface: &[u8]) -> Result<Option<String>> {
+    if preface.first() != Some(&22) {
+        return Ok(None);
+    }
+    // TLS permits a ClientHello handshake message to span multiple records.
+    // Parse record envelopes first and accumulate their handshake payloads so
+    // SNI extraction does not depend on the sender's record boundaries.
+    let mut records = preface;
+    let mut handshake = Vec::new();
+    let mut handshake_offset = 0;
+    loop {
+        let (remaining, record) = match parse_tls_raw_record(records) {
+            Ok(parsed) => parsed,
+            Err(tls_parser::Err::Incomplete(_)) => return Ok(None),
+            Err(error) => return Err(anyhow::anyhow!("parse TLS record: {error:?}")),
+        };
+        records = remaining;
+        if record.hdr.record_type == TlsRecordType::Handshake {
+            handshake.extend_from_slice(record.data);
+            loop {
+                if handshake.len().saturating_sub(handshake_offset) < 4 {
+                    break;
+                }
+                let message_len = u32::from_be_bytes([
+                    0,
+                    handshake[handshake_offset + 1],
+                    handshake[handshake_offset + 2],
+                    handshake[handshake_offset + 3],
+                ]) as usize;
+                let message_size = 4 + message_len;
+                if handshake.len().saturating_sub(handshake_offset) < message_size {
+                    break;
+                }
+                let message = &handshake[handshake_offset..handshake_offset + message_size];
+                handshake_offset += message_size;
+                if message[0] != 1 {
+                    continue;
+                }
+                let (_, message) = parse_tls_handshake_msg_client_hello(&message[4..])
+                    .map_err(|error| anyhow::anyhow!("parse TLS ClientHello: {error:?}"))?;
+                let tls_parser::TlsMessageHandshake::ClientHello(hello) = message else {
+                    return Ok(Some(String::new()));
+                };
+                let Some(extensions) = hello.ext else {
+                    return Ok(Some(String::new()));
+                };
+                let (_, extensions) = tls_parser::parse_tls_client_hello_extensions(extensions)
+                    .map_err(|error| {
+                        anyhow::anyhow!("parse TLS ClientHello extensions: {error:?}")
+                    })?;
+                for extension in extensions {
+                    if let tls_parser::TlsExtension::SNI(names) = extension {
+                        if let Some((tls_parser::SNIType::HostName, name)) =
+                            names.into_iter().next()
+                        {
+                            return Ok(Some(String::from_utf8_lossy(name).to_ascii_lowercase()));
+                        }
+                    }
+                }
+                return Ok(Some(String::new()));
+            }
+        }
+        if records.is_empty() {
+            return Ok(None);
+        }
+    }
+}
+
+fn original_destination(stream: &TcpStream) -> Result<(Ipv4Addr, u16)> {
+    // AgentENV intentionally mirrors the IPv4 guest-side interception path:
+    // IPv6 policy entries remain representable, but AF_INET6 original-dst and
+    // ip6tables enforcement require a separate end-to-end dataplane change.
+    let mut address = std::mem::MaybeUninit::<libc::sockaddr_in>::zeroed();
+    let mut length = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+    // SAFETY: address and length point to valid writable storage for getsockopt.
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_IP,
+            SO_ORIGINAL_DST,
+            address.as_mut_ptr().cast(),
+            &mut length,
+        )
+    };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    if usize::try_from(length).unwrap_or(0) < std::mem::size_of::<libc::sockaddr_in>() {
+        anyhow::bail!("SO_ORIGINAL_DST returned a short sockaddr_in ({length} bytes)");
+    }
+    // SAFETY: getsockopt returned success and initialized a complete sockaddr_in.
+    let address = unsafe { address.assume_init() };
+    if address.sin_family as libc::c_int != libc::AF_INET {
+        anyhow::bail!(
+            "SO_ORIGINAL_DST returned unexpected address family {}",
+            address.sin_family
+        );
+    }
+    let ip = Ipv4Addr::from(u32::from_be(address.sin_addr.s_addr));
+    Ok((ip, u16::from_be(address.sin_port)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::{BaseSandboxNetworkPolicy, SandboxNetworkEgressPolicy};
+
+    #[test]
+    fn http_host_is_parsed() {
+        let host = parse_http_host(b"GET / HTTP/1.1\r\nHost: Example.com:443\r\n\r\n")
+            .unwrap()
+            .unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(
+            parse_http_host(b"GET / HTTP/1.1\r\nHost: [2001:db8::1]:443\r\n\r\n")
+                .unwrap()
+                .unwrap(),
+            ""
+        );
+    }
+
+    #[test]
+    fn tls_sni_is_parsed() {
+        let hostname = b"example.com";
+        let mut client_hello = vec![
+            0x03, 0x03, // ClientHello version
+        ];
+        client_hello.extend_from_slice(&[0; 32]);
+        client_hello.extend_from_slice(&[
+            0x00, // session id length
+            0x00, 0x02, 0x00, 0x2f, // one cipher suite
+            0x01, 0x00, // one compression method
+            0x00, 0x14, // extensions length
+            0x00, 0x00, 0x00, 0x10, // server_name extension
+            0x00, 0x0e, // server name list length
+            0x00, // host_name
+            0x00, 0x0b, // hostname length
+        ]);
+        client_hello.extend_from_slice(hostname);
+
+        let mut preface = vec![0x16, 0x03, 0x03, 0x00, 0x43, 0x01, 0x00, 0x00, 0x3f];
+        preface.extend_from_slice(&client_hello);
+
+        assert_eq!(
+            parse_tls_sni(&preface).unwrap().as_deref(),
+            Some("example.com")
+        );
+
+        let payload = &preface[5..];
+        let split = 20;
+        let mut fragmented = vec![0x16, 0x03, 0x03, 0x00, split as u8];
+        fragmented.extend_from_slice(&payload[..split]);
+        let second_len = (payload.len() - split) as u16;
+        fragmented.extend_from_slice(&[0x16, 0x03, 0x03]);
+        fragmented.extend_from_slice(&second_len.to_be_bytes());
+        fragmented.extend_from_slice(&payload[split..]);
+        assert_eq!(
+            parse_tls_sni(&fragmented).unwrap().as_deref(),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn staged_replacement_keeps_old_policy_until_activation() {
+        let proxy = EgressProxy::new();
+        let ip = Ipv4Addr::new(10, 11, 0, 1);
+        let old = SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Deny,
+            SandboxNetworkEgressPolicy::new(
+                Some(vec!["old.example.com".to_string()]),
+                Some(vec!["0.0.0.0/0".to_string()]),
+            )
+            .unwrap(),
+        );
+        let new = SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Deny,
+            SandboxNetworkEgressPolicy::new(
+                Some(vec!["new.example.com".to_string()]),
+                Some(vec!["0.0.0.0/0".to_string()]),
+            )
+            .unwrap(),
+        );
+        proxy.prepare(ip, &old);
+        proxy.activate(ip);
+        proxy.prepare(ip, &new);
+        assert_eq!(proxy.active_policy(ip).unwrap().policy, old);
+        proxy.activate(ip);
+        assert_eq!(proxy.active_policy(ip).unwrap().policy, new);
+    }
+
+    #[test]
+    fn connection_limit_is_scoped_to_each_host_listener() {
+        let proxy = EgressProxy::new();
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let _client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        let first_host = Ipv4Addr::new(10, 11, 0, 1);
+        let second_host = Ipv4Addr::new(10, 11, 0, 2);
+
+        for _ in 0..MAX_CONNECTIONS_PER_PROXY {
+            assert!(proxy
+                .register_connection(first_host, &server)
+                .unwrap()
+                .is_some());
+        }
+        assert!(proxy
+            .register_connection(first_host, &server)
+            .unwrap()
+            .is_none());
+        assert!(proxy
+            .register_connection(second_host, &server)
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn deactivation_keeps_existing_connections_for_teardown() {
+        let proxy = EgressProxy::new();
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        let host = Ipv4Addr::new(10, 11, 0, 3);
+        let (connection_id, _) = proxy.register_connection(host, &server).unwrap().unwrap();
+
+        proxy.deactivate(host);
+        assert!(proxy
+            .connections
+            .lock()
+            .unwrap()
+            .get(&host)
+            .unwrap()
+            .sockets
+            .contains_key(&connection_id));
+        proxy.teardown(host);
+        assert!(!proxy.connections.lock().unwrap().contains_key(&host));
+        drop(client);
+    }
+
+    #[test]
+    fn domain_policy_denies_connections_without_a_hostname() {
+        let policy = SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Allow,
+            SandboxNetworkEgressPolicy::new(
+                Some(vec!["example.com".to_string()]),
+                Some(vec!["0.0.0.0/0".to_string()]),
+            )
+            .unwrap(),
+        );
+        let resolver = HostNetResolver::new();
+
+        assert!(matches!(
+            select_upstream(
+                &policy,
+                &resolver,
+                "",
+                SocketAddr::from(([203, 0, 113, 10], 443)),
+                None,
+            ),
+            UpstreamDecision::Deny
+        ));
+    }
+
+    #[test]
+    fn mixed_domain_and_cidr_policy_keeps_cidr_grants() {
+        let policy = SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Deny,
+            SandboxNetworkEgressPolicy::new(
+                Some(vec!["example.com".to_string(), "8.8.8.8".to_string()]),
+                Some(vec!["0.0.0.0/0".to_string()]),
+            )
+            .unwrap(),
+        );
+        let resolver = HostNetResolver::new();
+
+        assert!(matches!(
+            select_upstream(
+                &policy,
+                &resolver,
+                "",
+                SocketAddr::from(([8, 8, 8, 8], 443)),
+                None,
+            ),
+            UpstreamDecision::Forward(destinations)
+                if destinations == [SocketAddr::from(([8, 8, 8, 8], 443))]
+        ));
+    }
+}

--- a/src/sandbox/network/egress_proxy.rs
+++ b/src/sandbox/network/egress_proxy.rs
@@ -651,6 +651,9 @@ fn handle_connection(
         );
         return;
     }
+    // Domain inspection is intentionally per TCP connection, matching E2B's
+    // initial Host/SNI inspection. Keep-alive HTTP requests on this relay are
+    // not reparsed independently after the connection has been authorized.
     relay(client, upstream_stream);
 }
 
@@ -760,9 +763,27 @@ fn parse_http_host(preface: &[u8]) -> Result<Option<String>> {
     let mut request = httparse::Request::new(&mut headers);
     match request.parse(preface).context("parse HTTP request")? {
         Status::Partial => Ok(None),
-        Status::Complete(_) => Ok(request.headers.iter().find_map(|header| {
-            (header.name.eq_ignore_ascii_case("host")).then(|| normalize_host(header.value))
-        })),
+        Status::Complete(_) => {
+            let host_headers = request
+                .headers
+                .iter()
+                .filter(|header| header.name.eq_ignore_ascii_case("host"))
+                .collect::<Vec<_>>();
+            match host_headers.as_slice() {
+                [] => Ok(None),
+                [header]
+                    if !header
+                        .value
+                        .iter()
+                        .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace()) =>
+                {
+                    Ok(Some(normalize_host(header.value)))
+                }
+                // A malformed or duplicate Host header must not be authorized
+                // using only the first value; empty is fail-closed in policy.
+                _ => Ok(Some(String::new())),
+            }
+        }
     }
 }
 
@@ -902,6 +923,12 @@ mod tests {
                 .unwrap(),
             ""
         );
+    }
+
+    #[test]
+    fn duplicate_http_host_is_rejected() {
+        let request = b"GET / HTTP/1.1\r\nHost: example.com\r\nHost: other.example\r\n\r\n";
+        assert_eq!(parse_http_host(request).unwrap(), Some(String::new()));
     }
 
     #[test]

--- a/src/sandbox/network/manager.rs
+++ b/src/sandbox/network/manager.rs
@@ -210,7 +210,7 @@ impl NetworkManager {
         self.cleanup_slot_and_release_bit_inner(slot, false)
     }
 
-    fn cleanup_slot_and_release_bit_inner(&self, slot: Slot, sync_cleanup: bool) -> Result<()> {
+    fn cleanup_slot_and_release_bit_inner(&self, mut slot: Slot, sync_cleanup: bool) -> Result<()> {
         let idx = slot.idx;
         let cleanup_result = slot.cleanup(sync_cleanup);
         let bitset_result = self.release_slot_bit(idx);
@@ -270,7 +270,7 @@ impl NetworkManager {
 
         match self.allocated.set_next_free_bit() {
             Some(idx) => {
-                let slot = Slot::new(
+                let mut slot = Slot::new(
                     idx as u32,
                     self.address_plan,
                     self.netns_dir.clone(),

--- a/src/sandbox/network/manager.rs
+++ b/src/sandbox/network/manager.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use anyhow::{anyhow, Result};
 #[cfg(test)]
@@ -13,6 +13,7 @@ use nix::libc;
 use tracing::{debug, trace, warn};
 use warm_pool::{PoolConfig, PoolMaintenanceAction, WarmPool};
 
+use super::egress_proxy::EgressProxy;
 use super::iptables_util::{apply_iptables_commands, IptablesRestoreCommand, OpenFailurePolicy};
 use super::{NetworkAddressPlan, NetworkError, Slot, HOST_VETH_PREFIX, MAX_SLOTS};
 
@@ -44,16 +45,6 @@ struct NetworkManagerConfig {
     netns_dir: PathBuf,
 }
 
-fn get_network_manager_config() -> NetworkManagerConfig {
-    let cfg = crate::cfg::ConfigManager::global_config();
-    NetworkManagerConfig {
-        pool: cfg.network_pool_config(),
-        address_plan: NetworkAddressPlan::from_config(&cfg.network)
-            .expect("validated network.internal config should produce an address plan"),
-        netns_dir: cfg.runtime_path.join("netns"),
-    }
-}
-
 pub(crate) struct NetworkManager {
     /// Bitmap tracking allocated slots.
     allocated: AtomicBitSet<{ slot_count::from_bits(MAX_SLOTS) }>,
@@ -66,6 +57,10 @@ pub(crate) struct NetworkManager {
 
     /// Directory containing persistent namespace bind mounts.
     netns_dir: PathBuf,
+
+    /// Namespace-local transparent proxy for egress capabilities that require
+    /// connection inspection or mediation.
+    egress_proxy: Arc<EgressProxy>,
 
     /// Rejects new allocations once shutdown cleanup starts.
     shutting_down: AtomicBool,
@@ -88,7 +83,13 @@ impl NetworkManager {
                 );
             }
 
-            Self::with_config(get_network_manager_config())
+            let cfg = crate::cfg::ConfigManager::global_config();
+            Self::with_config(NetworkManagerConfig {
+                pool: cfg.network_pool_config(),
+                address_plan: NetworkAddressPlan::from_config(&cfg.network)
+                    .expect("validated network.internal config should produce an address plan"),
+                netns_dir: cfg.runtime_path.join("netns"),
+            })
         });
 
         manager.ensure_pool_maintenance_worker_started();
@@ -122,11 +123,13 @@ impl NetworkManager {
     }
 
     fn with_config(config: NetworkManagerConfig) -> Self {
+        let egress_proxy = EgressProxy::new();
         let manager = Self {
             allocated: AtomicBitSet::new(),
             pool: WarmPool::new(config.pool),
             address_plan: config.address_plan,
             netns_dir: config.netns_dir,
+            egress_proxy,
             shutting_down: AtomicBool::new(false),
         };
 
@@ -167,8 +170,13 @@ impl NetworkManager {
 
         match self.allocated.insert(idx as usize) {
             // insert returns true when the bit WAS already set (duplicate)
-            Some(false) => Ok(Slot::new(idx, self.address_plan, self.netns_dir.clone())
-                .expect("Slot index just validated")),
+            Some(false) => Ok(Slot::new(
+                idx,
+                self.address_plan,
+                self.netns_dir.clone(),
+                Arc::clone(&self.egress_proxy),
+            )
+            .expect("Slot index just validated")),
             Some(true) => Err(anyhow!("Slot {} already allocated", idx)),
             None => Err(anyhow!("Slot index {} out of range", idx)),
         }
@@ -262,8 +270,13 @@ impl NetworkManager {
 
         match self.allocated.set_next_free_bit() {
             Some(idx) => {
-                let slot = Slot::new(idx as u32, self.address_plan, self.netns_dir.clone())
-                    .expect("BitSet index within valid range");
+                let slot = Slot::new(
+                    idx as u32,
+                    self.address_plan,
+                    self.netns_dir.clone(),
+                    Arc::clone(&self.egress_proxy),
+                )
+                .expect("BitSet index within valid range");
                 if let Err(e) = slot.create_network() {
                     self.allocated.remove(idx);
                     return Err(anyhow!("Failed to create network: {e}"));
@@ -401,6 +414,7 @@ impl NetworkManager {
             }
         }
 
+        self.egress_proxy.shutdown();
         self.cleanup_global_host_iptables();
 
         if failures.is_empty() {
@@ -738,6 +752,7 @@ mod tests {
             idx,
             NetworkAddressPlan::default(),
             std::env::temp_dir().join("aenv-network-tests/netns"),
+            EgressProxy::new(),
         )
         .unwrap()
     }

--- a/src/sandbox/network/mod.rs
+++ b/src/sandbox/network/mod.rs
@@ -1,7 +1,9 @@
 mod address_plan;
+mod egress_proxy;
 mod iptables_util;
 mod manager;
 mod policy;
+mod resolver;
 mod slot;
 
 use std::path::Path;
@@ -10,7 +12,10 @@ use anyhow::Context;
 
 pub(crate) use address_plan::NetworkAddressPlan;
 pub(crate) use manager::NetworkManager;
-pub use policy::{BaseSandboxNetworkPolicy, SandboxNetworkEgressPolicy, SandboxNetworkPolicy};
+pub use policy::{
+    BaseSandboxNetworkPolicy, SandboxNetworkEgressPolicy, SandboxNetworkPolicy,
+    ALL_INTERNET_TRAFFIC_CIDR,
+};
 pub(crate) use slot::Slot;
 
 pub(crate) const MAX_SLOTS: usize = crate::cfg::network::NETWORK_MAX_SLOTS;

--- a/src/sandbox/network/policy.rs
+++ b/src/sandbox/network/policy.rs
@@ -6,17 +6,20 @@ use std::{
     sync::OnceLock,
 };
 
+use ipnetwork::{IpNetwork, Ipv4Network};
+
 use super::iptables_util::{apply_iptables_commands, IptablesRestoreCommand, OpenFailurePolicy};
 use crate::cfg::network::normalize_dns_name;
 
-pub const ALL_INTERNET_TRAFFIC_CIDR: &str = "0.0.0.0/0";
+pub const ALL_INTERNET_TRAFFIC_CIDR: IpNetwork =
+    IpNetwork::V4(Ipv4Network::new_checked(Ipv4Addr::UNSPECIFIED, 0).unwrap());
 
 const EGRESS_CHAIN: &str = "AGENTENV-EGRESS";
 const USER_EGRESS_CHAIN: &str = "AGENTENV-USER-EGRESS";
 const EGRESS_PROXY_CHAIN: &str = "AGENTENV-EGRESS-PROXY";
 const DOMAIN_INSPECTION_TCP_PORTS: &[u16] = &[80, 443];
 
-static PLATFORM_DENIED_CIDRS: OnceLock<Box<[String]>> = OnceLock::new();
+static PLATFORM_DENIED_CIDRS: OnceLock<Box<[Ipv4Network]>> = OnceLock::new();
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum BaseSandboxNetworkPolicy {
@@ -29,9 +32,9 @@ pub enum BaseSandboxNetworkPolicy {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SandboxNetworkEgressPolicy {
-    pub allowed_cidrs: Vec<String>,
+    pub allowed_cidrs: Vec<IpNetwork>,
     pub allowed_domains: Vec<String>,
-    pub denied_cidrs: Vec<String>,
+    pub denied_cidrs: Vec<IpNetwork>,
 }
 
 impl SandboxNetworkEgressPolicy {
@@ -43,7 +46,7 @@ impl SandboxNetworkEgressPolicy {
 
         for entry in allow_out.unwrap_or_default() {
             if let Some(cidr) = try_normalize_ip_or_cidr(&entry)? {
-                if allowed_cidrs.insert(cidr.clone()) {
+                if allowed_cidrs.insert(cidr) {
                     policy.allowed_cidrs.push(cidr);
                 }
             } else {
@@ -59,7 +62,7 @@ impl SandboxNetworkEgressPolicy {
             let Some(cidr) = try_normalize_ip_or_cidr(&entry)? else {
                 bail!("denyOut entry {entry:?} must be an IP address or CIDR block");
             };
-            if denied_cidrs.insert(cidr.clone()) {
+            if denied_cidrs.insert(cidr) {
                 policy.denied_cidrs.push(cidr);
             }
         }
@@ -157,7 +160,7 @@ impl SandboxNetworkPolicy {
             .egress
             .allowed_cidrs
             .iter()
-            .any(|cidr| cidr_contains(cidr, ip))
+            .any(|cidr| matches!(cidr, IpNetwork::V4(network) if network.contains(ip)))
         {
             return true;
         }
@@ -165,7 +168,7 @@ impl SandboxNetworkPolicy {
             .egress
             .denied_cidrs
             .iter()
-            .any(|cidr| cidr_contains(cidr, ip))
+            .any(|cidr| matches!(cidr, IpNetwork::V4(network) if network.contains(ip)))
         {
             return false;
         }
@@ -207,13 +210,13 @@ impl SandboxNetworkPolicy {
                     .egress
                     .always_denied_cidrs
                     .iter()
-                    .cloned()
-                    .chain(address_plan.internal_egress_denied_cidrs())
+                    .chain(address_plan.internal_egress_denied_cidrs().iter())
+                    .filter_map(|cidr| cidr.parse::<Ipv4Network>().ok())
                     .collect::<Vec<_>>()
                     .into_boxed_slice()
             })
             .iter()
-            .any(|cidr| cidr_contains(cidr, ip))
+            .any(|cidr| cidr.contains(ip))
     }
 }
 
@@ -253,12 +256,6 @@ fn domain_matches(hostname: &str, pattern: &str) -> bool {
             };
             !prefix.is_empty() && prefix.ends_with('.') && host_suffix.eq_ignore_ascii_case(suffix)
         })
-}
-
-fn cidr_contains(cidr: &str, ip: Ipv4Addr) -> bool {
-    cidr.parse::<ipnetwork::Ipv4Network>()
-        .map(|network| network.contains(ip))
-        .unwrap_or(false)
 }
 
 pub(super) fn initialize_namespace_egress_chain(
@@ -362,13 +359,19 @@ fn build_user_egress_commands(
         Vec::new()
     };
 
-    for cidr in policy.egress.allowed_cidrs.iter().map(String::as_str) {
+    for cidr in &policy.egress.allowed_cidrs {
+        let IpNetwork::V4(cidr) = cidr else {
+            continue;
+        };
         commands.push(append_user_egress_command(format!(
             "-i tap0 -o vpeer -d {cidr} -j ACCEPT"
         )));
     }
 
-    for cidr in policy.egress.denied_cidrs.iter().map(String::as_str) {
+    for cidr in &policy.egress.denied_cidrs {
+        let IpNetwork::V4(cidr) = cidr else {
+            continue;
+        };
         commands.push(append_user_egress_command(format!(
             "-i tap0 -o vpeer -d {cidr} -j REJECT"
         )));
@@ -419,16 +422,16 @@ fn append_user_egress_command(rule: String) -> IptablesRestoreCommand {
     }
 }
 
-fn try_normalize_ip_or_cidr(s: &str) -> Result<Option<String>> {
+fn try_normalize_ip_or_cidr(s: &str) -> Result<Option<IpNetwork>> {
     if let Ok(ip) = s.parse::<IpAddr>() {
         return Ok(Some(match ip {
-            IpAddr::V4(ip) => format!("{ip}/32"),
-            IpAddr::V6(ip) => format!("{ip}/128"),
+            IpAddr::V4(ip) => IpNetwork::V4(Ipv4Network::new(ip, 32)?),
+            IpAddr::V6(ip) => IpNetwork::V6(ipnetwork::Ipv6Network::new(ip, 128)?),
         }));
     }
 
     match s.parse::<ipnetwork::IpNetwork>() {
-        Ok(network) => Ok(Some(network.to_string())),
+        Ok(network) => Ok(Some(network)),
         Err(err) if s.contains('/') => {
             Err(err).with_context(|| format!("invalid IP or CIDR entry {s:?}"))
         }
@@ -475,9 +478,12 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(policy.allowed_cidrs, ["8.8.8.8/32", "1.1.1.0/24"]);
+        assert_eq!(
+            policy.allowed_cidrs,
+            ["8.8.8.8/32".parse().unwrap(), "1.1.1.0/24".parse().unwrap()]
+        );
         assert_eq!(policy.allowed_domains, ["*.example.com"]);
-        assert_eq!(policy.denied_cidrs, ["203.0.113.0/24"]);
+        assert_eq!(policy.denied_cidrs, ["203.0.113.0/24".parse().unwrap()]);
     }
 
     #[test]
@@ -498,9 +504,41 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(policy.allowed_cidrs, ["8.8.8.8/32", "1.1.1.1/32"]);
+        assert_eq!(
+            policy.allowed_cidrs,
+            ["8.8.8.8/32".parse().unwrap(), "1.1.1.1/32".parse().unwrap()]
+        );
         assert_eq!(policy.allowed_domains, ["example.com"]);
-        assert_eq!(policy.denied_cidrs, ["203.0.113.1/32", "203.0.113.0/24"]);
+        assert_eq!(
+            policy.denied_cidrs,
+            [
+                "203.0.113.1/32".parse().unwrap(),
+                "203.0.113.0/24".parse().unwrap()
+            ]
+        );
+    }
+
+    #[test]
+    fn structured_cidrs_keep_string_wire_format() {
+        let policy = SandboxNetworkEgressPolicy::new(
+            Some(vec!["8.8.8.8".to_string(), "2001:db8::1/128".to_string()]),
+            Some(vec!["0.0.0.0/0".to_string()]),
+        )
+        .unwrap();
+
+        let value = serde_json::to_value(&policy).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "allowed_cidrs": ["8.8.8.8/32", "2001:db8::1/128"],
+                "allowed_domains": [],
+                "denied_cidrs": ["0.0.0.0/0"]
+            })
+        );
+        assert_eq!(
+            serde_json::from_value::<SandboxNetworkEgressPolicy>(value).unwrap(),
+            policy
+        );
     }
 
     #[test]
@@ -536,7 +574,7 @@ mod tests {
             allow_public_traffic: true,
             base_policy: BaseSandboxNetworkPolicy::Deny,
             egress: SandboxNetworkEgressPolicy {
-                allowed_cidrs: vec!["8.8.8.8/32".to_string()],
+                allowed_cidrs: vec!["8.8.8.8/32".parse().unwrap()],
                 denied_cidrs: Vec::new(),
                 allowed_domains: Vec::new(),
             },
@@ -565,8 +603,8 @@ mod tests {
             allow_public_traffic: true,
             base_policy: BaseSandboxNetworkPolicy::Deny,
             egress: SandboxNetworkEgressPolicy {
-                allowed_cidrs: vec!["8.8.8.8/32".to_string()],
-                denied_cidrs: vec!["203.0.113.0/24".to_string()],
+                allowed_cidrs: vec!["8.8.8.8/32".parse().unwrap()],
+                denied_cidrs: vec!["203.0.113.0/24".parse().unwrap()],
                 allowed_domains: Vec::new(),
             },
         };
@@ -588,6 +626,21 @@ mod tests {
                 "-i tap0 -o vpeer -d 0.0.0.0/0 -j REJECT",
             ]
         );
+    }
+
+    #[test]
+    fn build_user_rules_ignores_ipv6_for_ipv4_iptables() {
+        let policy = SandboxNetworkPolicy {
+            allow_public_traffic: true,
+            base_policy: BaseSandboxNetworkPolicy::Allow,
+            egress: SandboxNetworkEgressPolicy {
+                allowed_cidrs: vec!["2001:db8::/32".parse().unwrap()],
+                denied_cidrs: vec!["2001:db8:1::/48".parse().unwrap()],
+                allowed_domains: Vec::new(),
+            },
+        };
+
+        assert!(build_user_egress_commands(&policy, false).is_empty());
     }
 
     #[test]

--- a/src/sandbox/network/policy.rs
+++ b/src/sandbox/network/policy.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     net::{IpAddr, Ipv4Addr},
+    sync::OnceLock,
 };
 
 use super::iptables_util::{apply_iptables_commands, IptablesRestoreCommand, OpenFailurePolicy};
@@ -12,6 +13,10 @@ pub const ALL_INTERNET_TRAFFIC_CIDR: &str = "0.0.0.0/0";
 
 const EGRESS_CHAIN: &str = "AGENTENV-EGRESS";
 const USER_EGRESS_CHAIN: &str = "AGENTENV-USER-EGRESS";
+const EGRESS_PROXY_CHAIN: &str = "AGENTENV-EGRESS-PROXY";
+const DOMAIN_INSPECTION_TCP_PORTS: &[u16] = &[80, 443];
+
+static PLATFORM_DENIED_CIDRS: OnceLock<Box<[String]>> = OnceLock::new();
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum BaseSandboxNetworkPolicy {
@@ -123,20 +128,104 @@ impl SandboxNetworkPolicy {
     pub(crate) fn has_domain_allow_rules(&self) -> bool {
         self.egress.has_domain_allow_rules()
     }
+
+    /// Whether this policy needs traffic interception by the namespace-local
+    /// egress proxy. Domain allowlists are the first proxy-backed capability;
+    /// future proxy capabilities should extend this decision at this boundary.
+    pub(crate) fn requires_egress_proxy(&self) -> bool {
+        self.has_domain_allow_rules()
+    }
+
+    /// TCP destination ports intercepted for the proxy-backed capabilities in this policy.
+    pub(crate) fn egress_proxy_tcp_ports(&self) -> &'static [u16] {
+        if self.has_domain_allow_rules() {
+            DOMAIN_INSPECTION_TCP_PORTS
+        } else {
+            &[]
+        }
+    }
+
+    /// Decide whether an original IP destination may leave the sandbox.
+    /// The runtime dataplane currently supplies IPv4 original destinations;
+    /// retain IPv6 CIDRs for wire compatibility without pretending this
+    /// method provides IPv6 iptables enforcement.
+    pub(crate) fn is_ip_allowed(&self, ip: Ipv4Addr) -> bool {
+        if self.is_absolutely_denied(ip) {
+            return false;
+        }
+        if self
+            .egress
+            .allowed_cidrs
+            .iter()
+            .any(|cidr| cidr_contains(cidr, ip))
+        {
+            return true;
+        }
+        if self
+            .egress
+            .denied_cidrs
+            .iter()
+            .any(|cidr| cidr_contains(cidr, ip))
+        {
+            return false;
+        }
+        // A domain allowlist is an opt-in capability. If the inspected host is
+        // absent or does not match, do not fall back to the base policy.
+        if self.has_domain_allow_rules() {
+            return false;
+        }
+        self.base_policy != BaseSandboxNetworkPolicy::Deny
+    }
+
+    /// Decide whether a host-side resolved address may leave the sandbox for
+    /// an allowed domain. Passing `None` checks only the hostname branch before
+    /// DNS resolution; the proxy passes `Some(resolved_ip)` before connecting.
+    /// User CIDR denies do not override an explicit domain allow, matching
+    /// E2B's allow precedence; absolute platform and slot denies remain
+    /// effective.
+    pub(crate) fn is_domain_allowed(&self, hostname: &str, resolved_ip: Option<Ipv4Addr>) -> bool {
+        if hostname.is_empty()
+            || !self
+                .egress
+                .allowed_domains
+                .iter()
+                .any(|pattern| domain_matches(hostname, pattern))
+        {
+            return false;
+        }
+        resolved_ip.is_none_or(|ip| !self.is_absolutely_denied(ip))
+    }
+
+    fn is_absolutely_denied(&self, ip: Ipv4Addr) -> bool {
+        PLATFORM_DENIED_CIDRS
+            .get_or_init(|| {
+                let config = crate::cfg::ConfigManager::global_config();
+                let address_plan = super::NetworkAddressPlan::from_config(&config.network)
+                    .expect("validated network config should produce an address plan");
+                config
+                    .network
+                    .egress
+                    .always_denied_cidrs
+                    .iter()
+                    .cloned()
+                    .chain(address_plan.internal_egress_denied_cidrs())
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice()
+            })
+            .iter()
+            .any(|cidr| cidr_contains(cidr, ip))
+    }
 }
 
-pub(super) fn set_namespace_egress_policy(policy: Option<&SandboxNetworkPolicy>) -> Result<()> {
+pub(super) fn set_namespace_egress_policy(
+    policy: Option<&SandboxNetworkPolicy>,
+    egress_proxy_port: u16,
+) -> Result<()> {
     let default_policy = SandboxNetworkPolicy::default();
     let policy = policy.unwrap_or(&default_policy);
 
-    if !policy.egress.allowed_domains.is_empty() {
-        bail!(
-            "domain entries in allowOut require the TCP egress proxy, which is not enabled yet: {:?}",
-            policy.egress.allowed_domains
-        );
-    }
-
-    let commands = build_user_egress_commands(policy, true);
+    let mut commands = build_user_egress_commands(policy, true);
+    commands.extend(build_egress_proxy_commands(policy, egress_proxy_port));
     apply_iptables_commands(&commands, OpenFailurePolicy::ReturnErr)
 }
 
@@ -145,6 +234,31 @@ fn configured_always_denied_cidrs() -> &'static [String] {
         .network
         .egress
         .always_denied_cidrs
+}
+
+fn domain_matches(hostname: &str, pattern: &str) -> bool {
+    let hostname = hostname.trim_end_matches('.');
+    let pattern = pattern.trim_end_matches('.');
+    pattern == "*"
+        || pattern.eq_ignore_ascii_case(hostname)
+        || pattern.strip_prefix("*.").is_some_and(|suffix| {
+            let Some(suffix_start) = hostname.len().checked_sub(suffix.len()) else {
+                return false;
+            };
+            let Some(prefix) = hostname.get(..suffix_start) else {
+                return false;
+            };
+            let Some(host_suffix) = hostname.get(suffix_start..) else {
+                return false;
+            };
+            !prefix.is_empty() && prefix.ends_with('.') && host_suffix.eq_ignore_ascii_case(suffix)
+        })
+}
+
+fn cidr_contains(cidr: &str, ip: Ipv4Addr) -> bool {
+    cidr.parse::<ipnetwork::Ipv4Network>()
+        .map(|network| network.contains(ip))
+        .unwrap_or(false)
 }
 
 pub(super) fn initialize_namespace_egress_chain(
@@ -176,6 +290,22 @@ pub(super) fn initialize_namespace_egress_chain(
         internal_egress_denied_cidrs,
         configured_always_denied_cidrs(),
     ));
+    commands.extend([
+        IptablesRestoreCommand::NewChain {
+            table: "nat",
+            chain: EGRESS_PROXY_CHAIN,
+        },
+        IptablesRestoreCommand::Insert {
+            table: "nat",
+            chain: "PREROUTING",
+            position: 1,
+            rule: format!("-i tap0 -j {EGRESS_PROXY_CHAIN}"),
+        },
+        IptablesRestoreCommand::FlushChain {
+            table: "nat",
+            chain: EGRESS_PROXY_CHAIN,
+        },
+    ]);
 
     apply_iptables_commands(&commands, OpenFailurePolicy::ReturnErr)
         .context("initialize AgentENV namespace egress iptables chains")
@@ -250,6 +380,26 @@ fn build_user_egress_commands(
         )));
     }
 
+    commands
+}
+
+fn build_egress_proxy_commands(
+    policy: &SandboxNetworkPolicy,
+    egress_proxy_port: u16,
+) -> Vec<IptablesRestoreCommand> {
+    let mut commands = vec![IptablesRestoreCommand::FlushChain {
+        table: "nat",
+        chain: EGRESS_PROXY_CHAIN,
+    }];
+    for port in policy.egress_proxy_tcp_ports() {
+        commands.push(IptablesRestoreCommand::Append {
+            table: "nat",
+            chain: EGRESS_PROXY_CHAIN,
+            rule: format!(
+                "-i tap0 -p tcp --dport {port} -j REDIRECT --to-ports {egress_proxy_port}"
+            ),
+        });
+    }
     commands
 }
 
@@ -542,5 +692,76 @@ mod tests {
         assert!(!commands.iter().any(
             |command| append_rule(command) == Some("-i tap0 -o vpeer -d 10.0.0.0/8 -j REJECT")
         ));
+    }
+
+    #[test]
+    fn egress_proxy_redirects_domain_inspection_ports() {
+        let policy = SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Deny,
+            SandboxNetworkEgressPolicy::new(
+                Some(vec!["example.com".to_string()]),
+                Some(vec![ALL_INTERNET_TRAFFIC_CIDR.to_string()]),
+            )
+            .unwrap(),
+        );
+        let commands = build_egress_proxy_commands(&policy, 43210);
+        let rules = commands.iter().filter_map(append_rule).collect::<Vec<_>>();
+        assert_eq!(rules.len(), 2);
+        assert!(rules[0].contains("--dport 80"));
+        assert!(rules[1].contains("--dport 443"));
+        assert!(rules.iter().all(|rule| rule.contains("--to-ports 43210")));
+    }
+
+    #[test]
+    fn egress_proxy_chain_is_cleared_when_policy_needs_no_proxy() {
+        let commands = build_egress_proxy_commands(&SandboxNetworkPolicy::default(), 43210);
+        assert!(matches!(
+            commands.as_slice(),
+            [IptablesRestoreCommand::FlushChain {
+                table: "nat",
+                chain: EGRESS_PROXY_CHAIN,
+            }]
+        ));
+    }
+
+    #[test]
+    fn authorization_uses_platform_denied_ranges() {
+        let policy = SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Allow,
+            SandboxNetworkEgressPolicy::default(),
+        );
+
+        assert!(policy.is_ip_allowed(Ipv4Addr::new(198, 51, 100, 10)));
+        assert!(!policy.is_ip_allowed(Ipv4Addr::new(10, 12, 1, 1)));
+    }
+
+    #[test]
+    fn domain_authorization_checks_hostname_and_resolved_ip() {
+        let policy = SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Default,
+            SandboxNetworkEgressPolicy::new(
+                Some(vec!["example.com".to_string()]),
+                Some(Vec::new()),
+            )
+            .unwrap(),
+        );
+
+        assert!(policy.is_domain_allowed("example.com", None));
+        assert!(policy.is_domain_allowed("example.com", Some(Ipv4Addr::new(192, 0, 2, 10))));
+        assert!(!policy.is_domain_allowed("other.example", None));
+        assert!(!policy.is_domain_allowed("example.com", Some(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(!policy.is_domain_allowed("example.com", Some(Ipv4Addr::new(10, 12, 1, 1))));
+    }
+
+    #[test]
+    fn domain_matching_handles_non_ascii_hostnames_without_panicking() {
+        assert!(std::panic::catch_unwind(|| domain_matches("é.com", "*.com")).is_ok());
+        assert!(
+            std::panic::catch_unwind(|| domain_matches("é.example.com", "*.example.com")).is_ok()
+        );
+        assert!(domain_matches("API.Example.COM", "*.example.com"));
     }
 }

--- a/src/sandbox/network/resolver.rs
+++ b/src/sandbox/network/resolver.rs
@@ -1,0 +1,167 @@
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use nix::sched::{setns, CloneFlags};
+use tracing::warn;
+
+use super::slot::host_ns_fd;
+
+const RESOLVER_QUEUE_CAPACITY: usize = 128;
+const RESOLVER_STOP_POLL: Duration = Duration::from_millis(100);
+const RESOLVER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+const RESOLVER_WORKERS: usize = 16;
+
+struct ResolveRequest {
+    hostname: String,
+    port: u16,
+    response: mpsc::SyncSender<Option<Vec<SocketAddr>>>,
+}
+
+/// Resolver worker that remains in the host network namespace for its entire
+/// lifetime. Connection handlers submit hostnames instead of changing their
+/// own namespace for every DNS lookup.
+pub(super) struct HostNetResolver {
+    requests: Mutex<Option<mpsc::SyncSender<ResolveRequest>>>,
+    stopped: AtomicBool,
+    joins: Mutex<Vec<JoinHandle<()>>>,
+}
+
+impl HostNetResolver {
+    pub(super) fn new() -> Self {
+        let (request_tx, request_rx): (
+            mpsc::SyncSender<ResolveRequest>,
+            mpsc::Receiver<ResolveRequest>,
+        ) = mpsc::sync_channel(RESOLVER_QUEUE_CAPACITY);
+        let request_rx = Arc::new(Mutex::new(request_rx));
+        let mut joins = Vec::with_capacity(RESOLVER_WORKERS);
+        for worker_id in 0..RESOLVER_WORKERS {
+            let request_rx = Arc::clone(&request_rx);
+            let join = match thread::Builder::new()
+                .name(format!("agentenv-egress-dns-resolver-{worker_id}"))
+                .spawn(move || {
+                    let host_namespace_ready = match setns(host_ns_fd(), CloneFlags::CLONE_NEWNET) {
+                        Ok(()) => true,
+                        Err(error) => {
+                            warn!(%error, "egress proxy resolver could not enter host network namespace");
+                            false
+                        }
+                    };
+                    loop {
+                        let request = match request_rx
+                            .lock()
+                            .expect("egress proxy resolver request lock poisoned")
+                            .recv_timeout(RESOLVER_STOP_POLL)
+                        {
+                            Ok(request) => request,
+                            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                        };
+                        let resolved = if host_namespace_ready {
+                            match (request.hostname.as_str(), request.port).to_socket_addrs() {
+                                Ok(addresses) => Some(addresses.collect::<Vec<_>>()),
+                                Err(error) => {
+                                    warn!(hostname = %request.hostname, %error, "egress proxy DNS lookup failed");
+                                    None
+                                }
+                            }
+                        } else {
+                            None
+                        };
+                        let _ = request.response.send(resolved);
+                    }
+                })
+            {
+                Ok(join) => join,
+                Err(error) => {
+                    // NetworkManager is a process-global infallible singleton;
+                    // degrade DNS-backed proxy rules to unavailable instead of
+                    // crashing the service when the host cannot create a worker.
+                    warn!(%error, "spawn egress proxy host DNS resolver failed; domain resolution is unavailable");
+                    break;
+                }
+            };
+            joins.push(join);
+        }
+        let requests = (!joins.is_empty()).then_some(request_tx);
+        Self {
+            // A failed thread spawn must not leave a queue with no consumer;
+            // resolve() then fails immediately instead of waiting for its
+            // response timeout on every request.
+            requests: Mutex::new(requests),
+            stopped: AtomicBool::new(false),
+            joins: Mutex::new(joins),
+        }
+    }
+
+    pub(super) fn resolve(
+        &self,
+        hostname: &str,
+        port: u16,
+        cancel: Option<&AtomicBool>,
+    ) -> Option<Vec<SocketAddr>> {
+        if self.stopped.load(Ordering::Acquire) {
+            return None;
+        }
+        let (response_tx, response_rx) = mpsc::sync_channel(1);
+        let requests = self
+            .requests
+            .lock()
+            .expect("egress proxy resolver request lock poisoned")
+            .as_ref()?
+            .clone();
+        requests
+            .try_send(ResolveRequest {
+                hostname: hostname.to_string(),
+                port,
+                response: response_tx,
+            })
+            .ok()?;
+        let deadline = Instant::now() + RESOLVER_RESPONSE_TIMEOUT;
+        loop {
+            if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+                return None;
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return None;
+            }
+            match response_rx.recv_timeout(remaining.min(RESOLVER_STOP_POLL)) {
+                Ok(resolved) => return resolved,
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => return None,
+            }
+        }
+    }
+
+    pub(super) fn shutdown(&self) {
+        self.stopped.store(true, Ordering::Release);
+        let _ = self
+            .requests
+            .lock()
+            .expect("egress proxy resolver request lock poisoned")
+            .take();
+        let joins = std::mem::take(
+            &mut *self
+                .joins
+                .lock()
+                .expect("egress proxy resolver join lock poisoned"),
+        );
+        // A libc resolver call is not cancellable. Join workers that have
+        // already observed shutdown, but detach one that is still in DNS so
+        // network teardown cannot hang indefinitely.
+        for join in joins {
+            if join.is_finished() {
+                let _ = join.join();
+            }
+        }
+    }
+}
+
+impl Drop for HostNetResolver {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}

--- a/src/sandbox/network/resolver.rs
+++ b/src/sandbox/network/resolver.rs
@@ -1,98 +1,69 @@
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc as std_mpsc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use hickory_resolver::config::{LookupIpStrategy, ResolverOpts};
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::TokioResolver;
 use nix::sched::{setns, CloneFlags};
-use tracing::warn;
+use tokio::sync::{mpsc, oneshot, Semaphore};
+use tokio::task::JoinSet;
+use tracing::{debug, warn};
 
 use super::slot::host_ns_fd;
 
 const RESOLVER_QUEUE_CAPACITY: usize = 128;
+const RESOLVER_MAX_IN_FLIGHT: usize = 16;
 const RESOLVER_STOP_POLL: Duration = Duration::from_millis(100);
+const RESOLVER_DNS_TIMEOUT: Duration = Duration::from_secs(5);
 const RESOLVER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
-const RESOLVER_WORKERS: usize = 16;
 
 struct ResolveRequest {
     hostname: String,
     port: u16,
-    response: mpsc::SyncSender<Option<Vec<SocketAddr>>>,
+    response: std_mpsc::SyncSender<Option<Vec<SocketAddr>>>,
+}
+
+#[derive(Default)]
+struct ResolverLifecycle {
+    requests: Option<mpsc::Sender<ResolveRequest>>,
+    shutdown: Option<oneshot::Sender<()>>,
+    join: Option<JoinHandle<()>>,
 }
 
 /// Resolver worker that remains in the host network namespace for its entire
-/// lifetime. Connection handlers submit hostnames instead of changing their
-/// own namespace for every DNS lookup.
+/// lifetime. DNS requests use an async resolver with bounded network timeouts
+/// so shutdown can cancel work instead of waiting on libc's non-cancellable
+/// resolver calls.
 pub(super) struct HostNetResolver {
-    requests: Mutex<Option<mpsc::SyncSender<ResolveRequest>>>,
+    lifecycle: Mutex<ResolverLifecycle>,
     stopped: AtomicBool,
-    joins: Mutex<Vec<JoinHandle<()>>>,
 }
 
 impl HostNetResolver {
     pub(super) fn new() -> Self {
-        let (request_tx, request_rx): (
-            mpsc::SyncSender<ResolveRequest>,
-            mpsc::Receiver<ResolveRequest>,
-        ) = mpsc::sync_channel(RESOLVER_QUEUE_CAPACITY);
-        let request_rx = Arc::new(Mutex::new(request_rx));
-        let mut joins = Vec::with_capacity(RESOLVER_WORKERS);
-        for worker_id in 0..RESOLVER_WORKERS {
-            let request_rx = Arc::clone(&request_rx);
-            let join = match thread::Builder::new()
-                .name(format!("agentenv-egress-dns-resolver-{worker_id}"))
-                .spawn(move || {
-                    let host_namespace_ready = match setns(host_ns_fd(), CloneFlags::CLONE_NEWNET) {
-                        Ok(()) => true,
-                        Err(error) => {
-                            warn!(%error, "egress proxy resolver could not enter host network namespace");
-                            false
-                        }
-                    };
-                    loop {
-                        let request = match request_rx
-                            .lock()
-                            .expect("egress proxy resolver request lock poisoned")
-                            .recv_timeout(RESOLVER_STOP_POLL)
-                        {
-                            Ok(request) => request,
-                            Err(mpsc::RecvTimeoutError::Timeout) => continue,
-                            Err(mpsc::RecvTimeoutError::Disconnected) => break,
-                        };
-                        let resolved = if host_namespace_ready {
-                            match (request.hostname.as_str(), request.port).to_socket_addrs() {
-                                Ok(addresses) => Some(addresses.collect::<Vec<_>>()),
-                                Err(error) => {
-                                    warn!(hostname = %request.hostname, %error, "egress proxy DNS lookup failed");
-                                    None
-                                }
-                            }
-                        } else {
-                            None
-                        };
-                        let _ = request.response.send(resolved);
-                    }
-                })
-            {
-                Ok(join) => join,
-                Err(error) => {
-                    // NetworkManager is a process-global infallible singleton;
-                    // degrade DNS-backed proxy rules to unavailable instead of
-                    // crashing the service when the host cannot create a worker.
-                    warn!(%error, "spawn egress proxy host DNS resolver failed; domain resolution is unavailable");
-                    break;
-                }
-            };
-            joins.push(join);
-        }
-        let requests = (!joins.is_empty()).then_some(request_tx);
+        let (request_tx, request_rx) = mpsc::channel(RESOLVER_QUEUE_CAPACITY);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let lifecycle = match thread::Builder::new()
+            .name("agentenv-egress-dns-resolver".to_string())
+            .spawn(move || run_resolver_thread(request_rx, shutdown_rx))
+        {
+            Ok(join) => ResolverLifecycle {
+                requests: Some(request_tx),
+                shutdown: Some(shutdown_tx),
+                join: Some(join),
+            },
+            Err(error) => {
+                warn!(%error, "spawn egress proxy host DNS resolver failed; domain resolution is unavailable");
+                ResolverLifecycle::default()
+            }
+        };
+
         Self {
-            // A failed thread spawn must not leave a queue with no consumer;
-            // resolve() then fails immediately instead of waiting for its
-            // response timeout on every request.
-            requests: Mutex::new(requests),
+            lifecycle: Mutex::new(lifecycle),
             stopped: AtomicBool::new(false),
-            joins: Mutex::new(joins),
         }
     }
 
@@ -105,11 +76,13 @@ impl HostNetResolver {
         if self.stopped.load(Ordering::Acquire) {
             return None;
         }
-        let (response_tx, response_rx) = mpsc::sync_channel(1);
+
+        let (response_tx, response_rx) = std_mpsc::sync_channel(1);
         let requests = self
-            .requests
+            .lifecycle
             .lock()
-            .expect("egress proxy resolver request lock poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .requests
             .as_ref()?
             .clone();
         requests
@@ -119,9 +92,12 @@ impl HostNetResolver {
                 response: response_tx,
             })
             .ok()?;
+
         let deadline = Instant::now() + RESOLVER_RESPONSE_TIMEOUT;
         loop {
-            if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+            if self.stopped.load(Ordering::Acquire)
+                || cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire))
+            {
                 return None;
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -130,32 +106,31 @@ impl HostNetResolver {
             }
             match response_rx.recv_timeout(remaining.min(RESOLVER_STOP_POLL)) {
                 Ok(resolved) => return resolved,
-                Err(mpsc::RecvTimeoutError::Timeout) => continue,
-                Err(mpsc::RecvTimeoutError::Disconnected) => return None,
+                Err(std_mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(std_mpsc::RecvTimeoutError::Disconnected) => return None,
             }
         }
     }
 
     pub(super) fn shutdown(&self) {
-        self.stopped.store(true, Ordering::Release);
-        let _ = self
-            .requests
-            .lock()
-            .expect("egress proxy resolver request lock poisoned")
-            .take();
-        let joins = std::mem::take(
-            &mut *self
-                .joins
+        if self.stopped.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let (shutdown, join) = {
+            let mut lifecycle = self
+                .lifecycle
                 .lock()
-                .expect("egress proxy resolver join lock poisoned"),
-        );
-        // A libc resolver call is not cancellable. Join workers that have
-        // already observed shutdown, but detach one that is still in DNS so
-        // network teardown cannot hang indefinitely.
-        for join in joins {
-            if join.is_finished() {
-                let _ = join.join();
-            }
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            lifecycle.requests.take();
+            (lifecycle.shutdown.take(), lifecycle.join.take())
+        };
+
+        if let Some(shutdown) = shutdown {
+            let _ = shutdown.send(());
+        }
+        if let Some(join) = join {
+            let _ = join.join();
         }
     }
 }
@@ -163,5 +138,137 @@ impl HostNetResolver {
 impl Drop for HostNetResolver {
     fn drop(&mut self) {
         self.shutdown();
+    }
+}
+
+fn run_resolver_thread(
+    mut requests: mpsc::Receiver<ResolveRequest>,
+    shutdown: oneshot::Receiver<()>,
+) {
+    if let Err(error) = setns(host_ns_fd(), CloneFlags::CLONE_NEWNET) {
+        warn!(%error, "egress proxy resolver could not enter host network namespace");
+        return;
+    }
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            warn!(%error, "build egress proxy DNS resolver runtime failed");
+            return;
+        }
+    };
+
+    let mut builder = match TokioResolver::builder(TokioRuntimeProvider::default()) {
+        Ok(builder) => builder,
+        Err(error) => {
+            warn!(%error, "read host DNS resolver configuration failed");
+            return;
+        }
+    };
+    let options: &mut ResolverOpts = builder.options_mut();
+    options.ip_strategy = LookupIpStrategy::Ipv4Only;
+    options.timeout = RESOLVER_DNS_TIMEOUT;
+    options.attempts = 1;
+    options.num_concurrent_reqs = 1;
+    options.max_active_requests = RESOLVER_MAX_IN_FLIGHT;
+    let resolver = match builder.build() {
+        Ok(resolver) => resolver,
+        Err(error) => {
+            warn!(%error, "build host DNS resolver failed");
+            return;
+        }
+    };
+
+    runtime.block_on(run_resolver(resolver, &mut requests, shutdown));
+}
+
+async fn run_resolver(
+    resolver: TokioResolver,
+    requests: &mut mpsc::Receiver<ResolveRequest>,
+    mut shutdown: oneshot::Receiver<()>,
+) {
+    let permits = std::sync::Arc::new(Semaphore::new(RESOLVER_MAX_IN_FLIGHT));
+    let mut tasks = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut shutdown => break,
+            request = requests.recv() => {
+                let Some(request) = request else { break };
+                let resolver = resolver.clone();
+                let permits = std::sync::Arc::clone(&permits);
+                tasks.spawn(async move {
+                    let Ok(_permit) = permits.acquire_owned().await else {
+                        return;
+                    };
+                    let resolved = resolver
+                        .lookup_ip(request.hostname.as_str())
+                        .await
+                        .ok()
+                        .map(|lookup| {
+                            lookup
+                            .iter()
+                                .filter_map(|ip| {
+                                    matches!(ip, IpAddr::V4(_))
+                                        .then_some(SocketAddr::new(ip, request.port))
+                                })
+                                .collect::<Vec<_>>()
+                        });
+                    let _ = request.response.send(resolved);
+                });
+            }
+            Some(result) = tasks.join_next(), if !tasks.is_empty() => {
+                if let Err(error) = result {
+                    debug!(%error, "egress proxy DNS lookup task failed");
+                }
+            }
+        }
+    }
+
+    tasks.abort_all();
+    while let Some(result) = tasks.join_next().await {
+        if let Err(error) = result {
+            debug!(%error, "egress proxy DNS lookup task stopped during shutdown");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn shutdown_is_idempotent_and_releases_waiters() {
+        let resolver = Arc::new(HostNetResolver::new());
+        let lookup_resolver = Arc::clone(&resolver);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(1);
+        let lookup = thread::spawn(move || {
+            let _ = result_tx.send(lookup_resolver.resolve("resolver-shutdown.invalid", 443, None));
+        });
+
+        resolver.shutdown();
+        resolver.shutdown();
+
+        assert!(result_rx.recv_timeout(Duration::from_secs(1)).is_ok());
+        lookup.join().unwrap();
+        assert!(resolver.resolve("example.com", 443, None).is_none());
+    }
+
+    #[test]
+    fn poisoned_lifecycle_lock_does_not_break_shutdown() {
+        let resolver = Arc::new(HostNetResolver::new());
+        let poisoned = Arc::clone(&resolver);
+        let _ = thread::spawn(move || {
+            let _guard = poisoned.lifecycle.lock().unwrap();
+            panic!("poison resolver lifecycle lock for test");
+        })
+        .join();
+
+        resolver.shutdown();
     }
 }

--- a/src/sandbox/network/slot.rs
+++ b/src/sandbox/network/slot.rs
@@ -4,7 +4,7 @@ use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::Duration;
 
@@ -23,6 +23,7 @@ use rtnetlink::packet_core::{
 use rtnetlink::{new_connection, Handle};
 use tracing::{debug, info, warn};
 
+use super::egress_proxy::EgressProxy;
 use super::iptables_util::{apply_iptables_commands, IptablesRestoreCommand, OpenFailurePolicy};
 use super::policy::{
     initialize_namespace_egress_chain, set_namespace_egress_policy, SandboxNetworkPolicy,
@@ -59,6 +60,7 @@ pub(crate) struct Slot {
     pub veth_vm_ip: Ipv4Addr,   // The IP on the VM/NS side interface (vpeer)
     address_plan: NetworkAddressPlan,
     netns_dir: PathBuf,
+    egress_proxy: Arc<EgressProxy>,
     cleanup_armed: AtomicBool,
     /// Whether this namespace's user egress chain currently contains rules.
     /// Warm-pool reuse preserves the namespace, so the next tenant may need to
@@ -85,6 +87,7 @@ impl Slot {
         idx: u32,
         address_plan: NetworkAddressPlan,
         netns_dir: PathBuf,
+        egress_proxy: Arc<EgressProxy>,
     ) -> Result<Self, NetworkError> {
         // Validation for zero and overflow.
         if idx == 0 || idx >= (MAX_SLOTS as u32) {
@@ -107,6 +110,7 @@ impl Slot {
             veth_vm_ip,
             address_plan,
             netns_dir,
+            egress_proxy,
             cleanup_armed: AtomicBool::new(false),
             user_egress_rules_present: AtomicBool::new(false),
         })
@@ -263,6 +267,7 @@ impl Slot {
         // IPTables Setup
         Self::configure_namespace_iptables_rules(
             host_interaction_ip,
+            veth_vm_ip,
             address_plan.vm_ip(),
             &address_plan.internal_egress_denied_cidrs(),
         )
@@ -453,12 +458,33 @@ impl Slot {
     }
 
     pub(crate) fn set_egress_policy(&self, policy: Option<&SandboxNetworkPolicy>) -> Result<()> {
+        // Policy updates run through the owning FirecrackerSandbox's mutable
+        // operation lock; cleanup owns this Slot exclusively. Avoid holding a
+        // second lock across namespace I/O, iptables, or proxy joins.
         let wants_rules = policy.is_some_and(SandboxNetworkPolicy::has_runtime_egress_rules);
         if !wants_rules && !self.user_egress_rules_present.load(Ordering::Acquire) {
             return Ok(());
         }
 
+        let requires_egress_proxy = policy.is_some_and(SandboxNetworkPolicy::requires_egress_proxy);
+        let had_active_proxy_policy = self.egress_proxy.has_active(self.host_interaction_ip);
+        if requires_egress_proxy {
+            self.egress_proxy
+                .ensure_listener(self.host_interaction_ip, &self.namespace_path())?;
+            self.egress_proxy.prepare(
+                self.host_interaction_ip,
+                policy.expect("proxy policy must be present when interception is requested"),
+            );
+            // There was no old proxy policy to preserve. Activating before the
+            // redirect is installed keeps the old default-allow behavior while
+            // the namespace rules are being committed.
+            if !had_active_proxy_policy {
+                self.egress_proxy.activate(self.host_interaction_ip);
+            }
+        }
+
         let netns_path = self.namespace_path();
+        let egress_proxy_port = self.egress_proxy.port();
         let policy = policy.cloned();
         let handle = thread::spawn(move || -> Result<()> {
             let netns = File::open(&netns_path).with_context(|| {
@@ -466,7 +492,7 @@ impl Slot {
             })?;
             nix::sched::setns(netns.as_fd(), CloneFlags::CLONE_NEWNET)
                 .context("failed to enter sandbox network namespace")?;
-            set_namespace_egress_policy(policy.as_ref())
+            set_namespace_egress_policy(policy.as_ref(), egress_proxy_port)
         });
 
         let result = match handle.join() {
@@ -476,6 +502,17 @@ impl Slot {
         if result.is_ok() {
             self.user_egress_rules_present
                 .store(wants_rules, Ordering::Release);
+            if requires_egress_proxy && had_active_proxy_policy {
+                self.egress_proxy.activate(self.host_interaction_ip);
+            } else if !requires_egress_proxy {
+                self.egress_proxy.deactivate(self.host_interaction_ip);
+            }
+        } else if requires_egress_proxy {
+            if had_active_proxy_policy {
+                self.egress_proxy.discard_pending(self.host_interaction_ip);
+            } else {
+                self.egress_proxy.teardown(self.host_interaction_ip);
+            }
         }
         result
     }
@@ -488,6 +525,7 @@ impl Slot {
     #[tracing::instrument(fields(vm_ip = %vm_ip, host_interaction_ip = %host_interaction_ip))]
     fn configure_namespace_iptables_rules(
         host_interaction_ip: Ipv4Addr,
+        veth_vm_ip: Ipv4Addr,
         vm_ip: Ipv4Addr,
         internal_egress_denied_cidrs: &[String],
     ) -> Result<()> {
@@ -511,6 +549,14 @@ impl Slot {
                 table: "nat",
                 chain: "POSTROUTING",
                 rule: format!("-o vpeer -s {} -j SNAT --to {}", vm_ip, host_interaction_ip),
+            },
+            // Namespace-local egress proxy connections originate from vpeer's
+            // address rather than the guest address above. Give them the same
+            // routable slot identity so host FORWARD/MASQUERADE rules apply.
+            IptablesRestoreCommand::Append {
+                table: "nat",
+                chain: "POSTROUTING",
+                rule: format!("-o vpeer -s {veth_vm_ip} -j SNAT --to {host_interaction_ip}"),
             },
             // DNAT: Rewrite destination IP from the host interaction IP to the VM.
             // This allows the host to reach the VM using the unique HostIP.
@@ -792,6 +838,11 @@ impl Slot {
             return Ok(());
         }
 
+        // A namespace-local listener pins the namespace. Stop proxy acceptance
+        // before removing the veth and unmounting the namespace, including
+        // panic/drop cleanup paths that bypass the normal release path.
+        self.egress_proxy.teardown(self.host_interaction_ip);
+
         // 1. Delete Host Veth Interface (this destroys the pair)
         let delete_result = if force_sync {
             Self::delete_host_veth_interface_sync(self.idx)
@@ -935,6 +986,7 @@ mod tests {
             idx,
             address_plan,
             std::env::temp_dir().join("aenv-network-tests/netns"),
+            EgressProxy::new(),
         )
     }
 

--- a/src/sandbox/network/slot.rs
+++ b/src/sandbox/network/slot.rs
@@ -3,7 +3,6 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::Duration;
@@ -61,11 +60,11 @@ pub(crate) struct Slot {
     address_plan: NetworkAddressPlan,
     netns_dir: PathBuf,
     egress_proxy: Arc<EgressProxy>,
-    cleanup_armed: AtomicBool,
+    cleanup_armed: bool,
     /// Whether this namespace's user egress chain currently contains rules.
     /// Warm-pool reuse preserves the namespace, so the next tenant may need to
     /// clear rules left by the previous tenant.
-    user_egress_rules_present: AtomicBool,
+    user_egress_rules_present: bool,
 }
 
 struct NamespaceSetup {
@@ -111,8 +110,8 @@ impl Slot {
             address_plan,
             netns_dir,
             egress_proxy,
-            cleanup_armed: AtomicBool::new(false),
-            user_egress_rules_present: AtomicBool::new(false),
+            cleanup_armed: false,
+            user_egress_rules_present: false,
         })
     }
 
@@ -127,10 +126,10 @@ impl Slot {
             host_interaction_ip = %self.host_interaction_ip
         )
     )]
-    pub(super) fn create_network(&self) -> Result<(), NetworkError> {
+    pub(super) fn create_network(&mut self) -> Result<(), NetworkError> {
         // Arm drop cleanup as soon as we begin touching kernel networking state.
         // If setup fails midway, Drop can still perform best-effort cleanup.
-        self.cleanup_armed.store(true, Ordering::Release);
+        self.cleanup_armed = true;
 
         // Capture individual fields rather than cloning `self`. Slot is not Clone
         // intentionally — a clone would carry Drop semantics and tear down the live
@@ -457,12 +456,15 @@ impl Slot {
         self.netns_dir.join(&self.namespace_id)
     }
 
-    pub(crate) fn set_egress_policy(&self, policy: Option<&SandboxNetworkPolicy>) -> Result<()> {
+    pub(crate) fn set_egress_policy(
+        &mut self,
+        policy: Option<&SandboxNetworkPolicy>,
+    ) -> Result<()> {
         // Policy updates run through the owning FirecrackerSandbox's mutable
         // operation lock; cleanup owns this Slot exclusively. Avoid holding a
         // second lock across namespace I/O, iptables, or proxy joins.
         let wants_rules = policy.is_some_and(SandboxNetworkPolicy::has_runtime_egress_rules);
-        if !wants_rules && !self.user_egress_rules_present.load(Ordering::Acquire) {
+        if !wants_rules && !self.user_egress_rules_present {
             return Ok(());
         }
 
@@ -500,8 +502,7 @@ impl Slot {
             Err(e) => Err(anyhow!("egress policy setup thread panicked: {:?}", e)),
         };
         if result.is_ok() {
-            self.user_egress_rules_present
-                .store(wants_rules, Ordering::Release);
+            self.user_egress_rules_present = wants_rules;
             if requires_egress_proxy && had_active_proxy_policy {
                 self.egress_proxy.activate(self.host_interaction_ip);
             } else if !requires_egress_proxy {
@@ -831,12 +832,13 @@ impl Slot {
             force_sync
         )
     )]
-    pub(super) fn cleanup(&self, force_sync: bool) -> Result<(), NetworkError> {
+    pub(super) fn cleanup(&mut self, force_sync: bool) -> Result<(), NetworkError> {
         // Skip cleanup for slots that never attempted network setup.
         // This avoids touching host networking state for logical-only Slot values.
-        if !self.cleanup_armed.swap(false, Ordering::AcqRel) {
+        if !self.cleanup_armed {
             return Ok(());
         }
+        self.cleanup_armed = false;
 
         // A namespace-local listener pins the namespace. Stop proxy acceptance
         // before removing the veth and unmounting the namespace, including
@@ -850,7 +852,7 @@ impl Slot {
             Self::delete_host_veth_interface(self.idx)
         };
         if let Err(e) = delete_result {
-            self.cleanup_armed.store(true, Ordering::Release);
+            self.cleanup_armed = true;
             return Err(NetworkError::NamespaceError(e));
         }
 
@@ -864,7 +866,7 @@ impl Slot {
                     Err(nix::errno::Errno::EINVAL) => break, // Not mounted anymore
                     Err(nix::errno::Errno::ENOENT) => break, // File removed by another process
                     Err(e) => {
-                        self.cleanup_armed.store(true, Ordering::Release);
+                        self.cleanup_armed = true;
                         return Err(NetworkError::NamespaceError(anyhow!(
                             "Failed to unmount netns: {}",
                             e
@@ -878,7 +880,7 @@ impl Slot {
                 Ok(_) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => {
-                    self.cleanup_armed.store(true, Ordering::Release);
+                    self.cleanup_armed = true;
                     return Err(NetworkError::IoError(e));
                 }
             }
@@ -1123,29 +1125,28 @@ mod tests {
 
     #[test]
     fn empty_egress_policy_skips_known_clean_slot() {
-        let slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
+        let mut slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
         let empty_policy = SandboxNetworkPolicy::default();
 
         slot.set_egress_policy(None).unwrap();
         slot.set_egress_policy(Some(&empty_policy)).unwrap();
 
-        assert!(!slot.user_egress_rules_present.load(Ordering::Acquire));
+        assert!(!slot.user_egress_rules_present);
     }
 
     #[test]
     fn failed_egress_cleanup_keeps_slot_marked_dirty() {
-        let slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
-        slot.user_egress_rules_present
-            .store(true, Ordering::Release);
+        let mut slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
+        slot.user_egress_rules_present = true;
 
         assert!(slot.set_egress_policy(None).is_err());
 
-        assert!(slot.user_egress_rules_present.load(Ordering::Acquire));
+        assert!(slot.user_egress_rules_present);
     }
 
     #[test]
     fn failed_egress_apply_keeps_clean_slot_marked_clean() {
-        let slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
+        let mut slot = test_slot(1, NetworkAddressPlan::default()).unwrap();
         let policy = SandboxNetworkPolicy::new(
             true,
             crate::sandbox::network::BaseSandboxNetworkPolicy::Deny,
@@ -1154,7 +1155,7 @@ mod tests {
 
         assert!(slot.set_egress_policy(Some(&policy)).is_err());
 
-        assert!(!slot.user_egress_rules_present.load(Ordering::Acquire));
+        assert!(!slot.user_egress_rules_present);
     }
 
     #[test]
@@ -1164,7 +1165,7 @@ mod tests {
 
         // Use a free high slot ID to avoid collisions with dev/prod and stale
         // devices from interrupted test runs.
-        let slot = unused_test_slot();
+        let mut slot = unused_test_slot();
 
         // 1. Create Network
         // This requires CAP_NET_ADMIN and CAP_SYS_ADMIN.

--- a/tests/integration/fc.rs
+++ b/tests/integration/fc.rs
@@ -497,6 +497,41 @@ async fn assert_tcp_connect(
     Ok(())
 }
 
+async fn assert_curl(
+    sandbox: &mut FirecrackerSandbox,
+    url: &str,
+    should_succeed: bool,
+) -> Result<()> {
+    let output = sandbox
+        .run_command(
+            "curl",
+            &[
+                "--noproxy",
+                "*",
+                "-4",
+                "-sS",
+                "--connect-timeout",
+                "5",
+                "--max-time",
+                "10",
+                "-o",
+                "/dev/null",
+                "--",
+                url,
+            ],
+        )
+        .await?;
+    assert_eq!(
+        output.exit_code == 0,
+        should_succeed,
+        "curl expectation failed for {url}; exit={}, stdout={}, stderr={}",
+        output.exit_code,
+        output.stdout,
+        output.stderr
+    );
+    Ok(())
+}
+
 async fn test_network(sandbox: &mut FirecrackerSandbox, after_resume: bool) -> Result<()> {
     let checks = [("tcp_ip", "8.8.8.8/53"), ("tcp_dns", "www.baidu.com/443")];
 
@@ -587,6 +622,39 @@ async fn microvm_network_policy_controls_egress() -> Result<()> {
         )))
         .await?;
     assert_tcp_connect(&mut sandbox, "10.255.255.254/80", false).await?;
+
+    sandbox
+        .update_network_policy(Some(SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Default,
+            SandboxNetworkEgressPolicy::new(
+                Some(vec!["www.baidu.com".to_string()]),
+                Some(vec!["0.0.0.0/0".to_string()]),
+            )?,
+        )))
+        .await?;
+
+    assert_curl(&mut sandbox, "http://www.baidu.com/", true).await?;
+    assert_curl(&mut sandbox, "https://www.baidu.com/", true).await?;
+    assert_curl(&mut sandbox, "https://www.qq.com/", false).await?;
+
+    sandbox
+        .update_network_policy(Some(SandboxNetworkPolicy::new(
+            true,
+            BaseSandboxNetworkPolicy::Default,
+            SandboxNetworkEgressPolicy::new(
+                Some(vec!["www.qq.com".to_string()]),
+                Some(vec!["0.0.0.0/0".to_string()]),
+            )?,
+        )))
+        .await?;
+
+    assert_curl(&mut sandbox, "https://www.baidu.com/", false).await?;
+    assert_curl(&mut sandbox, "https://www.qq.com/", true).await?;
+
+    sandbox.update_network_policy(None).await?;
+    assert_curl(&mut sandbox, "https://www.baidu.com/", true).await?;
+    assert_curl(&mut sandbox, "https://www.qq.com/", true).await?;
 
     sandbox.stop().await?;
     Ok(())


### PR DESCRIPTION
## What

Add E2B-compatible domain-based egress control for sandbox network policies. Domain entries in `allowOut` are now enforced for new HTTP/HTTPS connections through a namespace-local transparent proxy, with trusted host-side DNS resolution and lifecycle cleanup.

## Why

CIDR-only rules cannot express the common requirement of allowing a sandbox to reach a named service while denying all other internet destinations. This change makes domain allowlists usable while preserving existing CIDR behavior, policy replacement semantics, and warm-pool reuse.

## Related issue

No linked issue; this PR follows the existing E2B-compatible network-policy contract.

## Scope and non-goals

Included:

- Domain matching for exact names, `*.example.com`, and `*` patterns.
- Transparent interception on TCP ports 80 and 443, Host/SNI inspection, and host-network-namespace DNS resolution.
- Explicit validation that domain allowlists include `denyOut: ["0.0.0.0/0"]`.
- Atomic/staged policy replacement, connection tracking, teardown, and warm-pool cleanup.
- API behavior updates, architecture/networking documentation, and focused unit/integration coverage.

Excluded:

- Domain inspection on non-HTTP/HTTPS TCP ports.
- TLS termination, HTTP rewriting, or a new user-facing configuration knob.
- Changes to unrelated sandbox lifecycle or storage behavior.

## Design and behavior changes

`NetworkManager` owns a process-wide `EgressProxy` registry. Each namespace that needs proxy mediation gets its own listener on the fixed namespace-local port `15000`; the listener is not exposed as a host port. Namespace NAT redirects only TCP/80 and TCP/443. The proxy recovers the original destination, parses HTTP Host or TLS SNI, resolves candidates in a long-lived host-netns resolver, applies absolute-deny and domain policy checks, then relays the connection without terminating TLS.

Policy updates stage the new proxy policy and commit filter/NAT rules as one namespace update. Existing connections retain the policy selected when accepted; tracked sockets are closed during proxy/slot teardown so namespace resources can be safely released and reused.

## Compatibility and operations

- Public API or generated protocol: Existing `allowOut`/`denyOut` fields are extended to accept domain patterns; no generated protocol changes.
- Configuration or defaults: No new configuration; existing network address and deny settings remain authoritative.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: Nodes can be upgraded or rolled back with the existing network-policy API contract; policies without domain entries retain the prior path.
- Host requirements, permissions, ports, or dependencies: Uses the existing Linux network namespace, iptables, and socket capabilities. Port `15000` is bound only inside each sandbox namespace.

## Validation

- [x] `make fmt` (already run by the author)
- [x] `make clippy` (already run by the author)
- [x] `make test-unit` (already run by the author)
- [x] Relevant Rust integration tests (already run by the author)
- [ ] `make -C services test` (not applicable; `services/` is unchanged)
- [ ] Generated clients/server regenerated with the documented `make` target (not applicable; generated API code is unchanged)
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed (not applicable)

Commands and results:

```text
The author already ran the applicable formatting, lint, unit-test, and integration-test checks before requesting this PR. They are intentionally not repeated here.
```

Skipped checks and reasons:

```text
Services tests, code generation, and benchmarks were skipped because this change does not modify services, generated clients/server code, or benchmark targets.
```

## Risks and reviewer notes

- Review packet ordering and conntrack behavior in `src/sandbox/network/policy.rs` and `src/sandbox/network/egress_proxy.rs`; domain interception is intentionally limited to TCP/80 and TCP/443.
- Host-side DNS resolution is a security boundary: guest DNS answers and original destination IPs are not trusted for domain rules, and platform/internal deny ranges remain non-overridable.
- Proxy lifecycle and policy replacement are shared with warm-pool slot reuse; teardown closes tracked handlers before namespace resources are removed.
- The implementation adds a small bounded per-connection handler pool and resolver worker; long-lived established streams are not given an idle timeout.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
