### PR TITLE
feat: enable virtio-mem for firecracker

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -49,6 +49,17 @@ socket_poll_ms = 1
 # levels are Error, Warning, Info, Debug, and Trace; unset disables it.
 # log_level = "Info"
 
+# Firecracker virtio-mem hard elasticity. Disabled keeps the existing fixed
+# memory behavior and does not create a hotplug device.
+[firecracker.memory_hotplug]
+# enabled = false
+# total_size_mib = 0
+# slot_size_mib = 128
+# block_size_mib = 2
+# requested_size_mib = 0
+# resize_timeout_secs = 30
+# resize_poll_interval_ms = 50
+
 [kernel]
 # Use an existing uncompressed Linux kernel image instead of downloading one.
 # The file must be a readable, non-empty regular file.

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -49,6 +49,40 @@ Firecracker VM binary and boot configuration.
 | `serial_dir` | string | `"$AENV_HOME/logs/serial"` | Directory for persistent Firecracker serial output (per-sandbox subdirectories) |
 | `log_level` | string | unset (disabled) | Optional Firecracker log level (`Error`, `Warning`, `Info`, `Debug`, `Trace`, case-insensitive). When set to a non-empty value, Firecracker's own logging is enabled and written to a `firecracker.log` file in each sandbox's log directory (alongside the serial output). Empty/unset disables it |
 
+### `[firecracker.memory_hotplug]`
+
+Optional Firecracker virtio-mem hard elasticity. It is disabled by default, so
+existing VMs retain fixed memory. When enabled, AgentENV creates the device only
+on a fresh pre-boot path; snapshot resume restores it from `vm_state.bin` and
+validates it with `GET /hotplug/memory` without issuing another PUT.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Create and manage a virtio-mem device |
+| `total_size_mib` | integer | `0` | Maximum hotpluggable region; must be positive and slot-aligned |
+| `slot_size_mib` | integer | `128` | Slot size; at least 128 MiB and block-aligned |
+| `block_size_mib` | integer | `2` | Logical block size; at least 2 MiB |
+| `requested_size_mib` | integer | `0` | Initial requested size; block-aligned and no greater than total |
+| `resize_timeout_secs` | integer | `30` | Deadline for exact requested/plugged convergence |
+| `resize_poll_interval_ms` | integer | `50` | Firecracker status polling interval |
+
+Enabled VMs require `memhp_default_state=online_movable`. AgentENV appends it
+after all cold-start extension arguments are merged when absent, preserves the
+same explicit value, and rejects a conflicting value. Resize timeout or partial
+convergence is an error; requested memory is not treated as reclaimed until
+Firecracker reports `plugged_size_mib == requested_size_mib`.
+
+For a fresh sandbox, `memoryMB` is the total requested/billable memory rather
+than the Firecracker boot-memory field. AgentENV configures immutable boot
+memory as `memoryMB - requested_size_mib`. The runtime endpoint
+`PATCH /sandboxes/{sandboxID}/memory` accepts
+`requestedHotplugMemoryMB`; its response reports requested, plugged,
+total/slot/block, boot and effective memory. Expansion is accounted before the
+Firecracker request. Shrink accounting is released only after exact
+convergence. A timed-out target is rolled back and verified; if rollback also
+stalls, the sandbox remains in a resize transition and can only be inspected or
+deleted, not snapshotted.
+
 ## `[kernel]`
 
 Linux kernel image for microVMs.

