### PR TITLE
fix(tools): defer var/run creation until after pivot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - "scripts/tests/setup-ublk-access.sh"
       - "scripts/tests/verify-capability-runner.sh"
       - "scripts/tests/verify-install-service.sh"
+      - "scripts/tests/verify-tools-init.sh"
+      - "tools-image/init"
+      - "tools-image/pivot-init"
       - ".github/actions/**"
       - ".github/workflows/ci.yml"
   push:
@@ -28,6 +31,9 @@ on:
       - "scripts/tests/setup-ublk-access.sh"
       - "scripts/tests/verify-capability-runner.sh"
       - "scripts/tests/verify-install-service.sh"
+      - "scripts/tests/verify-tools-init.sh"
+      - "tools-image/init"
+      - "tools-image/pivot-init"
       - ".github/actions/**"
       - ".github/workflows/ci.yml"
 

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ test-unit:
 	$(CAPABILITY_TEST_ENV) $(CAPABILITY_RUNNER) $(CARGO) test -p uvm-ublk -p uvm-ublk-daemon --lib
 	bash scripts/tests/verify-capability-runner.sh
 	bash scripts/tests/verify-install-service.sh
+	bash scripts/tests/verify-tools-init.sh
 
 test-integration: test-agent-integration test-envd test-ublk
 

--- a/scripts/tests/verify-tools-init.sh
+++ b/scripts/tests/verify-tools-init.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+init_script="${repo_root}/tools-image/init"
+pivot_init_script="${repo_root}/tools-image/pivot-init"
+
+bash -n "$init_script"
+bash -n "$pivot_init_script"
+
+# Inspect executable source through the root switch, excluding comments that
+# document paths which must not be traversed at this stage.
+# Pattern matches literal shell source.
+# shellcheck disable=SC2016
+pre_pivot_script=$(sed -n '1,/^\$BB pivot_root /p' "$init_script")
+pre_pivot_commands=$(sed '/^[[:space:]]*#/d' <<<"$pre_pivot_script")
+
+# Absolute symlinks in the user image resolve against the tools root before
+# pivot_root. Only prepare the real /run directory at this stage; pivot-init
+# handles /var/run once absolute symlinks resolve inside the user root.
+if grep -Fq '/mnt/user/var/run' <<<"$pre_pivot_commands"; then
+  echo 'pre-pivot bootstrap must not traverse /mnt/user/var/run' >&2
+  exit 1
+fi
+grep -Fq '/mnt/user/run' <<<"$pre_pivot_commands"
+
+# Pattern matches literal shell source.
+# shellcheck disable=SC2016
+grep -Fq '$BB mkdir -p /var/run /tmp /var/log/agentenv/envd /run/sv/envd/log' \
+  "$pivot_init_script"

--- a/tools-image/init
+++ b/tools-image/init
@@ -23,13 +23,15 @@ $BB mount -n -o rw /dev/vdb /mnt/user || die "mount /dev/vdb"
 
 # Minimal user images may not ship the directories that become mount targets
 # after pivot_root. Create them on the mounted user rootfs before switching.
+# Do not touch /mnt/user/var/run here. Some distributions make it an absolute
+# symlink to /run, which would resolve against the tools root before the pivot.
+# pivot-init prepares /var/run after the root switch instead.
 $BB mkdir -p \
     /mnt/user/proc \
     /mnt/user/dev \
     /mnt/user/sys \
     /mnt/user/run \
     /mnt/user/tmp \
-    /mnt/user/var/run \
     /mnt/user/var/log/agentenv \
     /mnt/user/agentenv
 $BB chmod 1777 /mnt/user/tmp 2>/dev/null || true


### PR DESCRIPTION
Fixes #202

## Summary

- stop traversing `/mnt/user/var/run` before `pivot_root`
- keep the real `/mnt/user/run` preparation and let `pivot-init` create `/var/run` after the root switch
- add a regression check to `make test-unit` and cover both init scripts in the CI path filters

## Why

Some distribution images, including Ubuntu, provide `/var/run` as an absolute symlink to `/run`. Before `pivot_root`, following that symlink resolves against the tools-drive root instead of the mounted user root and produces the deterministic bootstrap warning reported in #202.

`pivot-init` already creates and mounts `/run`, then prepares `/var/run` after the root switch. Deferring this redundant directory preparation therefore fixes absolute-symlink resolution without distro detection or image-specific behavior.

## Validation

- `bash scripts/tests/verify-tools-init.sh`
- `shellcheck tools-image/init tools-image/pivot-init scripts/tests/verify-tools-init.sh`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Release note

This updates the tools-image source. After merge, a new immutable `ghcr.io/kvcache-ai/agentenv-tools` version still needs to be published and selected in `config/deps_manifest.toml`; the existing `0.1.0` artifact will not contain the change.