### PR TITLE
fix(overlaybd): preallocate cache blocks to avoid SIGBUS when disk is…

### DIFF
--- a/storage/overlaybd/src/backend/cache/full_file_cache/cache_entry.rs
+++ b/storage/overlaybd/src/backend/cache/full_file_cache/cache_entry.rs
@@ -78,6 +78,64 @@ pub(crate) enum AcquireRefillResult {
 }
 
 // ---------------------------------------------------------------------------
+// Disk range reservation
+// ---------------------------------------------------------------------------
+
+/// Outcome of preallocating a byte range of the sparse data file.
+pub(crate) enum RangeAllocation {
+    /// Disk blocks are reserved; a punch can roll the range back.
+    Reserved,
+    /// The filesystem does not support fallocate; nothing was reserved and
+    /// writes through the mmap keep the pre-reservation behavior.
+    Unsupported,
+}
+
+/// RAII guard for a reserved-but-not-yet-published disk range, returned by
+/// [`CacheEntry::reserve_range`]. Dropping an armed guard punches the range
+/// back to a hole so a failed or cancelled refill leaves no allocated disk
+/// blocks that capacity accounting never saw. Call
+/// [`commit`](Self::commit) once the covered blocks are published.
+pub(crate) struct ReservedRange<'a> {
+    entry: &'a CacheEntry,
+    offset: u64,
+    len: u64,
+    armed: bool,
+}
+
+impl ReservedRange<'_> {
+    /// Keep the reservation. Call this after the covered data is fully
+    /// written and before publishing the blocks in the bitmap, so an armed
+    /// guard never coexists with published blocks.
+    pub(crate) fn commit(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ReservedRange<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Best-effort: the range was never published, so leaving it allocated
+        // only wastes disk until the entry is evicted (whole-file punch).
+        if let Err(err) = nix::fcntl::fallocate(
+            &self.entry.data_file,
+            FallocateFlags::FALLOC_FL_PUNCH_HOLE | FallocateFlags::FALLOC_FL_KEEP_SIZE,
+            self.offset as i64,
+            self.len as i64,
+        ) {
+            tracing::warn!(
+                cache_id = %self.entry.cache_id,
+                offset = self.offset,
+                len = self.len,
+                %err,
+                "failed to punch back reserved cache range"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // AcquireRefillFut — custom Future for block load deduplication
 // ---------------------------------------------------------------------------
 
@@ -284,7 +342,77 @@ impl CacheEntry {
         Ok(Some(Bytes::from_owner(slice)))
     }
 
+    /// Reserve disk blocks for `[offset, offset + len)` of the sparse data
+    /// file before writing through the mmap region.
+    ///
+    /// Writing into an unallocated hole of a shared file mapping makes the
+    /// kernel allocate blocks at page-fault time; if the filesystem is out of
+    /// space that fault fails and the process gets SIGBUS instead of an error
+    /// return. Allocating up front turns disk exhaustion into a plain ENOSPC
+    /// that the refill path can surface, after which reads fall back to the
+    /// source. Filesystems without fallocate support keep the old behavior
+    /// and report [`RangeAllocation::Unsupported`].
+    ///
+    /// Call this directly only when no fallible or cancellable step sits
+    /// between the reservation and publication of the covered blocks;
+    /// otherwise use [`reserve_range`](Self::reserve_range) so a failure
+    /// rolls the reservation back.
+    pub(crate) fn ensure_range_allocated(&self, offset: u64, len: u64) -> Result<RangeAllocation> {
+        if len == 0 {
+            return Ok(RangeAllocation::Unsupported);
+        }
+        // KEEP_SIZE: allocation must never move the file length; the entry is
+        // rejected on reload if the data file size drifts from source_size.
+        match nix::fcntl::fallocate(
+            &self.data_file,
+            FallocateFlags::FALLOC_FL_KEEP_SIZE,
+            offset as i64,
+            len as i64,
+        ) {
+            Ok(()) => Ok(RangeAllocation::Reserved),
+            Err(nix::errno::Errno::EOPNOTSUPP | nix::errno::Errno::ENOSYS) => {
+                Ok(RangeAllocation::Unsupported)
+            }
+            Err(err) => Err(anyhow!(
+                "preallocate cache range failed: offset={offset}, len={len}: {err}"
+            )),
+        }
+    }
+
+    /// Reserve `[offset, offset + len)` and return a guard that punches the
+    /// range back to a hole on drop unless [`ReservedRange::commit`] is
+    /// called first.
+    ///
+    /// Use this when a fallible or cancellable step (such as an async source
+    /// read into the mmap) runs between reservation and publication: the
+    /// guard guarantees a failed refill leaves neither allocated-but-
+    /// unaccounted disk blocks nor partially written pages behind.
+    ///
+    /// # Punch invariant
+    ///
+    /// While the guard is armed, no block overlapping the range may be
+    /// published in the bitmap and the caller must be the sole elected
+    /// loader for every covered block — dropping the guard zeroes the range.
+    pub(crate) fn reserve_range(&self, offset: u64, len: u64) -> Result<ReservedRange<'_>> {
+        let armed = matches!(
+            self.ensure_range_allocated(offset, len)?,
+            RangeAllocation::Reserved
+        );
+        Ok(ReservedRange {
+            entry: self,
+            offset,
+            len,
+            armed,
+        })
+    }
+
     /// Write a block via the mmap region and mark it in the bitmap.
+    ///
+    /// The block's disk range is preallocated first so a full disk surfaces
+    /// as ENOSPC instead of SIGBUS. No rollback is needed: nothing between
+    /// the reservation and the bitmap publication below can fail or be
+    /// cancelled, and callers may overwrite already cached blocks, which a
+    /// punch-based rollback would corrupt.
     ///
     /// # Safety invariant
     /// The acquire/finish refill protocol guarantees at most one writer per
@@ -292,6 +420,7 @@ impl CacheEntry {
     /// writers for the same byte range.
     pub(crate) fn write_block(&self, block_id: u64, data: &[u8]) -> Result<()> {
         let offset = block_id.saturating_mul(self.block_size);
+        self.ensure_range_allocated(offset, data.len() as u64)?;
 
         let buf = unsafe {
             self.mem_region.get_mut(offset, data.len()).ok_or_else(|| {
@@ -368,6 +497,12 @@ impl CacheEntry {
     /// The caller must ensure exclusive access to this block. In the cache
     /// system this is guaranteed by the acquire_refill/finish_refill protocol
     /// (at most one loader per block).
+    ///
+    /// The caller must also reserve the block's disk range first (via
+    /// [`reserve_range`](Self::reserve_range) or
+    /// [`ensure_range_allocated`](Self::ensure_range_allocated)); writing the
+    /// returned slice over an unallocated hole raises SIGBUS when the disk
+    /// is full.
     #[allow(clippy::mut_from_ref)]
     pub(crate) unsafe fn mmap_mut_for_block(
         &self,

--- a/storage/overlaybd/src/backend/cache/full_file_cache/cache_store.rs
+++ b/storage/overlaybd/src/backend/cache/full_file_cache/cache_store.rs
@@ -588,6 +588,13 @@ impl FileCacheBackend {
             return Err(Errno::ENOSPC.into());
         }
 
+        // Reserve the block's disk range up front so writing the mmap below
+        // never allocates at page-fault time (SIGBUS when the disk is full).
+        // The guard punches the range back if the source read fails, is
+        // short, or the future is cancelled, so a failed refill leaves
+        // neither unaccounted disk blocks nor partially written pages.
+        let reservation = entry.reserve_range(offset, want as u64)?;
+
         // The caller holds the entry's refill barrier and passes the stable
         // entry reference. Never look up by cache_id here: that would allow a
         // stale task to populate a replacement entry after an ABA recycle.
@@ -608,6 +615,10 @@ impl FileCacheBackend {
                 "short refill read for cache_id={cache_id}, offset={offset}, got {n}, want {buf_len}"
             );
         }
+
+        // Commit before publishing: prevent RAII from punching holes in case
+        // of error (rollback).
+        reservation.commit();
 
         // Just update the bitmap — data is already in place via mmap.
         entry.mark_block_cached(block_id);
@@ -709,7 +720,6 @@ impl FileCacheBackend {
             entry.set_source_size(new_size)?;
         }
 
-        let mut bytes_added = 0u64;
         for block_id in start_block..=end_block {
             let block_start = block_id.saturating_mul(block_size);
             let in_write_start = offset.max(block_start);
@@ -767,16 +777,14 @@ impl FileCacheBackend {
             let was_cached = entry.index.read().contains(block_id as u32);
             entry.write_block(block_id, &block[..valid])?;
             if !was_cached {
-                bytes_added += valid as u64;
+                // Account immediately after each publication: an error on a
+                // later block (source read, reservation) must not leave the
+                // bytes already visible in the bitmap untracked.
+                self.add_current_bytes(valid as u64);
             }
         }
 
         entry.record_refill();
-
-        // Update global capacity and pressure state atomically as a pair.
-        if bytes_added > 0 {
-            self.add_current_bytes(bytes_added);
-        }
 
         // Trigger eviction check asynchronously.
         self.eviction_inner().await;
@@ -1159,6 +1167,13 @@ impl CachedFile {
             n as u64 == read_len,
             "short background chunk read at offset {offset}: got {n}, want {read_len}"
         );
+        // No rollback guard is needed: nothing past this point awaits or fails.
+        // Reserve the whole run before publishing any block: the mmap copies
+        // below must never allocate at page-fault time (SIGBUS when the disk
+        // is full), and a reservation failure returns before the first
+        // publication so the batched accounting below stays consistent.
+        entry.ensure_range_allocated(offset, read_len)?;
+
         let mut committed = 0u64;
         for (block_id, guard) in run {
             let want = source_size

--- a/storage/overlaybd/src/backend/cache/tests.rs
+++ b/storage/overlaybd/src/backend/cache/tests.rs
@@ -2669,3 +2669,100 @@ async fn test_eviction_clears_bitmap_before_destroying_data() {
         "reads after a failed eviction must fall back to the source"
     );
 }
+
+#[tokio::test]
+async fn test_reserve_range_guard_punches_unless_committed() {
+    use std::os::unix::fs::MetadataExt;
+
+    let tmp = tempdir().expect("create tempdir");
+    let mut options = test_options(tmp.path());
+    options.block_size = 4096;
+    let backend = FileCacheBackend::with_options(options)
+        .await
+        .expect("backend");
+    let source = Arc::new(ControlledSource::new(vec![1u8; 8192], 4096));
+    let _file = backend
+        .open_file_with_source_size("reserve-guard", source, 8192)
+        .await
+        .expect("open cached file");
+    let entry = backend
+        .get_cache_entry(&super::cache_key_digest("reserve-guard"))
+        .expect("entry");
+    let data_path = entry.paths.data_path.clone();
+    let allocated_blocks = move || {
+        std::fs::metadata(&data_path)
+            .expect("stat cache data file")
+            .blocks()
+    };
+
+    let baseline = allocated_blocks();
+    let reservation = entry.reserve_range(0, 4096).expect("reserve");
+    if allocated_blocks() == baseline {
+        // Filesystem without fallocate support: reservation and punch are
+        // no-ops and there is nothing further to verify.
+        return;
+    }
+
+    drop(reservation);
+    assert_eq!(
+        allocated_blocks(),
+        baseline,
+        "dropping an uncommitted reservation must punch the range back"
+    );
+
+    entry.reserve_range(0, 4096).expect("reserve").commit();
+    assert!(
+        allocated_blocks() > baseline,
+        "a committed reservation must keep the disk blocks"
+    );
+}
+
+#[tokio::test]
+async fn test_failed_foreground_refill_leaves_no_reserved_blocks() {
+    use std::os::unix::fs::MetadataExt;
+
+    let tmp = tempdir().expect("create tempdir");
+    let mut options = test_options(tmp.path());
+    options.block_size = 4096;
+    let backend = FileCacheBackend::with_options(options)
+        .await
+        .expect("backend");
+    let payload = uniform_char_random_data(8192, 42);
+    let source = Arc::new(ControlledSource::new(payload.clone(), 4096));
+    // Fail the refill's source read once; the foreground read then falls
+    // back to a second, successful source read.
+    source.fail_block(0, 1);
+    let file = backend
+        .open_file_with_source_size("refill-rollback", source.clone(), payload.len() as u64)
+        .await
+        .expect("open cached file");
+
+    let bytes = file
+        .read_at(0, 4096)
+        .await
+        .expect("read must fall back to the source after the failed refill");
+    assert_eq!(bytes.as_ref(), &payload[..4096]);
+    assert_eq!(source.calls(0), 2, "refill attempt plus fallback read");
+
+    // The failed refill must neither publish the block nor account bytes...
+    let stats = backend.file_stats("refill-rollback").expect("file stats");
+    assert_eq!(stats.bytes_used, 0, "failed refill must not publish blocks");
+    assert_eq!(
+        backend.stats().bytes_used,
+        0,
+        "failed refill must not change capacity accounting"
+    );
+
+    // ...and must roll its reservation back: no allocated disk blocks may
+    // remain in the sparse data file.
+    let entry = backend
+        .get_cache_entry(&super::cache_key_digest("refill-rollback"))
+        .expect("entry");
+    assert_eq!(
+        std::fs::metadata(&entry.paths.data_path)
+            .expect("stat cache data file")
+            .blocks(),
+        0,
+        "failed refill must leave the data file fully sparse"
+    );
+}


### PR DESCRIPTION
## What

Reserve the block's byte range with fallocate(FALLOC_FL_KEEP_SIZE) before handing out mmap write access (write_block and mmap_mut_for_block). Disk exhaustion now surfaces as a plain ENOSPC refill error, and reads fall back to the source exactly like the existing cache-capacity-full path. Filesystems without fallocate support (EOPNOTSUPP/ENOSYS) keep the previous behavior.

## Why

The full-file cache writes refilled blocks through a shared mmap over a sparse data file. Writing into an unallocated hole makes the kernel allocate filesystem blocks at page-fault time; when the local disk is full that allocation fails and the process is killed with SIGBUS, taking down the whole ublk-daemon.

## Design and behavior changes

Before write into mmap region of cache files, an extra `fallocate` syscall will be invoked.

## Validation

<!-- Check only commands you actually ran. Add focused tests and exact commands below. -->

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed


## Checklist

- [ ] The PR contains one coherent change and no unrelated formatting or refactoring.
- [ ] New behavior is covered by tests, or I explained why testing is impractical.
- [ ] Logs and examples contain no credentials, tokens, or private registry information.
- [ ] I did not manually edit generated code without updating its source and regenerating it.