--- a/src/api/generated/src/apis/sandboxes.rs
+++ b/src/api/generated/src/apis/sandboxes.rs
@@ -161,6 +161,46 @@ pub enum SandboxesSandboxIdGetResponse {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 #[allow(clippy::large_enum_variant)]
+pub enum SandboxesSandboxIdMemoryGetResponse {
+    /// Memory hotplug status
+    Status200_MemoryHotplugStatus(models::SandboxMemoryHotplugStatus),
+    /// Not found
+    Status404_NotFound(models::Error),
+    /// Authentication error
+    Status401_AuthenticationError(models::Error),
+    /// Conflict
+    Status409_Conflict(models::Error),
+    /// Unprocessable entity
+    Status422_UnprocessableEntity(models::Error),
+    /// Server error
+    Status500_ServerError(models::Error),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+#[allow(clippy::large_enum_variant)]
+pub enum SandboxesSandboxIdMemoryPatchResponse {
+    /// Memory resize converged
+    Status200_MemoryResizeConverged(models::SandboxMemoryHotplugStatus),
+    /// Bad request
+    Status400_BadRequest(models::Error),
+    /// Not found
+    Status404_NotFound(models::Error),
+    /// Authentication error
+    Status401_AuthenticationError(models::Error),
+    /// Conflict
+    Status409_Conflict(models::Error),
+    /// Unprocessable entity
+    Status422_UnprocessableEntity(models::Error),
+    /// Gateway timeout
+    Status504_GatewayTimeout(models::SandboxMemoryHotplugStatus),
+    /// Server error
+    Status500_ServerError(models::Error),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+#[allow(clippy::large_enum_variant)]
 pub enum SandboxesSandboxIdNetworkPutResponse {
     /// Successfully updated the sandbox network configuration
     Status204_SuccessfullyUpdatedTheSandboxNetworkConfiguration,
@@ -393,6 +433,33 @@ pub trait Sandboxes<E: std::fmt::Debug + Send + Sync + 'static = ()>:
         claims: &Self::Claims,
         path_params: &models::SandboxesSandboxIdGetPathParams,
     ) -> Result<SandboxesSandboxIdGetResponse, E>;
+
+    /// Get sandbox virtio-mem status.
+    ///
+    /// SandboxesSandboxIdMemoryGet - GET /sandboxes/{sandboxID}/memory
+    async fn sandboxes_sandbox_id_memory_get(
+        &self,
+
+        method: &Method,
+        host: &Host,
+        cookies: &CookieJar,
+        claims: &Self::Claims,
+        path_params: &models::SandboxesSandboxIdMemoryGetPathParams,
+    ) -> Result<SandboxesSandboxIdMemoryGetResponse, E>;
+
+    /// Resize sandbox virtio-mem memory.
+    ///
+    /// SandboxesSandboxIdMemoryPatch - PATCH /sandboxes/{sandboxID}/memory
+    async fn sandboxes_sandbox_id_memory_patch(
+        &self,
+
+        method: &Method,
+        host: &Host,
+        cookies: &CookieJar,
+        claims: &Self::Claims,
+        path_params: &models::SandboxesSandboxIdMemoryPatchPathParams,
+        body: &models::SandboxMemoryHotplugResize,
+    ) -> Result<SandboxesSandboxIdMemoryPatchResponse, E>;
 
     /// Update sandbox network.
     ///

--- a/src/api/generated/src/models.rs
+++ b/src/api/generated/src/models.rs
@@ -139,6 +139,18 @@ pub struct SandboxesSandboxIdGetPathParams {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SandboxesSandboxIdMemoryGetPathParams {
+    pub sandbox_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SandboxesSandboxIdMemoryPatchPathParams {
+    pub sandbox_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct SandboxesSandboxIdNetworkPutPathParams {
     pub sandbox_id: String,
 }
@@ -5738,6 +5750,522 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<SandboxLifec
                     }
                     std::result::Result::Err(err) => std::result::Result::Err(format!(
                         r#"Unable to convert header value '{value}' into SandboxLifecycle - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SandboxMemoryHotplugResize {
+    /// Target requested size of the virtio-mem region in MiB.
+    #[serde(rename = "requestedHotplugMemoryMB")]
+    #[validate(range(min = 0u32))]
+    pub requested_hotplug_memory_mb: u32,
+}
+
+impl SandboxMemoryHotplugResize {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(requested_hotplug_memory_mb: u32) -> SandboxMemoryHotplugResize {
+        SandboxMemoryHotplugResize {
+            requested_hotplug_memory_mb,
+        }
+    }
+}
+
+/// Converts the SandboxMemoryHotplugResize value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for SandboxMemoryHotplugResize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("requestedHotplugMemoryMB".to_string()),
+            Some(self.requested_hotplug_memory_mb.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a SandboxMemoryHotplugResize value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for SandboxMemoryHotplugResize {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub requested_hotplug_memory_mb: Vec<u32>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing SandboxMemoryHotplugResize".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "requestedHotplugMemoryMB" => {
+                        intermediate_rep.requested_hotplug_memory_mb.push(
+                            <u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                        )
+                    }
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing SandboxMemoryHotplugResize".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(SandboxMemoryHotplugResize {
+            requested_hotplug_memory_mb: intermediate_rep
+                .requested_hotplug_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "requestedHotplugMemoryMB missing in SandboxMemoryHotplugResize".to_string()
+                })?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<SandboxMemoryHotplugResize> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<SandboxMemoryHotplugResize>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<SandboxMemoryHotplugResize>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for SandboxMemoryHotplugResize - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<SandboxMemoryHotplugResize> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <SandboxMemoryHotplugResize as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into SandboxMemoryHotplugResize - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SandboxMemoryHotplugStatus {
+    #[serde(rename = "previousRequestedHotplugMemoryMB")]
+    #[validate(range(min = 0u32))]
+    pub previous_requested_hotplug_memory_mb: u32,
+
+    /// Target requested by the current or most recent resize operation.
+    #[serde(rename = "targetHotplugMemoryMB")]
+    #[validate(range(min = 0u32))]
+    pub target_hotplug_memory_mb: u32,
+
+    #[serde(rename = "requestedHotplugMemoryMB")]
+    #[validate(range(min = 0u32))]
+    pub requested_hotplug_memory_mb: u32,
+
+    #[serde(rename = "pluggedHotplugMemoryMB")]
+    #[validate(range(min = 0u32))]
+    pub plugged_hotplug_memory_mb: u32,
+
+    #[serde(rename = "totalHotplugMemoryMB")]
+    #[validate(range(min = 0u32))]
+    pub total_hotplug_memory_mb: u32,
+
+    #[serde(rename = "slotSizeMB")]
+    #[validate(range(min = 1u32))]
+    pub slot_size_mb: u32,
+
+    #[serde(rename = "blockSizeMB")]
+    #[validate(range(min = 1u32))]
+    pub block_size_mb: u32,
+
+    /// Immutable memory configured in the Firecracker machine.
+    #[serde(rename = "bootMemoryMB")]
+    #[validate(range(min = 128u32))]
+    pub boot_memory_mb: u32,
+
+    /// Guest memory currently effective, equal to boot plus plugged memory.
+    #[serde(rename = "effectiveMemoryMB")]
+    #[validate(range(min = 128u32))]
+    pub effective_memory_mb: u32,
+
+    /// Host scheduling grant retained for this sandbox.
+    #[serde(rename = "accountedMemoryMB")]
+    #[validate(range(min = 128u32))]
+    pub accounted_memory_mb: u32,
+
+    #[serde(rename = "elapsedMs")]
+    #[validate(range(min = 0u64))]
+    pub elapsed_ms: u64,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "status")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub status: String,
+
+    #[serde(rename = "rollbackTargetHotplugMemoryMB")]
+    #[validate(range(min = 0u32))]
+    #[serde(deserialize_with = "deserialize_optional_nullable")]
+    #[serde(default = "default_optional_nullable")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rollback_target_hotplug_memory_mb: Option<Nullable<u32>>,
+
+    #[serde(rename = "reason")]
+    #[serde(deserialize_with = "deserialize_optional_nullable")]
+    #[serde(default = "default_optional_nullable")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<Nullable<String>>,
+}
+
+impl SandboxMemoryHotplugStatus {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(
+        previous_requested_hotplug_memory_mb: u32,
+        target_hotplug_memory_mb: u32,
+        requested_hotplug_memory_mb: u32,
+        plugged_hotplug_memory_mb: u32,
+        total_hotplug_memory_mb: u32,
+        slot_size_mb: u32,
+        block_size_mb: u32,
+        boot_memory_mb: u32,
+        effective_memory_mb: u32,
+        accounted_memory_mb: u32,
+        elapsed_ms: u64,
+        status: String,
+    ) -> SandboxMemoryHotplugStatus {
+        SandboxMemoryHotplugStatus {
+            previous_requested_hotplug_memory_mb,
+            target_hotplug_memory_mb,
+            requested_hotplug_memory_mb,
+            plugged_hotplug_memory_mb,
+            total_hotplug_memory_mb,
+            slot_size_mb,
+            block_size_mb,
+            boot_memory_mb,
+            effective_memory_mb,
+            accounted_memory_mb,
+            elapsed_ms,
+            status,
+            rollback_target_hotplug_memory_mb: None,
+            reason: None,
+        }
+    }
+}
+
+/// Converts the SandboxMemoryHotplugStatus value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for SandboxMemoryHotplugStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("previousRequestedHotplugMemoryMB".to_string()),
+            Some(self.previous_requested_hotplug_memory_mb.to_string()),
+            Some("targetHotplugMemoryMB".to_string()),
+            Some(self.target_hotplug_memory_mb.to_string()),
+            Some("requestedHotplugMemoryMB".to_string()),
+            Some(self.requested_hotplug_memory_mb.to_string()),
+            Some("pluggedHotplugMemoryMB".to_string()),
+            Some(self.plugged_hotplug_memory_mb.to_string()),
+            Some("totalHotplugMemoryMB".to_string()),
+            Some(self.total_hotplug_memory_mb.to_string()),
+            Some("slotSizeMB".to_string()),
+            Some(self.slot_size_mb.to_string()),
+            Some("blockSizeMB".to_string()),
+            Some(self.block_size_mb.to_string()),
+            Some("bootMemoryMB".to_string()),
+            Some(self.boot_memory_mb.to_string()),
+            Some("effectiveMemoryMB".to_string()),
+            Some(self.effective_memory_mb.to_string()),
+            Some("accountedMemoryMB".to_string()),
+            Some(self.accounted_memory_mb.to_string()),
+            Some("elapsedMs".to_string()),
+            Some(self.elapsed_ms.to_string()),
+            Some("status".to_string()),
+            Some(self.status.to_string()),
+            self.rollback_target_hotplug_memory_mb.as_ref().map(
+                |rollback_target_hotplug_memory_mb| {
+                    [
+                        "rollbackTargetHotplugMemoryMB".to_string(),
+                        rollback_target_hotplug_memory_mb
+                            .as_ref()
+                            .map_or("null".to_string(), |x| x.to_string()),
+                    ]
+                    .join(",")
+                },
+            ),
+            self.reason.as_ref().map(|reason| {
+                [
+                    "reason".to_string(),
+                    reason
+                        .as_ref()
+                        .map_or("null".to_string(), |x| x.to_string()),
+                ]
+                .join(",")
+            }),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a SandboxMemoryHotplugStatus value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for SandboxMemoryHotplugStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub previous_requested_hotplug_memory_mb: Vec<u32>,
+            pub target_hotplug_memory_mb: Vec<u32>,
+            pub requested_hotplug_memory_mb: Vec<u32>,
+            pub plugged_hotplug_memory_mb: Vec<u32>,
+            pub total_hotplug_memory_mb: Vec<u32>,
+            pub slot_size_mb: Vec<u32>,
+            pub block_size_mb: Vec<u32>,
+            pub boot_memory_mb: Vec<u32>,
+            pub effective_memory_mb: Vec<u32>,
+            pub accounted_memory_mb: Vec<u32>,
+            pub elapsed_ms: Vec<u64>,
+            pub status: Vec<String>,
+            pub rollback_target_hotplug_memory_mb: Vec<u32>,
+            pub reason: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing SandboxMemoryHotplugStatus".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "previousRequestedHotplugMemoryMB" => intermediate_rep.previous_requested_hotplug_memory_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "targetHotplugMemoryMB" => intermediate_rep.target_hotplug_memory_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "requestedHotplugMemoryMB" => intermediate_rep.requested_hotplug_memory_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "pluggedHotplugMemoryMB" => intermediate_rep.plugged_hotplug_memory_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "totalHotplugMemoryMB" => intermediate_rep.total_hotplug_memory_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "slotSizeMB" => intermediate_rep.slot_size_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "blockSizeMB" => intermediate_rep.block_size_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "bootMemoryMB" => intermediate_rep.boot_memory_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "effectiveMemoryMB" => intermediate_rep.effective_memory_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "accountedMemoryMB" => intermediate_rep.accounted_memory_mb.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "elapsedMs" => intermediate_rep.elapsed_ms.push(<u64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "status" => intermediate_rep.status.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "rollbackTargetHotplugMemoryMB" => return std::result::Result::Err("Parsing a nullable type in this style is not supported in SandboxMemoryHotplugStatus".to_string()),
+                    "reason" => return std::result::Result::Err("Parsing a nullable type in this style is not supported in SandboxMemoryHotplugStatus".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing SandboxMemoryHotplugStatus".to_string())
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(SandboxMemoryHotplugStatus {
+            previous_requested_hotplug_memory_mb: intermediate_rep
+                .previous_requested_hotplug_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "previousRequestedHotplugMemoryMB missing in SandboxMemoryHotplugStatus"
+                        .to_string()
+                })?,
+            target_hotplug_memory_mb: intermediate_rep
+                .target_hotplug_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "targetHotplugMemoryMB missing in SandboxMemoryHotplugStatus".to_string()
+                })?,
+            requested_hotplug_memory_mb: intermediate_rep
+                .requested_hotplug_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "requestedHotplugMemoryMB missing in SandboxMemoryHotplugStatus".to_string()
+                })?,
+            plugged_hotplug_memory_mb: intermediate_rep
+                .plugged_hotplug_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "pluggedHotplugMemoryMB missing in SandboxMemoryHotplugStatus".to_string()
+                })?,
+            total_hotplug_memory_mb: intermediate_rep
+                .total_hotplug_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "totalHotplugMemoryMB missing in SandboxMemoryHotplugStatus".to_string()
+                })?,
+            slot_size_mb: intermediate_rep
+                .slot_size_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| "slotSizeMB missing in SandboxMemoryHotplugStatus".to_string())?,
+            block_size_mb: intermediate_rep
+                .block_size_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| "blockSizeMB missing in SandboxMemoryHotplugStatus".to_string())?,
+            boot_memory_mb: intermediate_rep
+                .boot_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| "bootMemoryMB missing in SandboxMemoryHotplugStatus".to_string())?,
+            effective_memory_mb: intermediate_rep
+                .effective_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "effectiveMemoryMB missing in SandboxMemoryHotplugStatus".to_string()
+                })?,
+            accounted_memory_mb: intermediate_rep
+                .accounted_memory_mb
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "accountedMemoryMB missing in SandboxMemoryHotplugStatus".to_string()
+                })?,
+            elapsed_ms: intermediate_rep
+                .elapsed_ms
+                .into_iter()
+                .next()
+                .ok_or_else(|| "elapsedMs missing in SandboxMemoryHotplugStatus".to_string())?,
+            status: intermediate_rep
+                .status
+                .into_iter()
+                .next()
+                .ok_or_else(|| "status missing in SandboxMemoryHotplugStatus".to_string())?,
+            rollback_target_hotplug_memory_mb: std::result::Result::Err(
+                "Nullable types not supported in SandboxMemoryHotplugStatus".to_string(),
+            )?,
+            reason: std::result::Result::Err(
+                "Nullable types not supported in SandboxMemoryHotplugStatus".to_string(),
+            )?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<SandboxMemoryHotplugStatus> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<SandboxMemoryHotplugStatus>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<SandboxMemoryHotplugStatus>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for SandboxMemoryHotplugStatus - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<SandboxMemoryHotplugStatus> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <SandboxMemoryHotplugStatus as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into SandboxMemoryHotplugStatus - {err}"#
                     )),
                 }
             }

--- a/src/api/generated/src/server/mod.rs
+++ b/src/api/generated/src/server/mod.rs
@@ -69,6 +69,11 @@ where
             post(sandboxes_sandbox_id_fork_post::<I, A, E, C>),
         )
         .route(
+            "/sandboxes/{sandbox_id}/memory",
+            get(sandboxes_sandbox_id_memory_get::<I, A, E, C>)
+                .patch(sandboxes_sandbox_id_memory_patch::<I, A, E, C>),
+        )
+        .route(
             "/sandboxes/{sandbox_id}/network",
             put(sandboxes_sandbox_id_network_put::<I, A, E, C>),
         )
