### PR TITLE
chore: bump Firecracker KVM dependency to 1.16.1-patch-v1

### DIFF
--- a/config/deps_manifest.toml
+++ b/config/deps_manifest.toml
@@ -1,6 +1,6 @@
 [firecracker.kvm]
-version = "1.15.1-patch-v1"
-url = "https://github.com/kvcache-ai/firecracker/releases/download/aenv-deps/firecracker-{version}-{arch}.tgz"
+version = "1.16.1-patch-v1"
+url = "https://github.com/kvcache-ai/firecracker/releases/download/v{version}/firecracker-{version}-{arch}.tgz"
 
 [firecracker.pvm]
 version = "v1.17.0-next.1"


### PR DESCRIPTION
## What
- Bump the managed KVM Firecracker runtime from `1.15.1-patch-v1` to `1.16.1-patch-v1`.
- Resolve its published archives from the versioned `v{version}` release tag.

## Why
The new Firecracker release is published under `v1.16.1-patch-v1`, rather than the legacy `aenv-deps` aggregate release tag.

## Related issue
N/A — dependency-only upgrade.

## Scope and non-goals
This PR contains only the dependency manifest update. It intentionally excludes idle-page tracking, KVM pre-fault integration, Swagger changes, and generated-client changes.

## Compatibility and operations
- Public API or generated protocol: N/A; no API/client changes.
- Configuration or defaults: the default managed KVM Firecracker binary changes to `1.16.1-patch-v1`.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: deployment downloads the newly selected artifact; reverting this commit restores the previous `1.15.1-patch-v1` selection.
- Host requirements, permissions, ports, or dependencies: N/A.

## Validation
- [x] `server --setup-only` with isolated home/deps paths; resolved `Firecracker v1.16.1-patch-v1`.
- [x] `scripts/run-with-capabilities.sh ... cargo test -p agentenv --test integration fc::microvm_lifecycle_and_snapshot_preserve_disk_state -- --exact --nocapture`
- [x] `cargo test -p agentenv setup::deps::tests --lib`
- [x] `cargo fmt --check`

## Risks and reviewer notes
The release URL changes because this version is published under its own versioned release tag. The PR is otherwise limited to one manifest entry.

## Checklist
- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] Validation covers isolated dependency provisioning and a create/pause/resume/restore smoke test.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] No generated code was edited.