@@ -2034,6 +2039,440 @@ where
                                                   response.body(Body::from(body_content))
                                                 },
                                                 apis::sandboxes::SandboxesSandboxIdGetResponse::Status500_ServerError
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(500);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                            },
+                                            Err(why) => {
+                                                    // Application code returned an error. This should not happen, as the implementation should
+                                                    // return a valid response.
+                                                    return api_impl.as_ref().handle_error(&method, &host, &cookies, why).await;
+                                            },
+                                        };
+
+    resp.map_err(|e| {
+        error!(error = ?e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+#[tracing::instrument(skip_all)]
+fn sandboxes_sandbox_id_memory_get_validation(
+    path_params: models::SandboxesSandboxIdMemoryGetPathParams,
+) -> std::result::Result<(models::SandboxesSandboxIdMemoryGetPathParams,), ValidationErrors> {
+    path_params.validate()?;
+
+    Ok((path_params,))
+}
+/// SandboxesSandboxIdMemoryGet - GET /sandboxes/{sandboxID}/memory
+#[tracing::instrument(skip_all)]
+async fn sandboxes_sandbox_id_memory_get<I, A, E, C>(
+    method: Method,
+    TypedHeader(host): TypedHeader<Host>,
+    cookies: CookieJar,
+    headers: HeaderMap,
+    Path(path_params): Path<models::SandboxesSandboxIdMemoryGetPathParams>,
+    State(api_impl): State<I>,
+) -> Result<Response, StatusCode>
+where
+    I: AsRef<A> + Send + Sync,
+    A: apis::sandboxes::Sandboxes<E, Claims = C>
+        + apis::ApiKeyAuthHeader<Claims = C>
+        + apis::ApiAuthBasic<Claims = C>
+        + Send
+        + Sync,
+    E: std::fmt::Debug + Send + Sync + 'static,
+{
+    // Authentication
+    let claims_in_header = api_impl
+        .as_ref()
+        .extract_claims_from_header(&headers, "X-Team-ID")
+        .await;
+    let claims_in_auth_header = api_impl
+        .as_ref()
+        .extract_claims_from_auth_header(apis::BasicAuthKind::Bearer, &headers, "authorization")
+        .await;
+    let claims = None.or(claims_in_header).or(claims_in_auth_header);
+    let Some(claims) = claims else {
+        return response_with_status_code_only(StatusCode::UNAUTHORIZED);
+    };
+
+    #[allow(clippy::redundant_closure)]
+    let validation = tokio::task::spawn_blocking(move || {
+        sandboxes_sandbox_id_memory_get_validation(path_params)
+    })
+    .await
+    .unwrap();
+
+    let Ok((path_params,)) = validation else {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::from(validation.unwrap_err().to_string()))
+            .map_err(|_| StatusCode::BAD_REQUEST);
+    };
+
+    let result = api_impl
+        .as_ref()
+        .sandboxes_sandbox_id_memory_get(&method, &host, &cookies, &claims, &path_params)
+        .await;
+
+    let mut response = Response::builder();
+
+    let resp = match result {
+        Ok(rsp) => match rsp {
+            apis::sandboxes::SandboxesSandboxIdMemoryGetResponse::Status200_MemoryHotplugStatus(
+                body,
+            ) => {
+                let mut response = response.status(200);
+                {
+                    let mut response_headers = response.headers_mut().unwrap();
+                    response_headers
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                }
+
+                let body_content = tokio::task::spawn_blocking(move || {
+                    serde_json::to_vec(&body).map_err(|e| {
+                        error!(error = ?e);
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })
+                })
+                .await
+                .unwrap()?;
+                response.body(Body::from(body_content))
+            }
+            apis::sandboxes::SandboxesSandboxIdMemoryGetResponse::Status404_NotFound(body) => {
+                let mut response = response.status(404);
+                {
+                    let mut response_headers = response.headers_mut().unwrap();
+                    response_headers
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                }
+
+                let body_content = tokio::task::spawn_blocking(move || {
+                    serde_json::to_vec(&body).map_err(|e| {
+                        error!(error = ?e);
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })
+                })
+                .await
+                .unwrap()?;
+                response.body(Body::from(body_content))
+            }
+            apis::sandboxes::SandboxesSandboxIdMemoryGetResponse::Status401_AuthenticationError(
+                body,
+            ) => {
+                let mut response = response.status(401);
+                {
+                    let mut response_headers = response.headers_mut().unwrap();
+                    response_headers
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                }
+
+                let body_content = tokio::task::spawn_blocking(move || {
+                    serde_json::to_vec(&body).map_err(|e| {
+                        error!(error = ?e);
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })
+                })
+                .await
+                .unwrap()?;
+                response.body(Body::from(body_content))
+            }
+            apis::sandboxes::SandboxesSandboxIdMemoryGetResponse::Status409_Conflict(body) => {
+                let mut response = response.status(409);
+                {
+                    let mut response_headers = response.headers_mut().unwrap();
+                    response_headers
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                }
+
+                let body_content = tokio::task::spawn_blocking(move || {
+                    serde_json::to_vec(&body).map_err(|e| {
+                        error!(error = ?e);
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })
+                })
+                .await
+                .unwrap()?;
+                response.body(Body::from(body_content))
+            }
+            apis::sandboxes::SandboxesSandboxIdMemoryGetResponse::Status422_UnprocessableEntity(
+                body,
+            ) => {
+                let mut response = response.status(422);
+                {
+                    let mut response_headers = response.headers_mut().unwrap();
+                    response_headers
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                }
+
+                let body_content = tokio::task::spawn_blocking(move || {
+                    serde_json::to_vec(&body).map_err(|e| {
+                        error!(error = ?e);
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })
+                })
+                .await
+                .unwrap()?;
+                response.body(Body::from(body_content))
+            }
+            apis::sandboxes::SandboxesSandboxIdMemoryGetResponse::Status500_ServerError(body) => {
+                let mut response = response.status(500);
+                {
+                    let mut response_headers = response.headers_mut().unwrap();
+                    response_headers
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                }
+
+                let body_content = tokio::task::spawn_blocking(move || {
+                    serde_json::to_vec(&body).map_err(|e| {
+                        error!(error = ?e);
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })
+                })
+                .await
+                .unwrap()?;
+                response.body(Body::from(body_content))
+            }
+        },
+        Err(why) => {
+            // Application code returned an error. This should not happen, as the implementation should
+            // return a valid response.
+            return api_impl
+                .as_ref()
+                .handle_error(&method, &host, &cookies, why)
+                .await;
+        }
+    };
+
+    resp.map_err(|e| {
+        error!(error = ?e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+#[derive(validator::Validate)]
+#[allow(dead_code)]
+struct SandboxesSandboxIdMemoryPatchBodyValidator<'a> {
+    #[validate(nested)]
+    body: &'a models::SandboxMemoryHotplugResize,
+}
+
+#[tracing::instrument(skip_all)]
+fn sandboxes_sandbox_id_memory_patch_validation(
+    path_params: models::SandboxesSandboxIdMemoryPatchPathParams,
+    body: models::SandboxMemoryHotplugResize,
+) -> std::result::Result<
+    (
+        models::SandboxesSandboxIdMemoryPatchPathParams,
+        models::SandboxMemoryHotplugResize,
+    ),
+    ValidationErrors,
+> {
+    path_params.validate()?;
+    let b = SandboxesSandboxIdMemoryPatchBodyValidator { body: &body };
+    b.validate()?;
+
+    Ok((path_params, body))
+}
+/// SandboxesSandboxIdMemoryPatch - PATCH /sandboxes/{sandboxID}/memory
+#[tracing::instrument(skip_all)]
+async fn sandboxes_sandbox_id_memory_patch<I, A, E, C>(
+    method: Method,
+    TypedHeader(host): TypedHeader<Host>,
+    cookies: CookieJar,
+    headers: HeaderMap,
+    Path(path_params): Path<models::SandboxesSandboxIdMemoryPatchPathParams>,
+    State(api_impl): State<I>,
+    Json(body): Json<models::SandboxMemoryHotplugResize>,
+) -> Result<Response, StatusCode>
+where
+    I: AsRef<A> + Send + Sync,
+    A: apis::sandboxes::Sandboxes<E, Claims = C>
+        + apis::ApiKeyAuthHeader<Claims = C>
+        + apis::ApiAuthBasic<Claims = C>
+        + Send
+        + Sync,
+    E: std::fmt::Debug + Send + Sync + 'static,
+{
+    // Authentication
+    let claims_in_header = api_impl
+        .as_ref()
+        .extract_claims_from_header(&headers, "X-Team-ID")
+        .await;
+    let claims_in_auth_header = api_impl
+        .as_ref()
+        .extract_claims_from_auth_header(apis::BasicAuthKind::Bearer, &headers, "authorization")
+        .await;
+    let claims = None.or(claims_in_header).or(claims_in_auth_header);
+    let Some(claims) = claims else {
+        return response_with_status_code_only(StatusCode::UNAUTHORIZED);
+    };
+
+    #[allow(clippy::redundant_closure)]
+    let validation = tokio::task::spawn_blocking(move || {
+        sandboxes_sandbox_id_memory_patch_validation(path_params, body)
+    })
+    .await
+    .unwrap();
+
+    let Ok((path_params, body)) = validation else {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::from(validation.unwrap_err().to_string()))
+            .map_err(|_| StatusCode::BAD_REQUEST);
+    };
+
+    let result = api_impl
+        .as_ref()
+        .sandboxes_sandbox_id_memory_patch(&method, &host, &cookies, &claims, &path_params, &body)
+        .await;
+
+    let mut response = Response::builder();
+
+    let resp = match result {
+                                            Ok(rsp) => match rsp {
+                                                apis::sandboxes::SandboxesSandboxIdMemoryPatchResponse::Status200_MemoryResizeConverged
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(200);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::sandboxes::SandboxesSandboxIdMemoryPatchResponse::Status400_BadRequest
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(400);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::sandboxes::SandboxesSandboxIdMemoryPatchResponse::Status404_NotFound
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(404);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::sandboxes::SandboxesSandboxIdMemoryPatchResponse::Status401_AuthenticationError
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(401);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::sandboxes::SandboxesSandboxIdMemoryPatchResponse::Status409_Conflict
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(409);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::sandboxes::SandboxesSandboxIdMemoryPatchResponse::Status422_UnprocessableEntity
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(422);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::sandboxes::SandboxesSandboxIdMemoryPatchResponse::Status504_GatewayTimeout
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(504);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::sandboxes::SandboxesSandboxIdMemoryPatchResponse::Status500_ServerError
                                                     (body)
                                                 => {
                                                   let mut response = response.status(500);

--- a/src/api/openapi.yml
+++ b/src/api/openapi.yml
@@ -150,6 +150,18 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    "422":
+      description: Unprocessable entity
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    "504":
+      description: Gateway timeout
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SandboxMemoryHotplugStatus"
     "500":
       description: Server error
       content:
@@ -169,6 +181,93 @@ components:
       format: int32
       minimum: 128
       description: Memory for the sandbox in MiB
+
+    SandboxMemoryHotplugResize:
+      type: object
+      required:
+        - requestedHotplugMemoryMB
+      properties:
+        requestedHotplugMemoryMB:
+          type: integer
+          format: int32
+          minimum: 0
+          description: Target requested size of the virtio-mem region in MiB.
+
+    SandboxMemoryHotplugStatus:
+      type: object
+      required:
+        - previousRequestedHotplugMemoryMB
+        - targetHotplugMemoryMB
+        - requestedHotplugMemoryMB
+        - pluggedHotplugMemoryMB
+        - totalHotplugMemoryMB
+        - slotSizeMB
+        - blockSizeMB
+        - bootMemoryMB
+        - effectiveMemoryMB
+        - accountedMemoryMB
+        - elapsedMs
+        - status
+      properties:
+        previousRequestedHotplugMemoryMB:
+          type: integer
+          format: int32
+          minimum: 0
+        targetHotplugMemoryMB:
+          type: integer
+          format: int32
+          minimum: 0
+          description: Target requested by the current or most recent resize operation.
+        requestedHotplugMemoryMB:
+          type: integer
+          format: int32
+          minimum: 0
+        pluggedHotplugMemoryMB:
+          type: integer
+          format: int32
+          minimum: 0
+        totalHotplugMemoryMB:
+          type: integer
+          format: int32
+          minimum: 0
+        slotSizeMB:
+          type: integer
+          format: int32
+          minimum: 1
+        blockSizeMB:
+          type: integer
+          format: int32
+          minimum: 1
+        bootMemoryMB:
+          type: integer
+          format: int32
+          minimum: 128
+          description: Immutable memory configured in the Firecracker machine.
+        effectiveMemoryMB:
+          type: integer
+          format: int32
+          minimum: 128
+          description: Guest memory currently effective, equal to boot plus plugged memory.
+        accountedMemoryMB:
+          type: integer
+          format: int32
+          minimum: 128
+          description: Host scheduling grant retained for this sandbox.
+        elapsedMs:
+          type: integer
+          format: int64
+          minimum: 0
+        status:
+          type: string
+          enum: [converged, resizing, rolled_back, partial]
+        rollbackTargetHotplugMemoryMB:
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: true
+        reason:
+          type: string
+          nullable: true
 
     DiskSizeMB:
       type: integer
@@ -1558,6 +1657,79 @@ paths:
           $ref: "#/components/responses/404"
         "401":
           $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /sandboxes/{sandboxID}/memory:
+    get:
+      summary: Get sandbox virtio-mem status
+      description: Get the latest stable or in-progress virtio-mem resize status.
+      tags: [sandboxes]
+      security:
+        - ApiKeyAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
+        - AdminApiKeyAuth: []
+          AdminTeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/sandboxID"
+      responses:
+        "200":
+          description: Memory hotplug status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxMemoryHotplugStatus"
+        "404":
+          $ref: "#/components/responses/404"
+        "401":
+          $ref: "#/components/responses/401"
+        "409":
+          $ref: "#/components/responses/409"
+        "422":
+          $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
+
+    patch:
+      summary: Resize sandbox virtio-mem memory
+      description: >
+        Set the requested virtio-mem size and wait for exact requested/plugged
+        convergence. memoryMB continues to represent total accounted memory.
+      tags: [sandboxes]
+      security:
+        - ApiKeyAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
+        - AdminApiKeyAuth: []
+          AdminTeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/sandboxID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SandboxMemoryHotplugResize"
+      responses:
+        "200":
+          description: Memory resize converged
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxMemoryHotplugStatus"
+        "400":
+          $ref: "#/components/responses/400"
+        "404":
+          $ref: "#/components/responses/404"
+        "401":
+          $ref: "#/components/responses/401"
+        "409":
+          $ref: "#/components/responses/409"
+        "422":
+          $ref: "#/components/responses/422"
+        "504":
+          $ref: "#/components/responses/504"
         "500":
           $ref: "#/components/responses/500"
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -11,7 +11,7 @@ pub use image::{
 };
 pub use network::{NetworkConfig, NetworkEgressConfig, NetworkInternalConfig};
 use overlaybd::config::UpperMode;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::virtualization::VirtualizationMode;
 
@@ -179,6 +179,101 @@ pub struct FirecrackerConfig {
     /// When set (non-empty), Firecracker logging is enabled and written to a
     /// `firecracker.log` file in the same directory as the Firecracker stdout log.
     pub log_level: Option<String>,
+    /// Optional virtio-mem hard-elasticity policy. Disabled by default.
+    #[config(nested)]
+    pub memory_hotplug: MemoryHotplugPolicy,
+}
+
+/// Firecracker virtio-mem device and resize policy.
+#[derive(Debug, Clone, Config, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryHotplugPolicy {
+    #[config(default = false)]
+    pub enabled: bool,
+    #[config(default = 0u32)]
+    pub total_size_mib: u32,
+    #[config(default = 128u32)]
+    pub slot_size_mib: u32,
+    #[config(default = 2u32)]
+    pub block_size_mib: u32,
+    #[config(default = 0u32)]
+    pub requested_size_mib: u32,
+    #[config(default = 30u64)]
+    #[serde(default = "default_memory_resize_timeout_secs", skip_serializing)]
+    pub resize_timeout_secs: u64,
+    #[config(default = 50u64)]
+    #[serde(default = "default_memory_resize_poll_interval_ms", skip_serializing)]
+    pub resize_poll_interval_ms: u64,
+}
+
+fn default_memory_resize_timeout_secs() -> u64 {
+    30
+}
+
+fn default_memory_resize_poll_interval_ms() -> u64 {
+    50
+}
+
+impl Default for MemoryHotplugPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            total_size_mib: 0,
+            slot_size_mib: 128,
+            block_size_mib: 2,
+            requested_size_mib: 0,
+            resize_timeout_secs: 30,
+            resize_poll_interval_ms: 50,
+        }
+    }
+}
+
+impl MemoryHotplugPolicy {
+    pub fn validate(&self) -> Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+        let prefix = "firecracker.memory_hotplug";
+        if self.total_size_mib == 0 {
+            bail!("{prefix}.total_size_mib must be > 0 when enabled");
+        }
+        if self.slot_size_mib < 128 {
+            bail!("{prefix}.slot_size_mib must be >= 128");
+        }
+        if self.block_size_mib < 2 {
+            bail!("{prefix}.block_size_mib must be >= 2");
+        }
+        if self.total_size_mib % self.slot_size_mib != 0 {
+            bail!("{prefix}.total_size_mib must be aligned to slot_size_mib");
+        }
+        if self.slot_size_mib % self.block_size_mib != 0 {
+            bail!("{prefix}.slot_size_mib must be aligned to block_size_mib");
+        }
+        if self.requested_size_mib > self.total_size_mib {
+            bail!("{prefix}.requested_size_mib must not exceed total_size_mib");
+        }
+        if self.requested_size_mib % self.block_size_mib != 0 {
+            bail!("{prefix}.requested_size_mib must be aligned to block_size_mib");
+        }
+        for (name, value) in [
+            ("total_size_mib", self.total_size_mib),
+            ("slot_size_mib", self.slot_size_mib),
+            ("block_size_mib", self.block_size_mib),
+            ("requested_size_mib", self.requested_size_mib),
+        ] {
+            i32::try_from(value)
+                .with_context(|| format!("{prefix}.{name} exceeds Firecracker i32 range"))?;
+        }
+        if self.resize_timeout_secs == 0 {
+            bail!("{prefix}.resize_timeout_secs must be > 0");
+        }
+        if self.resize_poll_interval_ms == 0 {
+            bail!("{prefix}.resize_poll_interval_ms must be > 0");
+        }
+        if u128::from(self.resize_poll_interval_ms) > u128::from(self.resize_timeout_secs) * 1000 {
+            bail!("{prefix}.resize_poll_interval_ms must not exceed resize_timeout_secs");
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Config, Clone)]
@@ -930,6 +1025,32 @@ impl AppConfig {
         self.validate_memory_snapshot_background_download()?;
         self.validate_overlaybd_global_config_paths()?;
         self.validate_disk_rate_limit()?;
+        self.firecracker.memory_hotplug.validate()?;
+        self.validate_memory_hotplug_boot_args()?;
+        Ok(())
+    }
+
+    fn validate_memory_hotplug_boot_args(&self) -> Result<()> {
+        if !self.firecracker.memory_hotplug.enabled {
+            return Ok(());
+        }
+        let Some(args) = self.firecracker.boot_args.as_deref() else {
+            return Ok(());
+        };
+        let values = args
+            .split_whitespace()
+            .filter_map(|arg| arg.strip_prefix("memhp_default_state="))
+            .collect::<Vec<_>>();
+        if values.len() > 1 {
+            bail!(
+                "firecracker.boot_args contains duplicate memhp_default_state values: {values:?}"
+            );
+        }
+        if values.iter().any(|value| *value != "online_movable") {
+            bail!(
+                "firecracker.boot_args conflicts with memory hotplug: expected memhp_default_state=online_movable, found {values:?}"
+            );
+        }
         Ok(())
     }
 
@@ -1465,6 +1586,88 @@ mod tests {
         config
             .validate()
             .expect("disabled disk rate limit config is not validated");
+    }
+
+    #[test]
+    fn memory_hotplug_defaults_disabled() {
+        let policy = MemoryHotplugPolicy::default();
+        assert!(!policy.enabled);
+        assert_eq!(policy.slot_size_mib, 128);
+        assert_eq!(policy.block_size_mib, 2);
+        policy.validate().expect("disabled policy is compatible");
+    }
+
+    #[test]
+    fn memory_hotplug_validates_alignment_and_range() {
+        let valid = MemoryHotplugPolicy {
+            enabled: true,
+            total_size_mib: 512,
+            requested_size_mib: 128,
+            ..Default::default()
+        };
+        valid.validate().expect("aligned policy");
+
+        for (policy, expected) in [
+            (
+                {
+                    let mut p = valid.clone();
+                    p.total_size_mib = 300;
+                    p
+                },
+                "total_size_mib",
+            ),
+            (
+                {
+                    let mut p = valid.clone();
+                    p.slot_size_mib = 96;
+                    p
+                },
+                "slot_size_mib",
+            ),
+            (
+                {
+                    let mut p = valid.clone();
+                    p.block_size_mib = 3;
+                    p
+                },
+                "block_size_mib",
+            ),
+            (
+                {
+                    let mut p = valid.clone();
+                    p.requested_size_mib = 129;
+                    p
+                },
+                "requested_size_mib",
+            ),
+            (
+                {
+                    let mut p = valid.clone();
+                    p.requested_size_mib = 514;
+                    p
+                },
+                "requested_size_mib",
+            ),
+        ] {
+            let err = policy.validate().expect_err("invalid policy");
+            assert!(
+                err.to_string().contains(expected),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn memory_hotplug_rejects_conflicting_config_boot_arg() {
+        let mut config = AppConfig::default();
+        config.firecracker.memory_hotplug = MemoryHotplugPolicy {
+            enabled: true,
+            total_size_mib: 512,
+            ..Default::default()
+        };
+        config.firecracker.boot_args = Some("console=ttyS0 memhp_default_state=online".into());
+        let err = config.validate().expect_err("conflicting boot argument");
+        assert!(err.to_string().contains("online_movable"));
     }
 
     #[test]

--- a/src/sandbox/backend.rs
+++ b/src/sandbox/backend.rs
@@ -14,8 +14,8 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use super::{
-    EnvdAccessToken, Executor, FreshSandboxBuildSpec, ProcessHandle, ProcessOpts, ProcessOutput,
-    SandboxLaunchConfig, SandboxNetworkPolicy,
+    EnvdAccessToken, Executor, FreshSandboxBuildSpec, MemoryHotplugUnsupported, MemoryResizeResult,
+    ProcessHandle, ProcessOpts, ProcessOutput, SandboxLaunchConfig, SandboxNetworkPolicy,
 };
 use crate::sandbox::CustomExtensionParams;
 use crate::snapshot::RunnableSnapshot;
@@ -191,6 +191,21 @@ pub trait SandboxBackend: Send + 'static {
     /// Should be called after [`start_nowait`][Self::start_nowait] before any
     /// workload is submitted.
     async fn wait_for_ready(&self) -> Result<()>;
+
+    /// Resize a configured virtio-mem device. Unsupported backends fail
+    /// explicitly rather than treating the request as successful.
+    async fn resize_memory_hotplug(
+        &mut self,
+        _requested_size_mib: u32,
+    ) -> Result<MemoryResizeResult> {
+        Err(MemoryHotplugUnsupported::new("sandbox backend does not expose virtio-mem").into())
+    }
+
+    /// Return the observed virtio-mem device state for accounting and API
+    /// readback. Backends without a persisted virtio-mem device fail closed.
+    async fn memory_hotplug_status(&mut self) -> Result<super::MemoryHotplugStatus> {
+        Err(MemoryHotplugUnsupported::new("sandbox backend does not expose virtio-mem").into())
+    }
 
     /// Pause the sandbox and capture its state for later resume.
     ///

--- a/src/sandbox/firecracker/config.rs
+++ b/src/sandbox/firecracker/config.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::mmds::MmdsMetadata;
-use crate::cfg::{AppConfig, ConfigManager, EnvdConfig, ToolsConfig};
+use crate::cfg::{AppConfig, ConfigManager, EnvdConfig, MemoryHotplugPolicy, ToolsConfig};
 use crate::sandbox::ublk::UblkConfig;
 use crate::sandbox::SandboxNetworkPolicy;
 use crate::sandbox::UblkBackend;
@@ -162,6 +162,10 @@ pub struct FirecrackerCommonConfig {
     /// the process-global config.
     #[serde(default)]
     pub disk_rate_limit: crate::cfg::DiskRateLimitConfig,
+    /// Effective virtio-mem policy, persisted so restored VMs are validated
+    /// against the device state contained in vm_state.bin.
+    #[serde(default)]
+    pub memory_hotplug: MemoryHotplugPolicy,
     /// Runtime-only envd credential. It is re-derived from sandbox metadata on
     /// resume and is intentionally excluded from persisted snapshot configs.
     #[serde(skip)]
@@ -199,6 +203,7 @@ impl FirecrackerCommonConfig {
             network_policy: None,
             custom_extension_params: None,
             disk_rate_limit: crate::cfg::DiskRateLimitConfig::default(),
+            memory_hotplug: MemoryHotplugPolicy::default(),
             envd_access_token: None,
         }
     }
@@ -211,6 +216,7 @@ impl FirecrackerCommonConfig {
         let mut common = Self::new(firecracker_binary, tools_drive_version, runtime_policy);
         common.envd_version = config.envd.version.clone();
         common.disk_rate_limit = config.machine.disk_rate_limit.clone();
+        common.memory_hotplug = config.firecracker.memory_hotplug.clone();
         common.track_dirty_pages = config.memory_snapshot.track_dirty_pages;
         common.rootfs_allow_shrink = config.ublk.overlaybd.allow_shrink;
         common.control_plane_port = config.tools.control_plane_port;
@@ -279,6 +285,9 @@ impl FirecrackerCommonConfig {
     }
 
     fn validate_persisted_artifacts(&self) -> Result<()> {
+        self.memory_hotplug
+            .validate()
+            .context("validate persisted virtio-mem policy")?;
         validate_overlaybd_extra_drive_set(&self.extra_drives)?;
         if matches!(self.rootfs_virtual_size, Some(0)) {
             anyhow::bail!("rootfs virtual size must be non-zero");
@@ -507,6 +516,11 @@ impl FirecrackerSnapshotConfig {
         // starts for the first time. When resuming from a snapshot, the full CPU state
         // is already serialised inside vm_state.bin, so re-applying a template would
         // be incorrect and is rejected by Firecracker anyway.
+        let mut persisted_memory_hotplug = manifest.memory_hotplug.clone();
+        persisted_memory_hotplug.resize_timeout_secs =
+            base_common.memory_hotplug.resize_timeout_secs;
+        persisted_memory_hotplug.resize_poll_interval_ms =
+            base_common.memory_hotplug.resize_poll_interval_ms;
         let snapshot_common = FirecrackerCommonConfig {
             ublk_config: Some(overlaybd_ublk_config),
             envd_version: snapshot.committed().runtime_versions.envd_version.clone(),
@@ -516,6 +530,7 @@ impl FirecrackerSnapshotConfig {
             rootfs_image_config: Some(rootfs_image_config),
             rootfs_virtual_size: Some(manifest.rootfs.virtual_size),
             extra_drives: manifest.extra_drives(),
+            memory_hotplug: persisted_memory_hotplug,
             ..base_common
         };
 
@@ -674,6 +689,19 @@ mod tests {
 
     fn test_runtime_policy() -> FirecrackerRuntimePolicy {
         FirecrackerRuntimePolicy::from_app_config(&base_app_config())
+    }
+
+    #[test]
+    fn legacy_common_config_defaults_memory_hotplug_to_disabled() {
+        let common = FirecrackerCommonConfig::new(
+            "firecracker".into(),
+            "0.1.0".into(),
+            test_runtime_policy(),
+        );
+        let mut value = serde_json::to_value(common).unwrap();
+        value.as_object_mut().unwrap().remove("memory_hotplug");
+        let decoded: FirecrackerCommonConfig = serde_json::from_value(value).unwrap();
+        assert!(!decoded.memory_hotplug.enabled);
     }
 
     #[test]

--- a/src/sandbox/firecracker/factory.rs
+++ b/src/sandbox/firecracker/factory.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::{Context, Result};
 use serde_json::Value;
 
-use super::config::FirecrackerSandboxConfig;
+use super::config::{FirecrackerCommonConfig, FirecrackerSandboxConfig};
 use super::sandbox::{FirecrackerPausedState, FirecrackerSandbox};
 use crate::cfg::ConfigManager;
 use crate::sandbox::backend::{PausedSandboxState, SandboxBackend, SandboxBackendFactory};
@@ -105,7 +105,23 @@ impl SandboxBackendFactory for FirecrackerSandboxFactory {
             runtime_upper_mode,
         ));
         config.vcpu_count = build_spec.resources.cpu_count;
-        config.mem_size_mib = build_spec.resources.memory_mib;
+        config.mem_size_mib = if config.common.memory_hotplug.enabled {
+            let initial_hotplug = config.common.memory_hotplug.requested_size_mib;
+            let boot_memory = build_spec
+                .resources
+                .memory_mib
+                .checked_sub(initial_hotplug)
+                .context("sandbox memoryMB must exceed the initial requested hotplug memory")?;
+            anyhow::ensure!(
+                boot_memory >= 128,
+                "sandbox boot memory must be at least 128 MiB after subtracting initial hotplug memory: total={} MiB initial_hotplug={} MiB",
+                build_spec.resources.memory_mib,
+                initial_hotplug
+            );
+            boot_memory
+        } else {
+            build_spec.resources.memory_mib
+        };
         config.common.rootfs_virtual_size = if build_spec.resources.disk_size_mib == 0 {
             None
         } else {
@@ -172,8 +188,18 @@ impl SandboxBackendFactory for FirecrackerSandboxFactory {
         let paused_state = state
             .downcast_ref::<FirecrackerPausedState>()
             .context("The provided PausedSandboxState is not a Firecracker paused state")?;
+        let mut snapshot_config = paused_state.snapshot_config().clone();
+        let current_common = FirecrackerCommonConfig::from_global_config()
+            .context("load current node runtime policy for paused sandbox resume")?;
+        snapshot_config.common.runtime_policy = current_common.runtime_policy;
+        snapshot_config.common.memory_hotplug.resize_timeout_secs =
+            current_common.memory_hotplug.resize_timeout_secs;
+        snapshot_config
+            .common
+            .memory_hotplug
+            .resize_poll_interval_ms = current_common.memory_hotplug.resize_poll_interval_ms;
         let sandbox = FirecrackerSandbox::from_snapshot_config_with_override(
-            paused_state.snapshot_config().clone(),
+            snapshot_config,
             sandbox_id,
             envd_access_token,
         )?;

--- a/src/sandbox/firecracker/instance.rs
+++ b/src/sandbox/firecracker/instance.rs
@@ -11,8 +11,8 @@ use firecracker_client::models::vm::State as VmState;
 use firecracker_client::models::{mmds_config::Version as MmdsVersion, MmdsConfig, PartialDrive};
 use firecracker_client::models::{
     Balloon, BootSource, DirtyMemoryRanges, Drive, InstanceActionInfo, Logger,
-    MachineConfiguration, MemoryBackend, NetworkInterface, NetworkOverride, RateLimiter,
-    SnapshotCreateParams, SnapshotLoadParams, Vm,
+    MachineConfiguration, MemoryBackend, MemoryHotplugConfig, MemoryHotplugSizeUpdate,
+    NetworkInterface, NetworkOverride, RateLimiter, SnapshotCreateParams, SnapshotLoadParams, Vm,
 };
 use hyper::Method;
 use nix::sys::signal::{kill, Signal};
@@ -30,6 +30,54 @@ use super::socket::UnixSocketClient;
 /// injected via the extra MMDS metadata pass-through.
 const MMDS_SIZE_LIMIT: usize = 1_048_576;
 const HTTP_API_MAX_PAYLOAD_SIZE: usize = MMDS_SIZE_LIMIT;
+
+/// Validated, unsigned view of Firecracker's virtio-mem status response.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MemoryHotplugStatus {
+    pub total_size_mib: u32,
+    pub slot_size_mib: u32,
+    pub block_size_mib: u32,
+    pub requested_size_mib: u32,
+    pub plugged_size_mib: u32,
+}
+
+/// Result of a virtio-mem resize after exact requested/plugged convergence.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MemoryResizeResult {
+    pub previous_requested_size_mib: u32,
+    pub requested_size_mib: u32,
+    pub plugged_size_mib: u32,
+    pub total_size_mib: u32,
+    pub slot_size_mib: u32,
+    pub block_size_mib: u32,
+    pub elapsed_ms: u64,
+}
+
+fn mib_to_i32(value: u32, field: &str) -> Result<i32> {
+    i32::try_from(value).with_context(|| format!("{field} ({value}) exceeds Firecracker i32 range"))
+}
+
+fn required_mib(value: Option<i32>, field: &str) -> Result<u32> {
+    let value =
+        value.with_context(|| format!("Firecracker memory hotplug status omitted {field}"))?;
+    u32::try_from(value).with_context(|| {
+        format!("Firecracker memory hotplug status returned negative {field}: {value}")
+    })
+}
+
+impl TryFrom<firecracker_client::models::MemoryHotplugStatus> for MemoryHotplugStatus {
+    type Error = anyhow::Error;
+
+    fn try_from(value: firecracker_client::models::MemoryHotplugStatus) -> Result<Self> {
+        Ok(Self {
+            total_size_mib: required_mib(value.total_size_mib, "total_size_mib")?,
+            slot_size_mib: required_mib(value.slot_size_mib, "slot_size_mib")?,
+            block_size_mib: required_mib(value.block_size_mib, "block_size_mib")?,
+            requested_size_mib: required_mib(value.requested_size_mib, "requested_size_mib")?,
+            plugged_size_mib: required_mib(value.plugged_size_mib, "plugged_size_mib")?,
+        })
+    }
+}
 
 pub(crate) struct FirecrackerInstance {
     client: UnixSocketClient,
@@ -423,6 +471,56 @@ impl FirecrackerInstance {
             .context("Failed to set balloon configuration")
     }
 
+    /// Creates the virtio-mem device. Pre-boot only and intentionally absent
+    /// from snapshot resume, where vm_state.bin restores the device.
+    pub async fn put_memory_hotplug(
+        &self,
+        total_size_mib: u32,
+        slot_size_mib: u32,
+        block_size_mib: u32,
+    ) -> Result<()> {
+        let mut config = MemoryHotplugConfig::new();
+        config.total_size_mib = Some(mib_to_i32(total_size_mib, "total_size_mib")?);
+        config.slot_size_mib = Some(mib_to_i32(slot_size_mib, "slot_size_mib")?);
+        config.block_size_mib = Some(mib_to_i32(block_size_mib, "block_size_mib")?);
+        self.client
+            .request_no_content(Method::PUT, "/hotplug/memory", Some(&config))
+            .await
+            .context("Failed to configure virtio-mem device")
+    }
+
+    /// Updates the runtime virtio-mem requested size.
+    pub async fn patch_memory_hotplug(
+        &self,
+        requested_size_mib: u32,
+    ) -> Result<MemoryHotplugStatus> {
+        let mut update = MemoryHotplugSizeUpdate::new();
+        update.requested_size_mib = Some(mib_to_i32(requested_size_mib, "requested_size_mib")?);
+        self.client
+            .request_no_content(Method::PATCH, "/hotplug/memory", Some(&update))
+            .await
+            .with_context(|| {
+                format!("Failed to request virtio-mem size {requested_size_mib} MiB")
+            })?;
+        self.get_memory_hotplug()
+            .await
+            .context("read back virtio-mem status after PATCH")
+    }
+
+    /// Reads and validates the complete runtime virtio-mem status.
+    pub async fn get_memory_hotplug(&self) -> Result<MemoryHotplugStatus> {
+        let status = self
+            .client
+            .request::<(), firecracker_client::models::MemoryHotplugStatus>(
+                Method::GET,
+                "/hotplug/memory",
+                None,
+            )
+            .await
+            .context("Failed to get virtio-mem status")?;
+        status.try_into()
+    }
+
     /// Starts the microVM.
     pub async fn start(&self) -> Result<()> {
         let action = InstanceActionInfo::new(ActionType::InstanceStart);
@@ -613,6 +711,33 @@ mod tests {
     use super::*;
     use std::process::Command as StdCommand;
     use tempfile::tempdir;
+
+    #[test]
+    fn memory_hotplug_mib_conversion_rejects_i32_overflow() {
+        assert_eq!(mib_to_i32(i32::MAX as u32, "size").unwrap(), i32::MAX);
+        assert!(mib_to_i32(i32::MAX as u32 + 1, "size").is_err());
+    }
+
+    #[test]
+    fn memory_hotplug_status_rejects_missing_and_negative_fields() {
+        let mut raw = firecracker_client::models::MemoryHotplugStatus::new();
+        raw.total_size_mib = Some(512);
+        raw.slot_size_mib = Some(128);
+        raw.block_size_mib = Some(2);
+        raw.requested_size_mib = Some(128);
+        raw.plugged_size_mib = Some(128);
+        assert_eq!(
+            MemoryHotplugStatus::try_from(raw.clone())
+                .unwrap()
+                .plugged_size_mib,
+            128
+        );
+
+        raw.plugged_size_mib = Some(-1);
+        assert!(MemoryHotplugStatus::try_from(raw.clone()).is_err());
+        raw.plugged_size_mib = None;
+        assert!(MemoryHotplugStatus::try_from(raw).is_err());
+    }
 
     #[tokio::test]
     async fn wait_for_ready_times_out_when_socket_never_appears() {

--- a/src/sandbox/firecracker/manifest.rs
+++ b/src/sandbox/firecracker/manifest.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::cfg::MemoryHotplugPolicy;
 use crate::sandbox::ExtraDrive;
 
 pub(crate) const MANIFEST_FORMAT_VERSION: u32 = 1;
@@ -23,6 +24,10 @@ pub struct FirecrackerSnapshotManifest {
     pub memory: FirecrackerMemoryArtifacts,
     pub rootfs: FirecrackerRootfsArtifacts,
     pub attached_drives: Vec<FirecrackerAttachedDriveArtifacts>,
+    /// Snapshot-time virtio-mem policy and requested size. Older manifests did
+    /// not contain this field and therefore restore with hotplug disabled.
+    #[serde(default)]
+    pub memory_hotplug: MemoryHotplugPolicy,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -85,6 +90,7 @@ impl FirecrackerSnapshotManifest {
                 virtual_size: rootfs_virtual_size,
             },
             attached_drives: Vec::new(),
+            memory_hotplug: MemoryHotplugPolicy::default(),
         }
         .with_extra_drives(attached_drives)
     }
@@ -170,6 +176,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn legacy_manifest_defaults_memory_hotplug_to_disabled() {
+        let decoded: FirecrackerSnapshotManifest = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/firecracker_manifest_v1_legacy.json"
+        ))
+        .unwrap();
+        assert!(!decoded.memory_hotplug.enabled);
+    }
+
+    #[test]
     fn attached_drive_virtual_size_is_required() {
         let err = serde_json::from_value::<FirecrackerAttachedDriveArtifacts>(serde_json::json!({
             "driveId": "data",
@@ -209,6 +224,7 @@ mod tests {
                 virtual_size: 4096,
             },
             attached_drives: vec![known],
+            memory_hotplug: MemoryHotplugPolicy::default(),
         };
 
         let drives = manifest.extra_drives();

--- a/src/sandbox/firecracker/mod.rs
+++ b/src/sandbox/firecracker/mod.rs
@@ -22,6 +22,7 @@ pub use config::{
 };
 pub use factory::FirecrackerSandboxFactory;
 pub(super) use instance::FirecrackerInstance;
+pub use instance::{MemoryHotplugStatus, MemoryResizeResult};
 pub use manifest::FirecrackerSnapshotManifest;
 pub use pool::FirecrackerPool;
 pub use sandbox::{FirecrackerCapturedSnapshot, FirecrackerPausedState, FirecrackerSandbox};

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -23,7 +23,7 @@ use super::overlaybd_snapshot::{
     restack_snapshot_overlaybd_device, restack_snapshot_overlaybd_rootfs,
 };
 use super::pool::{warm_stderr_path, warm_stdout_path, FirecrackerPool};
-use super::FirecrackerInstance;
+use super::{FirecrackerInstance, MemoryHotplugStatus, MemoryResizeResult};
 use crate::sandbox::custom_extension::{
     CustomExtensionClient, CustomExtensionHookGuard, CustomExtensionParams,
 };
@@ -46,9 +46,11 @@ use crate::sandbox::ublk::{
     OverlaybdCompactOutput, OverlaybdConfig, OverlaybdRuntimeHandle, SharedMemDevice, UblkBackend,
     UblkCreateSpec, UblkDeviceManager,
 };
-use crate::sandbox::SandboxLaunchConfig;
+use crate::sandbox::{MemoryHotplugUnsupported, MemoryResizeConvergenceError, SandboxLaunchConfig};
 use crate::snapshot::RunnableSnapshot;
 use crate::types::SandboxId;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration, Instant};
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -60,6 +62,77 @@ const USER_ROOTFS_DRIVE_PATH: &str = "user-rootfs";
 /// `refill_time`, not a per-second rate. Pinning the refill period to 1000 ms
 /// makes the configured `*_per_sec` values equal the sustained per-second rate.
 const RATE_LIMIT_REFILL_TIME_MS: i64 = 1000;
+
+#[derive(Debug, PartialEq, Eq)]
+enum MemoryResizePoll {
+    Converged,
+    Pending,
+    TimedOut,
+}
+
+fn evaluate_memory_resize(
+    status: &MemoryHotplugStatus,
+    target: u32,
+    elapsed: Duration,
+    timeout: Duration,
+) -> MemoryResizePoll {
+    if status.requested_size_mib == target && status.plugged_size_mib == target {
+        MemoryResizePoll::Converged
+    } else if elapsed >= timeout {
+        MemoryResizePoll::TimedOut
+    } else {
+        MemoryResizePoll::Pending
+    }
+}
+
+fn ensure_memory_hotplug_boot_arg(
+    boot_args: Option<String>,
+    enabled: bool,
+) -> Result<Option<String>> {
+    if !enabled {
+        return Ok(boot_args);
+    }
+    let mut args = boot_args.unwrap_or_default();
+    let values = args
+        .split_whitespace()
+        .filter_map(|arg| arg.strip_prefix("memhp_default_state="))
+        .collect::<Vec<_>>();
+    if !values.is_empty() {
+        anyhow::ensure!(
+            values.len() == 1,
+            "virtio-mem requires exactly one memhp_default_state argument; found {values:?}"
+        );
+        anyhow::ensure!(
+            values.iter().all(|value| *value == "online_movable"),
+            "virtio-mem requires memhp_default_state=online_movable; found values {values:?}"
+        );
+        return Ok(Some(args));
+    }
+    if !args.is_empty() {
+        args.push(' ');
+    }
+    args.push_str("memhp_default_state=online_movable");
+    Ok(Some(args))
+}
+
+fn validate_memory_hotplug_status(
+    policy: &crate::cfg::MemoryHotplugPolicy,
+    status: &MemoryHotplugStatus,
+) -> Result<()> {
+    anyhow::ensure!(
+        status.total_size_mib == policy.total_size_mib
+            && status.slot_size_mib == policy.slot_size_mib
+            && status.block_size_mib == policy.block_size_mib,
+        "virtio-mem status does not match persisted policy: expected total/slot/block={}/{}/{}, got {}/{}/{}",
+        policy.total_size_mib,
+        policy.slot_size_mib,
+        policy.block_size_mib,
+        status.total_size_mib,
+        status.slot_size_mib,
+        status.block_size_mib
+    );
+    Ok(())
+}
 
 fn bandwidth_bucket(
     cfg: &crate::cfg::DiskRateLimitConfig,
@@ -193,6 +266,9 @@ pub struct FirecrackerSandbox {
     /// best-effort notification. `None` when no start hook was delivered (or
     /// no extension is configured).
     custom_extension_hook_guard: Option<CustomExtensionHookGuard>,
+    /// Serializes virtio-mem resizing with pause/snapshot capture. This is also
+    /// the transaction boundary for any future runtime balloon resize API.
+    memory_resize_transaction: Arc<Mutex<()>>,
 }
 
 // ── SandboxBackend impl ──────────────────────────────────────────────────────
@@ -273,6 +349,17 @@ impl SandboxBackend for FirecrackerSandbox {
 
     async fn wait_for_ready(&self) -> Result<()> {
         FirecrackerSandbox::wait_for_ready(self).await
+    }
+
+    async fn resize_memory_hotplug(
+        &mut self,
+        requested_size_mib: u32,
+    ) -> Result<MemoryResizeResult> {
+        FirecrackerSandbox::resize_memory_hotplug(self, requested_size_mib).await
+    }
+
+    async fn memory_hotplug_status(&mut self) -> Result<MemoryHotplugStatus> {
+        FirecrackerSandbox::memory_hotplug_status(self).await
     }
 
     /// Pauses the VM and returns the paused state wrapped as a [`PausedSandboxState`].
@@ -605,6 +692,13 @@ impl FirecrackerSandbox {
                 self.runtime_policy.envd_poll_interval,
             )
             .await?;
+        if let LaunchMode::Fresh(config) = &self.launch {
+            if config.common.memory_hotplug.enabled {
+                self.resize_memory_hotplug(config.common.memory_hotplug.requested_size_mib)
+                    .await
+                    .context("apply initial virtio-mem requested size after guest readiness")?;
+            }
+        }
         if let Some(device_key) = &self.mem_snapshot_image_config_path {
             // envd is up: release held background downloads for this memory
             // device. Best-effort — downloads would also start after the
@@ -626,6 +720,184 @@ impl FirecrackerSandbox {
                 self.launch.common().default_user.clone(),
             )
             .await
+    }
+
+    /// Resize the Firecracker virtio-mem region and wait for exact convergence.
+    /// The transaction lock is shared with pause/snapshot capture.
+    #[tracing::instrument(skip(self), fields(requested_size_mib))]
+    pub async fn resize_memory_hotplug(
+        &self,
+        requested_size_mib: u32,
+    ) -> Result<MemoryResizeResult> {
+        let policy = &self.launch.common().memory_hotplug;
+        if !policy.enabled {
+            return Err(MemoryHotplugUnsupported::new(
+                "sandbox was created without a virtio-mem device",
+            )
+            .into());
+        }
+        policy
+            .validate()
+            .context("validate virtio-mem resize policy")?;
+        anyhow::ensure!(
+            requested_size_mib <= policy.total_size_mib,
+            "requested virtio-mem size {requested_size_mib} MiB exceeds total {} MiB",
+            policy.total_size_mib
+        );
+        anyhow::ensure!(
+            requested_size_mib % policy.block_size_mib == 0,
+            "requested virtio-mem size {requested_size_mib} MiB is not aligned to block size {} MiB",
+            policy.block_size_mib
+        );
+
+        let transaction = Arc::clone(&self.memory_resize_transaction);
+        let _guard = transaction.lock().await;
+        let started = Instant::now();
+        let timeout = Duration::from_secs(policy.resize_timeout_secs);
+        let poll_interval = Duration::from_millis(policy.resize_poll_interval_ms);
+
+        let previous = self.fc_instance.get_memory_hotplug().await?;
+        validate_memory_hotplug_status(policy, &previous)?;
+        if previous.requested_size_mib == requested_size_mib
+            && previous.plugged_size_mib == requested_size_mib
+        {
+            return Ok(MemoryResizeResult {
+                previous_requested_size_mib: previous.requested_size_mib,
+                requested_size_mib: previous.requested_size_mib,
+                plugged_size_mib: previous.plugged_size_mib,
+                total_size_mib: previous.total_size_mib,
+                slot_size_mib: previous.slot_size_mib,
+                block_size_mib: previous.block_size_mib,
+                elapsed_ms: 0,
+            });
+        }
+
+        self.fc_instance
+            .patch_memory_hotplug(requested_size_mib)
+            .await?;
+        loop {
+            let status = self.fc_instance.get_memory_hotplug().await?;
+            validate_memory_hotplug_status(policy, &status)?;
+            match evaluate_memory_resize(&status, requested_size_mib, started.elapsed(), timeout) {
+                MemoryResizePoll::Converged => {
+                    let elapsed_ms =
+                        u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+                    debug!(
+                        requested_size_mib = status.requested_size_mib,
+                        plugged_size_mib = status.plugged_size_mib,
+                        total_size_mib = status.total_size_mib,
+                        slot_size_mib = status.slot_size_mib,
+                        block_size_mib = status.block_size_mib,
+                        elapsed_ms,
+                        status = "converged",
+                        "virtio-mem resize completed"
+                    );
+                    return Ok(MemoryResizeResult {
+                        previous_requested_size_mib: previous.requested_size_mib,
+                        requested_size_mib: status.requested_size_mib,
+                        plugged_size_mib: status.plugged_size_mib,
+                        total_size_mib: status.total_size_mib,
+                        slot_size_mib: status.slot_size_mib,
+                        block_size_mib: status.block_size_mib,
+                        elapsed_ms,
+                    });
+                }
+                MemoryResizePoll::Pending => sleep(poll_interval).await,
+                MemoryResizePoll::TimedOut => {
+                    let elapsed_ms = started.elapsed().as_millis();
+                    let elapsed_ms_field = u64::try_from(elapsed_ms).unwrap_or(u64::MAX);
+                    warn!(
+                        requested_size_mib = status.requested_size_mib,
+                        plugged_size_mib = status.plugged_size_mib,
+                        target_size_mib = requested_size_mib,
+                        total_size_mib = status.total_size_mib,
+                        slot_size_mib = status.slot_size_mib,
+                        block_size_mib = status.block_size_mib,
+                        elapsed_ms = elapsed_ms_field,
+                        status = "timeout",
+                        reason = "requested and plugged sizes did not converge before deadline",
+                        "virtio-mem resize failed"
+                    );
+                    if let Err(error) = self
+                        .fc_instance
+                        .patch_memory_hotplug(previous.requested_size_mib)
+                        .await
+                    {
+                        return Err(MemoryResizeConvergenceError::Partial {
+                            target_size_mib: requested_size_mib,
+                            rollback_target_size_mib: previous.requested_size_mib,
+                            observed: status,
+                            elapsed_ms: elapsed_ms_field,
+                            reason: format!("failed to request rollback: {error:#}"),
+                        }
+                        .into());
+                    }
+                    let rollback_started = Instant::now();
+                    let mut last_rollback = status;
+                    loop {
+                        let rollback = match self.fc_instance.get_memory_hotplug().await {
+                            Ok(rollback) => rollback,
+                            Err(error) => {
+                                return Err(MemoryResizeConvergenceError::Partial {
+                                    target_size_mib: requested_size_mib,
+                                    rollback_target_size_mib: previous.requested_size_mib,
+                                    observed: last_rollback,
+                                    elapsed_ms: elapsed_ms_field,
+                                    reason: format!("failed to observe rollback: {error:#}"),
+                                }
+                                .into())
+                            }
+                        };
+                        validate_memory_hotplug_status(policy, &rollback)?;
+                        match evaluate_memory_resize(
+                            &rollback,
+                            previous.requested_size_mib,
+                            rollback_started.elapsed(),
+                            timeout,
+                        ) {
+                            MemoryResizePoll::Converged => {
+                                return Err(MemoryResizeConvergenceError::RolledBack {
+                                    target_size_mib: requested_size_mib,
+                                    rollback_target_size_mib: previous.requested_size_mib,
+                                    observed: rollback,
+                                    elapsed_ms: elapsed_ms_field,
+                                }
+                                .into())
+                            }
+                            MemoryResizePoll::Pending => {
+                                last_rollback = rollback;
+                                sleep(poll_interval).await;
+                            }
+                            MemoryResizePoll::TimedOut => {
+                                return Err(MemoryResizeConvergenceError::Partial {
+                                    target_size_mib: requested_size_mib,
+                                    rollback_target_size_mib: previous.requested_size_mib,
+                                    observed: rollback,
+                                    elapsed_ms: elapsed_ms_field,
+                                    reason: "rollback did not converge before deadline".to_string(),
+                                }
+                                .into())
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub async fn memory_hotplug_status(&self) -> Result<MemoryHotplugStatus> {
+        if !self.launch.common().memory_hotplug.enabled {
+            return Err(MemoryHotplugUnsupported::new(
+                "sandbox was created without a virtio-mem device",
+            )
+            .into());
+        }
+        self.fc_instance.get_memory_hotplug().await
+    }
+
+    /// Host PID for runtime observability such as RSS evidence.
+    pub fn firecracker_pid(&self) -> Result<i32> {
+        Ok(self.fc_instance.pid()?.as_raw())
     }
 
     /// Pause the running sandbox and create a snapshot for later resume.
@@ -661,6 +933,8 @@ impl FirecrackerSandbox {
         &mut self,
         snapshot_dir: &Path,
     ) -> Result<(FirecrackerSnapshotConfig, FirecrackerSnapshotManifest)> {
+        let transaction = Arc::clone(&self.memory_resize_transaction);
+        let _guard = transaction.lock().await;
         debug!(snapshot_dir = %snapshot_dir.display(), "pausing sandbox");
         self.fc_instance.pause().await?;
 
@@ -767,6 +1041,21 @@ impl FirecrackerSandbox {
             .await
             .context("snapshot extra drives to persistent dir")?;
         let mut snapshot_common = self.launch.common().clone();
+        if snapshot_common.memory_hotplug.enabled {
+            let status = self
+                .fc_instance
+                .get_memory_hotplug()
+                .await
+                .context("read virtio-mem status while capturing snapshot")?;
+            validate_memory_hotplug_status(&snapshot_common.memory_hotplug, &status)?;
+            anyhow::ensure!(
+                status.plugged_size_mib == status.requested_size_mib,
+                "refusing snapshot with partially converged virtio-mem state: requested={} plugged={}",
+                status.requested_size_mib,
+                status.plugged_size_mib
+            );
+            snapshot_common.memory_hotplug.requested_size_mib = status.requested_size_mib;
+        }
         snapshot_common.network_policy = self.current_network_policy.clone();
         snapshot_common.custom_extension_params = self.current_custom_extension_params.clone();
         snapshot_common.extra_drives = snapshot_extra_drives.clone();
@@ -793,7 +1082,7 @@ impl FirecrackerSandbox {
         });
         snapshot_common.rootfs_virtual_size = Some(rootfs_virtual_size);
 
-        let manifest = FirecrackerSnapshotManifest::new(
+        let mut manifest = FirecrackerSnapshotManifest::new(
             vm_state_path.clone(),
             mem_overlaybd_config.image_config_path.clone(),
             mem_virtual_size,
@@ -802,6 +1091,7 @@ impl FirecrackerSandbox {
             &snapshot_extra_drives,
         )
         .context("build firecracker snapshot manifest")?;
+        manifest.memory_hotplug = snapshot_common.memory_hotplug.clone();
 
         let snapshot = FirecrackerSnapshotConfig {
             common: snapshot_common,
@@ -1185,6 +1475,7 @@ impl FirecrackerSandbox {
             extra_drive_runtimes: Vec::new(),
             live_snapshot_root: None,
             custom_extension_hook_guard: None,
+            memory_resize_transaction: Arc::new(Mutex::new(())),
         })
     }
 
@@ -1330,6 +1621,9 @@ impl FirecrackerSandbox {
                 });
             }
         }
+
+        boot_args =
+            ensure_memory_hotplug_boot_arg(boot_args, config.common.memory_hotplug.enabled)?;
 
         // ── Spawn Firecracker inside the network namespace so it can access tap0 ──
         let firecracker_binary = config.common.firecracker_binary.clone();
@@ -1580,6 +1874,23 @@ impl FirecrackerSandbox {
             )
             .await?;
 
+        if config.common.memory_hotplug.enabled {
+            let status = self
+                .fc_instance
+                .get_memory_hotplug()
+                .await
+                .context("read restored virtio-mem status")?;
+            validate_memory_hotplug_status(&config.common.memory_hotplug, &status)?;
+            anyhow::ensure!(
+                status.requested_size_mib == config.common.memory_hotplug.requested_size_mib
+                    && status.plugged_size_mib == config.common.memory_hotplug.requested_size_mib,
+                "restored virtio-mem size mismatch: expected requested/plugged={}, got requested={} plugged={}",
+                config.common.memory_hotplug.requested_size_mib,
+                status.requested_size_mib,
+                status.plugged_size_mib
+            );
+        }
+
         let mmds_metadata = self.mmds_metadata(&config.common);
         self.fc_instance.set_mmds(&mmds_metadata).await?;
 
@@ -1682,6 +1993,17 @@ impl FirecrackerSandbox {
                 config.common.track_dirty_pages,
             )
             .await?;
+
+        if config.common.memory_hotplug.enabled {
+            let policy = &config.common.memory_hotplug;
+            self.fc_instance
+                .put_memory_hotplug(
+                    policy.total_size_mib,
+                    policy.slot_size_mib,
+                    policy.block_size_mib,
+                )
+                .await?;
+        }
 
         if let Some(cpu_json) = config.common.cpu_config_json.as_deref() {
             if !cpu_json.is_empty() {
@@ -1918,6 +2240,67 @@ mod tests {
             "0.1.0".to_string(),
             "user-image.json".into(),
         )
+    }
+
+    fn memory_status(requested: u32, plugged: u32) -> MemoryHotplugStatus {
+        MemoryHotplugStatus {
+            total_size_mib: 512,
+            slot_size_mib: 128,
+            block_size_mib: 2,
+            requested_size_mib: requested,
+            plugged_size_mib: plugged,
+        }
+    }
+
+    #[test]
+    fn memory_hotplug_boot_arg_is_added_and_conflicts_fail() {
+        let added = ensure_memory_hotplug_boot_arg(Some("console=ttyS0".into()), true)
+            .unwrap()
+            .unwrap();
+        assert!(added.contains("memhp_default_state=online_movable"));
+        let unchanged =
+            ensure_memory_hotplug_boot_arg(Some("memhp_default_state=online_movable".into()), true)
+                .unwrap();
+        assert_eq!(
+            unchanged.as_deref(),
+            Some("memhp_default_state=online_movable")
+        );
+        assert!(
+            ensure_memory_hotplug_boot_arg(Some("memhp_default_state=online".into()), true)
+                .is_err()
+        );
+        assert!(ensure_memory_hotplug_boot_arg(
+            Some("memhp_default_state=online_movable memhp_default_state=online_movable".into()),
+            true
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn memory_resize_poll_requires_exact_convergence_and_times_out_partial() {
+        let timeout = Duration::from_secs(1);
+        assert_eq!(
+            evaluate_memory_resize(
+                &memory_status(256, 256),
+                256,
+                Duration::from_millis(10),
+                timeout,
+            ),
+            MemoryResizePoll::Converged
+        );
+        assert_eq!(
+            evaluate_memory_resize(
+                &memory_status(256, 128),
+                256,
+                Duration::from_millis(500),
+                timeout,
+            ),
+            MemoryResizePoll::Pending
+        );
+        assert_eq!(
+            evaluate_memory_resize(&memory_status(256, 128), 256, timeout, timeout,),
+            MemoryResizePoll::TimedOut
+        );
     }
 
     fn overlaybd_config() -> FirecrackerSandboxConfig {

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -33,6 +33,7 @@ pub use firecracker::{
     FirecrackerCapturedSnapshot, FirecrackerCommonConfig, FirecrackerPausedState, FirecrackerPool,
     FirecrackerRuntimePolicy, FirecrackerSandbox, FirecrackerSandboxConfig,
     FirecrackerSandboxFactory, FirecrackerSnapshotConfig, FirecrackerSnapshotManifest,
+    MemoryHotplugStatus, MemoryResizeResult,
 };
 pub(crate) use network::{prepare_runtime as prepare_network_runtime, NetworkManager};
 pub use network::{
@@ -41,6 +42,39 @@ pub use network::{
 };
 pub use process::{Executor, ProcessHandle, ProcessOpts, ProcessOutput};
 pub use ublk::{OverlaybdConfig, UblkBackend, UblkConfig, UblkDaemonConfig, UblkDeviceManager};
+
+#[derive(Debug, thiserror::Error)]
+#[error("memory hotplug is unsupported: {reason}")]
+pub struct MemoryHotplugUnsupported {
+    pub reason: String,
+}
+
+impl MemoryHotplugUnsupported {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum MemoryResizeConvergenceError {
+    #[error("virtio-mem resize to {target_size_mib} MiB timed out and rolled back to {rollback_target_size_mib} MiB")]
+    RolledBack {
+        target_size_mib: u32,
+        rollback_target_size_mib: u32,
+        observed: MemoryHotplugStatus,
+        elapsed_ms: u64,
+    },
+    #[error("virtio-mem resize to {target_size_mib} MiB did not converge and rollback to {rollback_target_size_mib} MiB remains partial: {reason}")]
+    Partial {
+        target_size_mib: u32,
+        rollback_target_size_mib: u32,
+        observed: MemoryHotplugStatus,
+        elapsed_ms: u64,
+        reason: String,
+    },
+}
 
 #[derive(Clone, Debug)]
 pub struct FreshSandboxBuildSpec {


### PR DESCRIPTION
## What

Add hard virtio-mem memory resize support to Firecracker-backed AgentENV
sandboxes.

## Why

AgentENV currently treats sandbox memory as fixed after boot. Firecracker
supports virtio-mem, but AgentENV does not expose a validated or
lifecycle-aware way to grow and shrink guest memory.
## Related issue

## Scope and non-goals

Included:

- Firecracker virtio-mem hard resize.
- Sandbox and orchestrator lifecycle integration.
- Public memory resize and status endpoints.
- Snapshot and legacy manifest compatibility.

## Design and behavior changes

### Public API
The PR adds:
- `GET /sandboxes/{sandboxId}/memory`
- `PATCH /sandboxes/{sandboxId}/memory`
Responses distinguish:
- Requested memory.
- Observed plugged memory.
- Converged state.
- Partial or unknown state.
- Unsupported legacy backends.
- Invalid requests.
- Lifecycle conflicts.
- Gateway timeout.

## Compatibility and operations

<!-- Explain applicable compatibility and deployment impact. Write "N/A" with a reason where appropriate. -->

- Public API or generated protocol:
- Configuration or defaults:
- Snapshot manifest, artifact layout, or storage format:
- Upgrade and rollback:
- Host requirements, permissions, ports, or dependencies:

## Validation

<!-- Check only commands you actually ran. Add focused tests and exact commands below. -->

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text

```

Skipped checks and reasons:

## Risks and reviewer notes

<!-- Identify correctness, security, compatibility, resource, and operational risks. Point reviewers to the most important files or commits. -->

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
