### PR TITLE
feat(overlaybd): port the crate to macOS behind a platform sys module

### DIFF
--- a/storage/overlaybd/src/backend/cache/cached_fs.rs
+++ b/storage/overlaybd/src/backend/cache/cached_fs.rs
@@ -17,6 +17,7 @@ use crate::backend::local::LocalFile;
 use crate::io::virtual_file::VirtualFile;
 #[cfg(feature = "io-uring")]
 use crate::io::virtual_file::{IoCtx, LocalBoxFuture};
+use crate::sys;
 
 #[async_trait]
 pub trait CachedFsSource: Send + Sync {
@@ -226,99 +227,28 @@ impl CachedFsSource for LocalFsSource {
         let path = self.resolve_path(path);
         let cpath = Self::path_to_cstring(&path)?;
         let cname = CString::new(name).context("xattr name contains interior NUL byte")?;
-        // SAFETY: pointers are valid; null destination with 0 length queries size.
-        let need =
-            unsafe { libc::getxattr(cpath.as_ptr(), cname.as_ptr(), std::ptr::null_mut(), 0) };
-        if need < 0 {
-            return Err(Errno::last().into());
-        }
-        let need = usize::try_from(need).context("xattr length overflow")?;
-        let mut out = vec![0u8; need];
-        // SAFETY: destination is valid for `need` bytes; pointers remain valid.
-        let got = unsafe {
-            libc::getxattr(
-                cpath.as_ptr(),
-                cname.as_ptr(),
-                out.as_mut_ptr() as *mut libc::c_void,
-                need,
-            )
-        };
-        if got < 0 {
-            return Err(Errno::last().into());
-        }
-        let got = usize::try_from(got).context("xattr length overflow")?;
-        out.truncate(got);
-        Ok(out)
+        sys::getxattr(&cpath, &cname).with_context(|| format!("getxattr {name} on {path:?}"))
     }
 
     async fn listxattr(&self, path: &str) -> Result<Vec<String>> {
         let path = self.resolve_path(path);
         let cpath = Self::path_to_cstring(&path)?;
-        // SAFETY: pointers are valid; null destination with 0 length queries size.
-        let need = unsafe { libc::listxattr(cpath.as_ptr(), std::ptr::null_mut(), 0) };
-        if need < 0 {
-            return Err(Errno::last().into());
-        }
-        let need = usize::try_from(need).context("xattr list length overflow")?;
-        if need == 0 {
-            return Ok(Vec::new());
-        }
-
-        let mut buf = vec![0u8; need];
-        // SAFETY: destination is valid for `need` bytes; pointers remain valid.
-        let got =
-            unsafe { libc::listxattr(cpath.as_ptr(), buf.as_mut_ptr() as *mut libc::c_char, need) };
-        if got < 0 {
-            return Err(Errno::last().into());
-        }
-        let got = usize::try_from(got).context("xattr list length overflow")?;
-        buf.truncate(got);
-
-        let mut names = Vec::new();
-        let mut begin = 0usize;
-        while begin < buf.len() {
-            let Some(end_rel) = buf[begin..].iter().position(|b| *b == 0) else {
-                break;
-            };
-            if end_rel > 0 {
-                let end = begin + end_rel;
-                names.push(String::from_utf8_lossy(&buf[begin..end]).to_string());
-            }
-            begin += end_rel + 1;
-        }
-        Ok(names)
+        sys::listxattr(&cpath).with_context(|| format!("listxattr on {path:?}"))
     }
 
     async fn setxattr(&self, path: &str, name: &str, value: &[u8], flags: i32) -> Result<()> {
         let path = self.resolve_path(path);
         let cpath = Self::path_to_cstring(&path)?;
         let cname = CString::new(name).context("xattr name contains interior NUL byte")?;
-        // SAFETY: pointers are valid for the provided lengths and remain live during call.
-        let ret = unsafe {
-            libc::setxattr(
-                cpath.as_ptr(),
-                cname.as_ptr(),
-                value.as_ptr() as *const libc::c_void,
-                value.len(),
-                flags,
-            )
-        };
-        if ret == 0 {
-            return Ok(());
-        }
-        Err(Errno::last().into())
+        sys::setxattr(&cpath, &cname, value, flags)
+            .with_context(|| format!("setxattr {name} on {path:?}"))
     }
 
     async fn removexattr(&self, path: &str, name: &str) -> Result<()> {
         let path = self.resolve_path(path);
         let cpath = Self::path_to_cstring(&path)?;
         let cname = CString::new(name).context("xattr name contains interior NUL byte")?;
-        // SAFETY: pointers are valid and remain live during call.
-        let ret = unsafe { libc::removexattr(cpath.as_ptr(), cname.as_ptr()) };
-        if ret == 0 {
-            return Ok(());
-        }
-        Err(Errno::last().into())
+        sys::removexattr(&cpath, &cname).with_context(|| format!("removexattr {name} on {path:?}"))
     }
 }
 

--- a/storage/overlaybd/src/backend/cache/full_file_cache/cache_entry.rs
+++ b/storage/overlaybd/src/backend/cache/full_file_cache/cache_entry.rs
@@ -1,11 +1,14 @@
 use anyhow::{anyhow, bail, Result};
+// Aliased to `_`: the trait methods are what we want, and the name `Context` is
+// already taken by `std::task::Context` below.
+use anyhow::Context as _;
 use bytes::Bytes;
-use nix::fcntl::FallocateFlags;
 use parking_lot::{Mutex, RwLock};
 use roaring::RoaringBitmap;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::future::Future;
+use std::os::fd::AsFd;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -16,6 +19,7 @@ use super::super::meta::{
     fsync, now_unix_nanos, BlockLoadState, CacheMetaDisk, CacheMetaDiskHeader, EntryPaths,
 };
 use super::cache_pool::FileCacheBackendOptions;
+use crate::sys;
 use storage_util::MMapRegion;
 
 /// The core per-cache-entry object. One per remote file (keyed by cache_id).
@@ -85,8 +89,11 @@ pub(crate) enum AcquireRefillResult {
 pub(crate) enum RangeAllocation {
     /// Disk blocks are reserved; a punch can roll the range back.
     Reserved,
-    /// The filesystem does not support fallocate; nothing was reserved and
-    /// writes through the mmap keep the pre-reservation behavior.
+    /// The platform or filesystem cannot reserve a range; nothing was reserved
+    /// and writes through the mmap keep the pre-reservation behavior — meaning
+    /// the SIGBUS-on-full-disk hazard this reservation exists to remove is
+    /// still present. This is the case on **all** of macOS, not just exotic
+    /// filesystems; see [`sys::reserve_space`] for why.
     Unsupported,
 }
 
@@ -95,6 +102,10 @@ pub(crate) enum RangeAllocation {
 /// back to a hole so a failed or cancelled refill leaves no allocated disk
 /// blocks that capacity accounting never saw. Call
 /// [`commit`](Self::commit) once the covered blocks are published.
+///
+/// The guard is armed only when the reservation actually happened, so on a
+/// platform reporting [`RangeAllocation::Unsupported`] the whole mechanism is
+/// inert — including the partially-written-page cleanup it provides on drop.
 pub(crate) struct ReservedRange<'a> {
     entry: &'a CacheEntry,
     offset: u64,
@@ -118,12 +129,9 @@ impl Drop for ReservedRange<'_> {
         }
         // Best-effort: the range was never published, so leaving it allocated
         // only wastes disk until the entry is evicted (whole-file punch).
-        if let Err(err) = nix::fcntl::fallocate(
-            &self.entry.data_file,
-            FallocateFlags::FALLOC_FL_PUNCH_HOLE | FallocateFlags::FALLOC_FL_KEEP_SIZE,
-            self.offset as i64,
-            self.len as i64,
-        ) {
+        if let Err(err) =
+            sys::release_space_hint(self.entry.data_file.as_fd(), self.offset, self.len)
+        {
             tracing::warn!(
                 cache_id = %self.entry.cache_id,
                 offset = self.offset,
@@ -350,8 +358,9 @@ impl CacheEntry {
     /// space that fault fails and the process gets SIGBUS instead of an error
     /// return. Allocating up front turns disk exhaustion into a plain ENOSPC
     /// that the refill path can surface, after which reads fall back to the
-    /// source. Filesystems without fallocate support keep the old behavior
-    /// and report [`RangeAllocation::Unsupported`].
+    /// source. Platforms and filesystems that cannot reserve a range keep the
+    /// old behavior and report [`RangeAllocation::Unsupported`]; that covers
+    /// all of macOS, so this protection is Linux-only in practice.
     ///
     /// Call this directly only when no fallible or cancellable step sits
     /// between the reservation and publication of the covered blocks;
@@ -361,18 +370,16 @@ impl CacheEntry {
         if len == 0 {
             return Ok(RangeAllocation::Unsupported);
         }
-        // KEEP_SIZE: allocation must never move the file length; the entry is
-        // rejected on reload if the data file size drifts from source_size.
-        match nix::fcntl::fallocate(
-            &self.data_file,
-            FallocateFlags::FALLOC_FL_KEEP_SIZE,
-            offset as i64,
-            len as i64,
-        ) {
+        // The reservation never moves the file length; the entry is rejected on
+        // reload if the data file size drifts from source_size.
+        match sys::reserve_space(self.data_file.as_fd(), offset, len) {
             Ok(()) => Ok(RangeAllocation::Reserved),
-            Err(nix::errno::Errno::EOPNOTSUPP | nix::errno::Errno::ENOSYS) => {
-                Ok(RangeAllocation::Unsupported)
-            }
+            // The platform or filesystem cannot reserve a range. Not an error:
+            // the caller has to keep working without a reservation, which is
+            // the pre-reservation behavior. Whole platforms land here — macOS
+            // has no interior-range equivalent of `fallocate` at all — so
+            // failing instead would break every refill there.
+            Err(err) if err.is_unsupported() => Ok(RangeAllocation::Unsupported),
             Err(err) => Err(anyhow!(
                 "preallocate cache range failed: offset={offset}, len={len}: {err}"
             )),
@@ -469,12 +476,12 @@ impl CacheEntry {
                 Err(err) => return Err(err.into()),
             }
             if source_size > 0 {
-                nix::fcntl::fallocate(
-                    &data_file,
-                    FallocateFlags::FALLOC_FL_PUNCH_HOLE | FallocateFlags::FALLOC_FL_KEEP_SIZE,
-                    0,
-                    source_size as i64,
-                )?;
+                // The bitmap was cleared above, so the bytes are already
+                // logically gone; this is purely about getting the disk space
+                // back. Failure still propagates: an eviction that cannot
+                // reclaim must not look like it succeeded.
+                sys::release_space_hint(data_file.as_fd(), 0, source_size)
+                    .with_context(|| format!("release {source_size} cached bytes"))?;
             }
             Ok(())
         })

--- a/storage/overlaybd/src/backend/cache/full_file_cache/cache_pool.rs
+++ b/storage/overlaybd/src/backend/cache/full_file_cache/cache_pool.rs
@@ -10,13 +10,11 @@ use super::cache_store::CachedFile;
 use crate::config::CacheConfig;
 use crate::io::virtual_file::VirtualFile;
 use crate::lsmt::file::PREMERGED_INDEX_DIR;
-use anyhow::{anyhow, bail, Context, Result};
+use crate::sys;
+use anyhow::{anyhow, bail, Result};
 use dashmap::DashMap;
-use nix::errno::Errno;
 use parking_lot::{Mutex, RwLock};
-use std::ffi::CString;
-use std::os::unix::ffi::OsStrExt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use tokio::sync::Notify;
@@ -446,33 +444,20 @@ impl FileCacheBackend {
         Self::risk_mark_for_options(&self.options)
     }
 
-    fn statvfs_for_path(path: &Path) -> Result<libc::statvfs> {
-        let cpath =
-            CString::new(path.as_os_str().as_bytes()).context("path contains interior NUL byte")?;
-        let mut st = std::mem::MaybeUninit::<libc::statvfs>::uninit();
-        let ret = unsafe { libc::statvfs(cpath.as_ptr(), st.as_mut_ptr()) };
-        if ret != 0 {
-            return Err(Errno::last().into());
-        }
-        Ok(unsafe { st.assume_init() })
-    }
-
     fn capture_disk_pressure(options: &FileCacheBackendOptions) -> DiskPressureSnapshot {
         let water_mark = Self::calc_water_mark(options.capacity_bytes);
-        let Ok(st) = Self::statvfs_for_path(&options.cache_dir) else {
+        let Ok(space) = sys::fs_space(&options.cache_dir) else {
             return DiskPressureSnapshot::default();
         };
-        let fs_capacity = st.f_frsize.saturating_mul(st.f_blocks);
-        let disk_avail = st.f_bavail.saturating_mul(st.f_frsize);
-        if disk_avail < DEFAULT_DISK_AVAIL_BYTES {
+        if space.avail_bytes < DEFAULT_DISK_AVAIL_BYTES {
             DiskPressureSnapshot {
-                evict_bytes: DEFAULT_DISK_AVAIL_BYTES.saturating_sub(disk_avail),
+                evict_bytes: DEFAULT_DISK_AVAIL_BYTES.saturating_sub(space.avail_bytes),
                 suppress_cache_pressure: false,
             }
         } else {
             DiskPressureSnapshot {
                 evict_bytes: 0,
-                suppress_cache_pressure: fs_capacity <= water_mark,
+                suppress_cache_pressure: space.capacity_bytes <= water_mark,
             }
         }
     }

--- a/storage/overlaybd/src/backend/cache/full_file_cache/cache_store.rs
+++ b/storage/overlaybd/src/backend/cache/full_file_cache/cache_store.rs
@@ -942,6 +942,16 @@ impl FileCacheBackend {
 // CachedFile — per-open handle (unchanged public API)
 // ---------------------------------------------------------------------------
 
+/// What [`CachedFile::fadvise`] should do with a range.
+///
+/// Deliberately not a `libc` advice value: `POSIX_FADV_*` does not exist on
+/// Darwin, and the method only ever accepted one of them anyway.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheAdvice {
+    /// Pull the range into the local cache now.
+    WillNeed,
+}
+
 pub struct CachedFile {
     pub(crate) backend: FileCacheBackend,
     pub(crate) source: Arc<RwLock<Option<Arc<dyn VirtualFile>>>>,
@@ -1272,9 +1282,16 @@ impl CachedFile {
         self.try_refill_range(offset, count).await
     }
 
-    pub async fn fadvise(&self, offset: u64, len: u64, advice: i32) -> Result<()> {
-        if advice != libc::POSIX_FADV_WILLNEED {
-            bail!("advice {advice} is not supported");
+    /// Prefetch `[offset, offset + len)` into the local cache.
+    ///
+    /// Despite the name this never calls `posix_fadvise`; it refills cache
+    /// blocks from the source. It used to take a raw `libc` advice value and
+    /// reject anything but `POSIX_FADV_WILLNEED`, which both leaked a
+    /// Linux-only constant into the signature and misdescribed the behaviour.
+    /// [`CacheAdvice`] names the one thing that was ever accepted.
+    pub async fn fadvise(&self, offset: u64, len: u64, advice: CacheAdvice) -> Result<()> {
+        match advice {
+            CacheAdvice::WillNeed => {}
         }
 
         let page_size = 4096;

--- a/storage/overlaybd/src/backend/cache/mod.rs
+++ b/storage/overlaybd/src/backend/cache/mod.rs
@@ -16,7 +16,10 @@ pub use full_file_cache::cache_pool::{
     CacheListType, CachePoolStat, CacheStats, CachedFileStats, FileCacheBackend,
     FileCacheBackendOptions,
 };
-pub use full_file_cache::cache_store::CachedFile;
+// `CacheAdvice` is re-exported alongside `CachedFile` because it is the argument
+// type of the public `CachedFile::fadvise`: without it here, that method cannot
+// be called from outside the crate at all, since `full_file_cache` is private.
+pub use full_file_cache::cache_store::{CacheAdvice, CachedFile};
 
 const GIB: u64 = 1024 * 1024 * 1024;
 const META_MAGIC: u32 = 0x4f42_4348; // "OBCH"

--- a/storage/overlaybd/src/backend/cache/tests.rs
+++ b/storage/overlaybd/src/backend/cache/tests.rs
@@ -1,6 +1,8 @@
 use super::super::local::LocalFile;
 use super::*;
+use crate::backend::cache::full_file_cache::cache_store::CacheAdvice;
 use crate::io::virtual_file::VirtualFile;
+use crate::sys;
 use anyhow::{bail, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -1456,14 +1458,14 @@ async fn test_ro_cached_fs_basic() {
     assert_eq!(prefetched.as_ref(), &payload[page_size..page_size * 3]);
 
     cached
-        .fadvise(234, (5000 * page_size) as u64, libc::POSIX_FADV_WILLNEED)
+        .fadvise(234, (5000 * page_size) as u64, CacheAdvice::WillNeed)
         .await
         .expect("fadvise large prefetch");
     cached
         .fadvise(
             (aligned_size - page_size) as u64,
             (5000 * page_size) as u64,
-            libc::POSIX_FADV_WILLNEED,
+            CacheAdvice::WillNeed,
         )
         .await
         .expect("fadvise tail prefetch");
@@ -1609,38 +1611,27 @@ async fn test_ro_cached_fs_xattr() {
     let name = CString::new("user.testxattr").expect("name cstr");
     let value = b"yes";
 
-    unsafe {
-        // SAFETY: pointers are valid and lengths are exact for libc xattr calls.
-        let ret = libc::setxattr(
-            path_c.as_ptr(),
-            name.as_ptr(),
-            value.as_ptr() as *const libc::c_void,
-            value.len(),
-            0,
-        );
-        if ret != 0 {
-            let err = Errno::last();
-            let unsupported = err == Errno::ENOTSUP
-                || (libc::EOPNOTSUPP != libc::ENOTSUP && err == Errno::EOPNOTSUPP);
-            if unsupported {
-                return;
-            }
+    // Set the attribute out of band so the cached-fs layer has a real one to
+    // read back. Going through `crate::sys` rather than raw libc keeps this
+    // portable and drops the `unsafe` block.
+    if let Err(err) = sys::setxattr(&path_c, &name, value, 0) {
+        let sys::SysError::Errno(errno) = err else {
             panic!("setxattr failed: {err}");
+        };
+        // Compared rather than matched: `ENOTSUP` and `EOPNOTSUPP` share a value
+        // on Linux, so listing both as match arms would be an unreachable arm
+        // there while still being two distinct codes elsewhere.
+        if errno == Errno::ENOTSUP || errno == Errno::EOPNOTSUPP {
+            // This filesystem has no xattr support; nothing to exercise.
+            return;
         }
-
-        let mut out = [0u8; 32];
-        let got = libc::getxattr(
-            path_c.as_ptr(),
-            name.as_ptr(),
-            out.as_mut_ptr() as *mut libc::c_void,
-            out.len(),
-        );
-        assert_eq!(got as usize, value.len());
-        assert_eq!(&out[..value.len()], value);
-
-        let ret = libc::removexattr(path_c.as_ptr(), name.as_ptr());
-        assert_eq!(ret, 0);
+        panic!("setxattr failed: {errno}");
     }
+
+    let got = sys::getxattr(&path_c, &name).expect("getxattr");
+    assert_eq!(got, value);
+
+    sys::removexattr(&path_c, &name).expect("removexattr");
 
     let source = Arc::new(LocalFile::open_rw(&path, false).expect("open source"));
     let backend = FileCacheBackend::with_options(test_options(tmp.path()))

--- a/storage/overlaybd/src/backend/local.rs
+++ b/storage/overlaybd/src/backend/local.rs
@@ -6,7 +6,7 @@ use std::cmp::min;
 use std::ffi::CString;
 use std::fmt;
 use std::fs::{File, OpenOptions};
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd};
 use std::os::unix::fs::{FileExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use crate::io::virtual_file::VirtualFile;
 #[cfg(feature = "io-uring")]
 use crate::io::virtual_file::{IoCtx, LocalBoxFuture};
+use crate::sys;
 #[cfg(feature = "io-uring")]
 use storage_util::io_ring::{self, IoUringSubmitter};
 use storage_util::AlignedBuffer;
@@ -106,11 +107,24 @@ impl LocalFileBuilder {
             .create(self.create)
             .truncate(self.truncate)
             .mode(self.mode);
+
         if self.direct_io {
-            options.custom_flags(libc::O_DIRECT);
+            if let Some(flag) = sys::direct_io_open_flag() {
+                options.custom_flags(flag);
+            }
         }
 
         let file = options.open(&path)?;
+        if self.direct_io {
+            // Platforms with no open-time flag finish the job here (macOS
+            // `fcntl(F_NOCACHE)`). Propagating the failure rather than quietly
+            // handing back a cached file keeps `direct_io(true)` meaning one
+            // thing everywhere, including the alignment rules enforced in
+            // `write_at_sync`.
+            sys::enable_direct_io(&file)
+                .with_context(|| format!("enable direct io on {}", path.display()))?;
+        }
+
         Ok(LocalFile {
             inner: Arc::new(LocalFileInner {
                 path,
@@ -241,33 +255,6 @@ impl LocalFileInner {
 
     fn to_off_t(offset: u64) -> Result<libc::off_t> {
         libc::off_t::try_from(offset).context(format!("offset {offset} does not fit in off_t"))
-    }
-
-    fn posix_fadvise_dontneed(fd: i32, offset: u64, len: u64) -> Result<()> {
-        let offset = Self::to_off_t(offset)?;
-        let len = Self::to_off_t(len)?;
-        let ret = unsafe { libc::posix_fadvise(fd, offset, len, libc::POSIX_FADV_DONTNEED) };
-        if ret == 0 {
-            return Ok(());
-        }
-        Err(Errno::from_raw(ret).into())
-    }
-
-    fn punch_hole_keep_size(fd: i32, offset: u64, len: u64) -> Result<()> {
-        let offset = Self::to_off_t(offset)?;
-        let len = Self::to_off_t(len)?;
-        let ret = unsafe {
-            libc::fallocate(
-                fd,
-                libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE,
-                offset,
-                len,
-            )
-        };
-        if ret == 0 {
-            return Ok(());
-        }
-        Err(Errno::last().into())
     }
 
     /// Read as most `buf.len()` bytes into `buf`.
@@ -737,36 +724,51 @@ impl VirtualFile for LocalFile {
         Ok(Some(val))
     }
 
-    /// Offloaded: `FALLOC_FL_PUNCH_HOLE` is real filesystem work (freeing
-    /// extents plus a journal commit), not a hint, and it sits on a
-    /// guest-triggerable path — a guest `fstrim` reaches here in a loop from
+    /// Offloaded: releasing space is real filesystem work — on Linux, freeing
+    /// extents plus a journal commit — not a hint, and it sits on a
+    /// guest-triggerable path: a guest `fstrim` reaches here in a loop from
     /// `LSMTFile::discard_range`. Inline it would stall every in-flight I/O on
     /// the ublk queue thread.
     ///
     /// The yield point this adds only widens an existing window:
     /// `discard_range` takes the index write lock *after* this call returns, so
-    /// a concurrent read could already see the punched-but-not-yet-remapped
-    /// range. Such a read resolves through the old mapping into the punched
-    /// region and gets zeros, which is what a completed discard means anyway.
+    /// a concurrent read can already resolve through the pre-discard mapping.
+    /// What it finds there is unspecified — Linux's punch zeroes the range,
+    /// macOS's `F_PUNCHHOLE` does not — but a read racing an in-flight discard
+    /// has no defined result either way.
     async fn discard(&self, offset: u64, len: u64) -> Result<()> {
         if len == 0 {
             return Ok(());
         }
+        // A hint about space only: it makes no promise that the range reads back
+        // as zeros, and a range too small to cover a block releases nothing and
+        // still succeeds. Real syscall failures are still propagated, unlike the
+        // eviction hints below.
         self.offload("discard", move |inner| {
-            LocalFileInner::punch_hole_keep_size(inner.file.as_raw_fd(), offset, len)
+            sys::release_space_hint(inner.file.as_fd(), offset, len)
+                .with_context(|| format!("discard {len} bytes at offset {offset}"))
         })
         .await
     }
 
-    /// Offloaded: `POSIX_FADV_DONTNEED` is a hint, but servicing it still walks
-    /// the page cache over the range and can queue behind writeback of any
-    /// dirty page it finds. No caller is on a hot path — the only in-tree ones
-    /// are the ZFile checksum/decompress retry branches — so the offload costs
-    /// nothing. Awaiting it keeps the ordering those retries rely on: the
+    /// Offloaded: dropping page-cache residency is advisory, but servicing it
+    /// still walks the cache over the range and can queue behind writeback of
+    /// any dirty page it finds. No caller is on a hot path — the only in-tree
+    /// ones are the ZFile checksum/decompress retry branches — so the offload
+    /// costs nothing. Awaiting it keeps the ordering those retries rely on: the
     /// eviction completes before the range is re-read.
     async fn evict_range(&self, offset: u64, len: u64) -> Result<()> {
         self.offload("evict_range", move |inner| {
-            LocalFileInner::posix_fadvise_dontneed(inner.file.as_raw_fd(), offset, len)
+            match sys::evict_page_cache(inner.file.as_fd(), offset, len) {
+                // Advisory, so an unsupported platform is not a failure: dropping
+                // cache residency never changes what a read returns. It has to be
+                // swallowed rather than propagated because `zfile` calls
+                // `evict_range`/`evict_all` with `?` while writing, so turning "this
+                // platform has no posix_fadvise" into an error would break ZFile
+                // writes on macOS outright. Real errno failures still propagate.
+                Err(err) if err.is_unsupported() => Ok(()),
+                other => other.map_err(Into::into),
+            }
         })
         .await
     }
@@ -775,96 +777,36 @@ impl VirtualFile for LocalFile {
     /// `len == 0` means "to end of file", so this walks the page cache of an
     /// entire layer file.
     async fn evict_all(&self) -> Result<()> {
+        // A zero length means "through end of file". Unsupported is swallowed for
+        // the same reason as in `evict_range`.
         self.offload("evict_all", |inner| {
-            LocalFileInner::posix_fadvise_dontneed(inner.file.as_raw_fd(), 0, 0)
+            match sys::evict_page_cache(inner.file.as_fd(), 0, 0) {
+                Err(err) if err.is_unsupported() => Ok(()),
+                other => other.map_err(Into::into),
+            }
         })
         .await
     }
 
     async fn fgetxattr(&self, name: &str) -> Result<Vec<u8>> {
         let cname = CString::new(name).context("xattr name contains interior NUL byte")?;
-        let fd = self.inner.file.as_raw_fd();
-
-        // SAFETY: fd and C string are valid; null buffer with size 0 is allowed to query length.
-        let need = unsafe { libc::fgetxattr(fd, cname.as_ptr(), std::ptr::null_mut(), 0) };
-        if need < 0 {
-            return Err(Errno::last().into());
-        }
-        let need = usize::try_from(need).context("xattr length overflow")?;
-        let mut buf = vec![0u8; need];
-        // SAFETY: destination buffer is valid for `need` bytes; fd/name unchanged.
-        let got = unsafe {
-            libc::fgetxattr(
-                fd,
-                cname.as_ptr(),
-                buf.as_mut_ptr() as *mut libc::c_void,
-                need,
-            )
-        };
-        if got < 0 {
-            return Err(Errno::last().into());
-        }
-        let got = usize::try_from(got).context("xattr length overflow")?;
-        buf.truncate(got);
-        Ok(buf)
+        sys::fgetxattr(self.inner.file.as_fd(), &cname).with_context(|| format!("fgetxattr {name}"))
     }
 
     async fn flistxattr(&self) -> Result<Vec<String>> {
-        let fd = self.inner.file.as_raw_fd();
-
-        // SAFETY: fd is valid; null buffer with size 0 is allowed to query length.
-        let need = unsafe { libc::flistxattr(fd, std::ptr::null_mut(), 0) };
-        if need < 0 {
-            return Err(Errno::last().into());
-        }
-        let need = usize::try_from(need).context("xattr list length overflow")?;
-        if need == 0 {
-            return Ok(Vec::new());
-        }
-        let mut buf = vec![0u8; need];
-        // SAFETY: destination buffer is valid for `need` bytes.
-        let got = unsafe { libc::flistxattr(fd, buf.as_mut_ptr() as *mut libc::c_char, need) };
-        if got < 0 {
-            return Err(Errno::last().into());
-        }
-        let got = usize::try_from(got).context("xattr list length overflow")?;
-        buf.truncate(got);
-
-        let mut out = Vec::new();
-        for raw in buf.split(|b| *b == 0).filter(|s| !s.is_empty()) {
-            out.push(String::from_utf8_lossy(raw).into_owned());
-        }
-        Ok(out)
+        sys::flistxattr(self.inner.file.as_fd()).context("flistxattr")
     }
 
     async fn fsetxattr(&self, name: &str, value: &[u8], flags: i32) -> Result<()> {
         let cname = CString::new(name).context("xattr name contains interior NUL byte")?;
-        let fd = self.inner.file.as_raw_fd();
-        // SAFETY: fd/name/value pointers are valid for the supplied length.
-        let ret = unsafe {
-            libc::fsetxattr(
-                fd,
-                cname.as_ptr(),
-                value.as_ptr() as *const libc::c_void,
-                value.len(),
-                flags,
-            )
-        };
-        if ret != 0 {
-            return Err(Errno::last().into());
-        }
-        Ok(())
+        sys::fsetxattr(self.inner.file.as_fd(), &cname, value, flags)
+            .with_context(|| format!("fsetxattr {name}"))
     }
 
     async fn fremovexattr(&self, name: &str) -> Result<()> {
         let cname = CString::new(name).context("xattr name contains interior NUL byte")?;
-        let fd = self.inner.file.as_raw_fd();
-        // SAFETY: fd/name are valid.
-        let ret = unsafe { libc::fremovexattr(fd, cname.as_ptr()) };
-        if ret != 0 {
-            return Err(Errno::last().into());
-        }
-        Ok(())
+        sys::fremovexattr(self.inner.file.as_fd(), &cname)
+            .with_context(|| format!("fremovexattr {name}"))
     }
 }
 

--- a/storage/overlaybd/src/dense_export.rs
+++ b/storage/overlaybd/src/dense_export.rs
@@ -155,7 +155,10 @@ pub async fn write_dense_layer_to(path: &Path, writer: Arc<dyn CompactWriter>) -
         .with_context(|| format!("dense-export sparse overlaybd layer '{}'", path.display()))
 }
 
-#[cfg(test)]
+// Every test in this module builds a sparse LSMT layer, which is rejected where
+// the filesystem does not guarantee that unwritten regions read back as holes;
+// see `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use std::sync::Arc;
 

--- a/storage/overlaybd/src/image/image_file.rs
+++ b/storage/overlaybd/src/image/image_file.rs
@@ -1443,6 +1443,10 @@ mod tests {
         assert!(!image.is_read_only().await);
     }
 
+    // Sparse LSMT files are rejected where the filesystem does not guarantee
+    // that unwritten regions read back as holes; see
+    // `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_image_file_stack_lower_and_existing_sparse_upper() {
         let tmp = TempDir::new().expect("tempdir");
@@ -1502,6 +1506,10 @@ mod tests {
         assert!(!image.is_read_only().await);
     }
 
+    // Sparse LSMT files are rejected where the filesystem does not guarantee
+    // that unwritten regions read back as holes; see
+    // `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_image_file_sparse_discard_passthrough() {
         let tmp = TempDir::new().expect("tempdir");
@@ -1691,6 +1699,10 @@ mod tests {
         assert_eq!(got_snapshot.as_ref(), first_overlay.as_slice());
     }
 
+    // Sparse LSMT files are rejected where the filesystem does not guarantee
+    // that unwritten regions read back as holes; see
+    // `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_create_snapshot_and_restack_keeps_sparse_image_writable() {
         let tmp = TempDir::new().expect("tempdir");

--- a/storage/overlaybd/src/lib.rs
+++ b/storage/overlaybd/src/lib.rs
@@ -38,6 +38,7 @@ pub mod snapshot {
     #[cfg(feature = "full")]
     pub use crate::image::snapshot::*;
 }
+mod sys;
 pub mod tools;
 pub mod vfile_io {
     pub use crate::io::vfile_io::*;

--- a/storage/overlaybd/src/lsmt/file/helper.rs
+++ b/storage/overlaybd/src/lsmt/file/helper.rs
@@ -679,6 +679,7 @@ pub(crate) fn initialize_file_rw_paths(
     virtual_size: u64,
     rw_layout: RwLayout,
 ) -> Result<()> {
+    let rw_layout = rw_layout.ensure_supported()?;
     let uuid = Uuid::new_v4();
     let header = rw_header(virtual_size, rw_layout, uuid, None, None);
     let data_file = open_truncated_rw_file(data_path)?;
@@ -718,6 +719,35 @@ pub(crate) fn initialize_file_rw_paths(
 ///   the logic offset in the SegmentMapping. For example, if start_offset is 4K, then the
 ///   logic offset in the returned SegmentMapping will minus 4K from physical offset from the
 ///   file.
+///
+/// # The caller decides what "this range is data" is allowed to mean
+///
+/// The extent map is accurate about what it actually claims: which ranges are
+/// *allocated*. The trap is that allocated is not the same as written. APFS
+/// speculatively allocates around scattered writes — a gap smaller than roughly
+/// 16-20 MiB between two written blocks gets allocated whole, see
+/// [`crate::sys::sparse_extents_are_reliable`] — so a range can be reported as
+/// data without anyone ever having written it.
+///
+/// This function therefore reports allocation and leaves the interpretation to
+/// the caller, because the two callers need different things from it:
+///
+/// - Recovering a Sparse upper's index (`LSMTFile::open`) needs **written**, and
+///   reading allocation as written is **catastrophic**: a speculatively
+///   allocated block gets claimed as owned by the upper, the upper holds a hole
+///   there, so the read returns zeros and masks every lower layer. That caller
+///   gates on [`crate::sys::sparse_extents_are_reliable`].
+/// - Packaging a raw image into a sealed layer
+///   ([`crate::tools::package_raw_as_overlaybd`]) only needs **allocated**, and
+///   is happy to copy more than necessary: every reported range is read out of
+///   the source, where an unwritten block reads as zeros, then written to the
+///   output and indexed as ordinary data. The result is byte-for-byte correct
+///   and merely larger. That caller deliberately does not gate — refusing would
+///   leave a fully dense copy as the only option.
+///
+/// The reverse error — written data reported as a hole — would be silent data
+/// loss for both callers, but that would be a filesystem bug rather than a
+/// documented allocation heuristic.
 pub async fn create_mappings_from_sparse(
     file: &Arc<dyn VirtualFile>,
     start_offset: u64,

--- a/storage/overlaybd/src/lsmt/file/helper.rs
+++ b/storage/overlaybd/src/lsmt/file/helper.rs
@@ -784,6 +784,20 @@ pub async fn create_mappings_from_sparse(
             continue;
         }
 
+        // The block arithmetic below truncates, and `end` is clamped to the file
+        // size, so an extent boundary that is not a multiple of ALIGNMENT would
+        // silently drop the trailing partial block: it would read back as zeros
+        // with no error raised anywhere. Both platforms report extent boundaries
+        // at filesystem-block granularity, so in practice this only fires on a
+        // source whose *size* is not a multiple of ALIGNMENT — which is worth
+        // rejecting loudly rather than truncating.
+        ensure!(
+            begin.is_multiple_of(ALIGNMENT) && end.is_multiple_of(ALIGNMENT),
+            "unaligned data extent [{begin}, {end}) reported for a file scanned by \
+             create_mappings_from_sparse: extent boundaries must be multiples of \
+             {ALIGNMENT} bytes"
+        );
+
         let mut logical = (begin - start_offset) / ALIGNMENT;
         let mut physical = begin / ALIGNMENT;
         let mut blocks = (end - begin) / ALIGNMENT;

--- a/storage/overlaybd/src/lsmt/file/readwrite.rs
+++ b/storage/overlaybd/src/lsmt/file/readwrite.rs
@@ -87,7 +87,7 @@ impl LSMTFile {
         let data_file_size = rw_data_file.size().await?;
 
         let header = verify_ht(&rw_data_file, false, data_file_size).await?;
-        let rw_layout = Self::rw_layout_from_header(&header)?;
+        let rw_layout = Self::rw_layout_from_header(&header)?.ensure_supported()?;
 
         if data_file_size >= HEADER_SIZE + 4096
             && verify_ht(&rw_data_file, true, data_file_size).await.is_ok()
@@ -105,6 +105,21 @@ impl LSMTFile {
         let mut rw_index_append_offset = HEADER_SIZE;
 
         if rw_layout == RwLayout::Sparse {
+            // Redundant with the `ensure_supported` above, and kept anyway: the
+            // hazard is not "this layout is Sparse", it is "we are about to let
+            // an extent map tell us which blocks this layer owns". Guarding the
+            // point where that trust is actually placed keeps the check attached
+            // to the reason it exists, so a future refactor of the layout
+            // plumbing cannot quietly drop it. See
+            // `create_mappings_from_sparse` for why its other caller
+            // (raw-image packaging) is deliberately not gated.
+            ensure!(
+                crate::sys::sparse_extents_are_reliable(),
+                "cannot recover a sparse upper's index on this platform: it does \
+                 not guarantee that unwritten regions are reported as holes, so \
+                 the extent map cannot tell us which blocks the upper owns, and \
+                 over-reported blocks would mask the lower layers with zeros"
+            );
             let mappings = create_mappings_from_sparse(&rw_data_file, HEADER_SIZE).await?;
             for m in mappings {
                 mutable_index.insert(m);
@@ -196,6 +211,7 @@ impl LSMTFile {
         parent_uuid: Option<Uuid>,
         user_tag: Option<&[u8]>,
     ) -> Result<Self> {
+        let rw_layout = rw_layout.ensure_supported()?;
         let header = rw_header(virtual_size, rw_layout, uuid, parent_uuid, user_tag);
         write_header_block(&rw_data_file, &header).await?;
 

--- a/storage/overlaybd/src/lsmt/file/tests.rs
+++ b/storage/overlaybd/src/lsmt/file/tests.rs
@@ -11,7 +11,8 @@ use crate::backend::local::LocalFile;
 use crate::io::virtual_file::{IoCtx, LocalBoxFuture};
 use crate::io::virtual_file::{VirtualFile, VirtualFileWriter};
 use crate::lsmt::format::{DiskSegmentMapping, HeaderTrailer};
-use crate::lsmt::index::{ReadOnlyIndex, Segment, SegmentMapping};
+use crate::lsmt::index::Segment;
+use crate::lsmt::index::{ReadOnlyIndex, SegmentMapping};
 use anyhow::{bail, ensure, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -204,9 +205,14 @@ async fn prepared_log_and_hybrid_uppers_use_compatible_index_offset() {
     }
 }
 
+// The two log-structured layouts are portable, so they are validated on every
+// target. Only the sparse case needs a filesystem that reports unwritten regions
+// as holes, so it is included exactly when that capability is present — keyed
+// off the same predicate the production guard uses, rather than a second copy of
+// the platform test that could drift away from it.
 #[test]
-fn validate_rw_header_pair_paths_accepts_all_layouts() {
-    for (mode, layout) in [
+fn validate_rw_header_pair_paths_accepts_all_supported_layouts() {
+    let mut cases = vec![
         (
             crate::config::UpperMode::LogStructured,
             RwLayout::LogStructured,
@@ -215,8 +221,12 @@ fn validate_rw_header_pair_paths_accepts_all_layouts() {
             crate::config::UpperMode::HybridLogStructured,
             RwLayout::HybridLogStructured,
         ),
-        (crate::config::UpperMode::Sparse, RwLayout::Sparse),
-    ] {
+    ];
+    if crate::sys::sparse_extents_are_reliable() {
+        cases.push((crate::config::UpperMode::Sparse, RwLayout::Sparse));
+    }
+
+    for (mode, layout) in cases {
         let dir = TempDir::new().unwrap();
         let data = dir.path().join("upper.data");
         let index = dir.path().join("upper.index");
@@ -224,6 +234,64 @@ fn validate_rw_header_pair_paths_accepts_all_layouts() {
         crate::image::helper::prepare_runtime_upper(&data, index_path, 8192, mode).unwrap();
         validate_rw_header_pair_paths(&data, index_path, 8192, layout).unwrap();
     }
+}
+
+/// The layout guard tracks the extent capability exactly: both log-structured
+/// layouts are always available, and sparse is available precisely when extent
+/// maps can be trusted.
+///
+/// This runs on every target. The sparse tests further down are compiled only on
+/// Linux because they need a filesystem that really reports holes, which would
+/// otherwise leave the *rejecting* half of this behaviour — the entire point of
+/// the guard — untested exactly where it takes effect.
+#[test]
+fn ensure_supported_tracks_the_extent_capability() {
+    RwLayout::LogStructured
+        .ensure_supported()
+        .expect("a log-structured upper is portable");
+    RwLayout::HybridLogStructured
+        .ensure_supported()
+        .expect("a hybrid upper is portable");
+    assert_eq!(
+        RwLayout::Sparse.ensure_supported().is_ok(),
+        crate::sys::sparse_extents_are_reliable(),
+        "sparse must be accepted exactly where extent maps are trustworthy"
+    );
+}
+
+/// Creating a sparse upper must fail *before* anything is written, on a platform
+/// whose extent maps cannot be trusted.
+///
+/// This pins the failure mode that motivated putting the guard on every entry
+/// point rather than only on the recovery scan: without it the upper is created,
+/// written to successfully, and only fails when it is reopened — by which point
+/// the guest's data is already in it.
+#[test]
+#[cfg_attr(
+    target_os = "linux",
+    ignore = "Linux reports holes reliably, so a sparse upper is supported here"
+)]
+fn preparing_a_sparse_upper_is_refused_where_extents_are_unreliable() {
+    assert!(
+        !crate::sys::sparse_extents_are_reliable(),
+        "this test describes platforms without trustworthy extent maps"
+    );
+
+    let dir = TempDir::new().unwrap();
+    let data = dir.path().join("upper.data");
+    let err = crate::image::helper::prepare_runtime_upper(
+        &data,
+        None,
+        8192,
+        crate::config::UpperMode::Sparse,
+    )
+    .expect_err("a sparse upper must be refused where extents are unreliable");
+
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("sparse RW layout is not supported"),
+        "expected the layout guard to reject this, got: {rendered}"
+    );
 }
 
 #[test]
@@ -329,6 +397,8 @@ async fn created_log_and_hybrid_uppers_use_compatible_index_offset() {
     }
 }
 
+// Only used by the Linux-gated sparse tests.
+#[cfg(target_os = "linux")]
 async fn create_sparse_lsmt_env(dir: &TempDir, vsize: u64) -> (Arc<LocalFile>, LSMTFile) {
     let data_path = dir.path().join("sparse-data.lsmt");
     let data_file = Arc::new(LocalFile::new(&data_path).expect("create sparse data file"));
@@ -407,6 +477,8 @@ async fn create_sealed_layer(
     data
 }
 
+// Only used by the Linux-gated sparse tests below.
+#[cfg(target_os = "linux")]
 async fn open_sparse_lsmt_env(
     data_file: Arc<LocalFile>,
     lower_layers: Vec<Arc<dyn VirtualFile>>,
@@ -877,6 +949,10 @@ async fn test_create_open() {
     assert_eq!(lsmt2.size().await.unwrap(), vsize);
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_sparse_rw() {
     let temp_dir = TempDir::new().unwrap();
@@ -1415,6 +1491,10 @@ async fn test_stack_files() {
     assert_eq!(read_new[0], 0xCC);
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_stack_files_with_sparse_upper_and_sparse_lower() {
     let temp_dir = TempDir::new().unwrap();
@@ -1451,6 +1531,10 @@ async fn test_stack_files_with_sparse_upper_and_sparse_lower() {
     assert_eq!(lsmt_stacked.file_type(), LSMTFileType::SparseReadWrite);
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_stack_files_with_sparse_upper_and_multiple_sparse_lowers() {
     let base_dir = TempDir::new().unwrap();
@@ -1489,6 +1573,10 @@ async fn test_stack_files_with_sparse_upper_and_multiple_sparse_lowers() {
     assert_eq!(got12k.as_ref(), vec![0xAB; 4096].as_slice());
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_sparse_restack_twice_preserves_lower_chain() {
     let temp_dir = TempDir::new().unwrap();
@@ -1615,6 +1703,10 @@ async fn test_update_vsize_after_write_preserves_close_seal_descriptor() {
     );
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_sparse_close_seal_and_commit_roundtrip() {
     let temp_dir = TempDir::new().unwrap();
@@ -1871,6 +1963,10 @@ async fn test_hybrid_append_cursor_survives_reopen() {
     assert_eq!(lsmt.read_at(8192, 4096).await.unwrap()[0], 0xB4);
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_sparse_discard_range_persists_via_hole_punch() {
     let temp_dir = TempDir::new().unwrap();
@@ -2257,6 +2353,10 @@ async fn test_compact_to_rejects_short_reads() {
     assert_err_contains(&err, "failed to read");
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_sparse_factory_without_index() {
     let temp_dir = TempDir::new().unwrap();
@@ -3096,6 +3196,10 @@ async fn test_lsmt_size() {
     assert_eq!(lsmt.size().await.unwrap(), 8192);
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_sparse_write_read() {
     let dir = TempDir::new().unwrap();
@@ -3106,6 +3210,10 @@ async fn test_sparse_write_read() {
     assert_eq!(buf[0], 0xAA);
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_sparse_commit_matches_logical_content_of_log_structured() {
     let temp_dir = TempDir::new().unwrap();
@@ -3245,6 +3353,10 @@ async fn test_direct_io_close_seal() {
     }
 }
 
+// Sparse LSMT files are rejected where the filesystem does not guarantee
+// that unwritten regions read back as holes; see
+// `sys::sparse_extents_are_reliable`. Lift this together with that gate.
+#[cfg(target_os = "linux")]
 /// `LSMTFile::create` with `sparse_rw = true` on an O_DIRECT data file
 /// (no index file required for sparse mode).  Verifies that the
 /// 4096-byte aligned header write path works for sparse files too, and

--- a/storage/overlaybd/src/lsmt/file/types.rs
+++ b/storage/overlaybd/src/lsmt/file/types.rs
@@ -127,6 +127,29 @@ impl RwLayout {
             RwLayout::HybridLogStructured => LSMTFileType::HybridReadWrite,
         }
     }
+
+    /// Reject a layout the current platform cannot support.
+    ///
+    /// `Sparse` pre-sizes the upper to the whole virtual disk and recovers "which
+    /// blocks were written" from the filesystem's extent map, so it only works
+    /// where unwritten regions are guaranteed to be reportable holes — see
+    /// [`crate::sys::sparse_extents_are_reliable`].
+    ///
+    /// Called from every entry point that creates *or* opens an upper, not just
+    /// from the recovery scan in `create_mappings_from_sparse`. Guarding only the
+    /// scan would let an unsupported platform create a sparse upper, write to it
+    /// successfully, and then fail to reopen it on the next restart — surfacing
+    /// the problem after the data is already there instead of before.
+    pub(super) fn ensure_supported(self) -> Result<Self> {
+        ensure!(
+            self != RwLayout::Sparse || crate::sys::sparse_extents_are_reliable(),
+            "sparse RW layout is not supported on this platform: it does not \
+             guarantee that unwritten regions are reported as holes, so the \
+             upper's extent map cannot be used to recover which blocks were \
+             written"
+        );
+        Ok(self)
+    }
 }
 
 impl From<crate::config::UpperMode> for RwLayout {

--- a/storage/overlaybd/src/sys/fs_space.rs
+++ b/storage/overlaybd/src/sys/fs_space.rs
@@ -1,0 +1,116 @@
+//! Filesystem space accounting.
+
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+use nix::errno::Errno;
+
+use super::{SysError, SysResult};
+
+/// Space accounting for the filesystem holding a path, in bytes.
+///
+/// Returning derived byte counts rather than a `statvfs` keeps the platform's
+/// integer widths out of callers: Darwin's `f_blocks` and `f_bavail` are 32-bit
+/// where Linux's are 64-bit, so multiplying them by the fragment size has a
+/// different result type per target. Normalizing once here means the arithmetic
+/// is written once.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FsSpace {
+    /// Total size of the filesystem.
+    pub capacity_bytes: u64,
+    /// Bytes available to an unprivileged process.
+    pub avail_bytes: u64,
+}
+
+/// Query the filesystem holding `path`.
+///
+/// `statvfs` exists on every target this crate builds for — a syscall wrapper on
+/// Linux, a libc wrapper over `statfs` on Darwin — so unlike the other
+/// capabilities in [`super`] this one needs no per-platform arm, only the width
+/// normalization above. Verified against `df` on both: `f_frsize * f_blocks`
+/// reproduces the reported size exactly.
+///
+/// # Two portability traps, both deliberately avoided here
+///
+/// - **Use `f_frsize`, never `f_bsize`.** The block counts are in `f_frsize`
+///   units on both platforms, but `f_bsize` means "preferred I/O size" and
+///   diverges wildly: measured 4096 on Linux against **1048576** on macOS.
+///   Multiplying the counts by `f_bsize` would overstate macOS capacity 256x.
+/// - **Darwin's counts are 32-bit.** `f_blocks` and `f_bavail` are 4 bytes
+///   there against 8 on Linux, so with a 4096-byte `f_frsize` this saturates at
+///   2^32 * 4096 = 16 TiB. A cache directory on a larger volume would report
+///   wrong numbers on macOS; switching the Darwin arm to `statfs`, whose counts
+///   are 64-bit, is the fix if that ever matters.
+///
+/// Darwin's `man 3 statvfs` also warns that "portable applications must not
+/// depend on" the structure being filled in, which is part of why the result is
+/// narrowed to two derived numbers rather than exposed as a `statvfs`.
+// `useless_conversion` is allowed because it is only useless on *one* target:
+// these fields are already `u64` on Linux but 32-bit on Darwin, so removing the
+// conversions as clippy suggests would break the macOS build.
+#[allow(clippy::useless_conversion)]
+pub fn fs_space(path: &Path) -> SysResult<FsSpace> {
+    let cpath =
+        CString::new(path.as_os_str().as_bytes()).map_err(|_| SysError::Errno(Errno::EINVAL))?;
+
+    let mut st = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    // SAFETY: `cpath` is a valid NUL-terminated path and `statvfs` fully
+    // initializes `st` when it returns 0.
+    let ret = unsafe { libc::statvfs(cpath.as_ptr(), st.as_mut_ptr()) };
+    if ret != 0 {
+        return Err(SysError::last());
+    }
+    // SAFETY: `statvfs` returned 0, so `st` is initialized.
+    let st = unsafe { st.assume_init() };
+
+    // `u64::from` rather than `as`: it compiles for both the 32-bit Darwin and
+    // 64-bit Linux field types while still refusing a lossy conversion if a
+    // future target widens something unexpectedly.
+    let frsize = u64::from(st.f_frsize);
+    Ok(FsSpace {
+        capacity_bytes: frsize.saturating_mul(u64::from(st.f_blocks)),
+        avail_bytes: frsize.saturating_mul(u64::from(st.f_bavail)),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fs_space_reports_nonzero_capacity_for_tempdir() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let space = fs_space(dir.path()).expect("statvfs on tempdir");
+        assert!(space.capacity_bytes > 0, "capacity should be positive");
+        assert!(
+            space.avail_bytes <= space.capacity_bytes,
+            "available ({}) must not exceed capacity ({})",
+            space.avail_bytes,
+            space.capacity_bytes
+        );
+    }
+
+    /// Doubles as the check that [`SysError::last`] really reads `errno` on this
+    /// platform: asserting the exact code, not merely that some error came back,
+    /// is what proves `nix::errno::Errno::last()` works here. It is only correct
+    /// because every caller of `SysError::last` in this module invokes it
+    /// immediately after the failing syscall, before anything can clobber
+    /// `errno`.
+    #[test]
+    fn fs_space_fails_with_enoent_for_missing_path() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let missing = dir.path().join("no-such-directory");
+        let err = fs_space(&missing).expect_err("statvfs on missing path must fail");
+        match err {
+            SysError::Errno(errno) => assert_eq!(
+                errno,
+                Errno::ENOENT,
+                "statvfs on a missing path must report ENOENT, got {errno}"
+            ),
+            SysError::Unsupported(op) => {
+                panic!("statvfs is available on all targets, got Unsupported({op})")
+            }
+        }
+    }
+}

--- a/storage/overlaybd/src/sys/mod.rs
+++ b/storage/overlaybd/src/sys/mod.rs
@@ -1,0 +1,90 @@
+//! Platform-specific filesystem primitives.
+//!
+//! The module is split by *capability*, not by platform: each submodule owns
+//! the portable public signature, whatever portable logic that capability
+//! needs, and the per-OS implementations. Two consequences are deliberate:
+//!
+//! - The Linux and macOS versions of one syscall sit next to each other, so a
+//!   reviewer can compare them without jumping between files.
+//! - Bringing up a new target means adding one `imp` arm per capability file
+//!   and touching nothing else. A platform that simply lacks a capability
+//!   returns [`SysError::Unsupported`] from its own arm, right beside the
+//!   implementations it is standing in for.
+//!
+//! Callers outside this module should never name a `libc` type or constant for
+//! these operations.
+
+use std::fmt;
+
+use nix::errno::Errno;
+
+mod fs_space;
+mod open_flags;
+mod page_cache;
+mod release_space;
+mod reserve_space;
+mod xattr;
+
+pub use fs_space::fs_space;
+pub use open_flags::{direct_io_open_flag, enable_direct_io};
+pub use page_cache::evict_page_cache;
+pub use release_space::release_space_hint;
+pub use reserve_space::reserve_space;
+pub use xattr::{
+    fgetxattr, flistxattr, fremovexattr, fsetxattr, getxattr, listxattr, removexattr, setxattr,
+};
+
+/// Failure of a platform primitive.
+///
+/// `Unsupported` is a separate variant rather than an errno because callers
+/// legitimately disagree about what it means: page-cache eviction is a hint and
+/// degrades to a no-op, a cache refill has to keep working without a space
+/// reservation, while a failed hole punch has to surface. Distinguishing these by
+/// matching on this enum is sturdier than downcasting an `anyhow::Error`.
+#[derive(Debug)]
+pub enum SysError {
+    /// The current platform has no equivalent of this operation. The payload is
+    /// the operation name, for diagnostics only.
+    ///
+    /// Constructed on every target: the macOS arms report the capabilities
+    /// Darwin lacks, and `reserve_space` also reports it on Linux for
+    /// filesystems without `fallocate`.
+    Unsupported(&'static str),
+    /// The syscall was attempted and failed.
+    Errno(Errno),
+}
+
+impl SysError {
+    /// True when the platform never attempted the operation.
+    pub fn is_unsupported(&self) -> bool {
+        matches!(self, Self::Unsupported(_))
+    }
+
+    /// Capture the thread's current `errno`.
+    fn last() -> Self {
+        Self::Errno(Errno::last())
+    }
+}
+
+impl fmt::Display for SysError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsupported(op) => {
+                write!(f, "{op} is not supported on this platform")
+            }
+            Self::Errno(errno) => write!(f, "{errno}"),
+        }
+    }
+}
+
+impl std::error::Error for SysError {}
+
+pub type SysResult<T> = Result<T, SysError>;
+
+/// Convert a byte offset or length to `off_t`.
+///
+/// Reports `EOVERFLOW` rather than panicking; only reachable on targets with a
+/// 32-bit `off_t`.
+fn to_off_t(value: u64) -> SysResult<libc::off_t> {
+    libc::off_t::try_from(value).map_err(|_| SysError::Errno(Errno::EOVERFLOW))
+}

--- a/storage/overlaybd/src/sys/mod.rs
+++ b/storage/overlaybd/src/sys/mod.rs
@@ -23,6 +23,7 @@ mod open_flags;
 mod page_cache;
 mod release_space;
 mod reserve_space;
+mod sparse;
 mod xattr;
 
 pub use fs_space::fs_space;
@@ -30,6 +31,7 @@ pub use open_flags::{direct_io_open_flag, enable_direct_io};
 pub use page_cache::evict_page_cache;
 pub use release_space::release_space_hint;
 pub use reserve_space::reserve_space;
+pub use sparse::sparse_extents_are_reliable;
 pub use xattr::{
     fgetxattr, flistxattr, fremovexattr, fsetxattr, getxattr, listxattr, removexattr, setxattr,
 };

--- a/storage/overlaybd/src/sys/open_flags.rs
+++ b/storage/overlaybd/src/sys/open_flags.rs
@@ -1,0 +1,87 @@
+//! Open-time flags, and post-open setup, that differ by platform.
+
+use std::fs::File;
+
+use super::SysResult;
+
+/// The open flag requesting cache-bypassing I/O, or `None` on platforms that
+/// express it after open instead (see [`enable_direct_io`]).
+pub fn direct_io_open_flag() -> Option<i32> {
+    imp::DIRECT_IO_OPEN_FLAG
+}
+
+/// Finish enabling cache-bypassing I/O on a freshly opened file.
+///
+/// Call this after `open` whenever direct I/O was requested — on every
+/// platform. Linux already got what it needed from [`direct_io_open_flag`] and
+/// this is a no-op there; macOS does all of its work here.
+///
+/// # Platform differences
+///
+/// macOS has no `O_DIRECT`. The analogue is `fcntl(F_NOCACHE)`, which is weaker
+/// in three ways worth knowing about:
+///
+/// 1. It is applied after open rather than being an open flag — hence this
+///    function existing at all.
+/// 2. It imposes no alignment requirements on offsets, lengths or buffers
+///    (measured: a 100-byte write at offset 1 succeeds). Callers still get the
+///    Linux alignment rules enforced, so that `direct_io` means one thing
+///    everywhere and unaligned I/O cannot pass on macOS only to fail on Linux.
+/// 3. It only keeps *new* pages out of the unified buffer cache; pages already
+///    resident are still served from it. So unlike `O_DIRECT` this is **not** a
+///    way to read around the cache and observe on-disk state.
+///
+/// Point 3 is fine for why this is used here — avoiding a second copy of data
+/// overlaybd already caches itself — but would silently defeat anyone reaching
+/// for direct I/O to bypass caching for correctness.
+pub fn enable_direct_io(file: &File) -> SysResult<()> {
+    imp::enable_direct_io(file)
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::fs::File;
+
+    use super::super::SysResult;
+
+    pub(super) const DIRECT_IO_OPEN_FLAG: Option<i32> = Some(libc::O_DIRECT);
+
+    /// `O_DIRECT` was set at open time, so there is nothing left to do.
+    pub(super) fn enable_direct_io(_file: &File) -> SysResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::fs::File;
+    use std::os::fd::AsRawFd;
+
+    use super::super::{SysError, SysResult};
+
+    /// Darwin has no open-time flag for this; see [`enable_direct_io`].
+    pub(super) const DIRECT_IO_OPEN_FLAG: Option<i32> = None;
+
+    pub(super) fn enable_direct_io(file: &File) -> SysResult<()> {
+        // SAFETY: `file` owns a live descriptor and `F_NOCACHE` takes an int by
+        // value.
+        let ret = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_NOCACHE, 1) };
+        if ret != -1 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod imp {
+    use std::fs::File;
+
+    use super::super::{SysError, SysResult};
+
+    pub(super) const DIRECT_IO_OPEN_FLAG: Option<i32> = None;
+
+    pub(super) fn enable_direct_io(_file: &File) -> SysResult<()> {
+        Err(SysError::Unsupported("direct_io"))
+    }
+}

--- a/storage/overlaybd/src/sys/page_cache.rs
+++ b/storage/overlaybd/src/sys/page_cache.rs
@@ -1,0 +1,57 @@
+//! Dropping page-cache residency for a file range.
+
+use std::os::fd::BorrowedFd;
+
+use super::SysResult;
+
+/// Hint that the page cache backing `[offset, offset + len)` can be dropped.
+///
+/// A `len` of zero means "through end of file", following the Linux
+/// `posix_fadvise` convention.
+///
+/// This is advisory: it never changes what a subsequent read returns, only
+/// whether that read has to touch the device. macOS has no equivalent and
+/// returns [`super::SysError::Unsupported`], so callers that treat eviction as a
+/// hint should map that variant to success rather than propagating it.
+pub fn evict_page_cache(fd: BorrowedFd<'_>, offset: u64, len: u64) -> SysResult<()> {
+    imp::evict_page_cache(fd, offset, len)
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::os::fd::{AsRawFd, BorrowedFd};
+
+    use nix::errno::Errno;
+
+    use super::super::{to_off_t, SysError, SysResult};
+
+    pub(super) fn evict_page_cache(fd: BorrowedFd<'_>, offset: u64, len: u64) -> SysResult<()> {
+        let offset = to_off_t(offset)?;
+        let len = to_off_t(len)?;
+        // SAFETY: `fd` is a live borrowed descriptor and `posix_fadvise` only
+        // reads its scalar arguments.
+        let ret =
+            unsafe { libc::posix_fadvise(fd.as_raw_fd(), offset, len, libc::POSIX_FADV_DONTNEED) };
+        if ret == 0 {
+            return Ok(());
+        }
+        // `posix_fadvise` returns the error number directly instead of setting
+        // `errno`.
+        Err(SysError::Errno(Errno::from_raw(ret)))
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    use std::os::fd::BorrowedFd;
+
+    use super::super::{SysError, SysResult};
+
+    /// Darwin has no `posix_fadvise`. `F_NOCACHE` changes the caching policy for
+    /// all future I/O on the descriptor rather than evicting a range that is
+    /// already resident, so it is not a substitute; `madvise` only applies to a
+    /// mapping the caller owns. Report the gap and let callers decide.
+    pub(super) fn evict_page_cache(_fd: BorrowedFd<'_>, _offset: u64, _len: u64) -> SysResult<()> {
+        Err(SysError::Unsupported("evict_page_cache"))
+    }
+}

--- a/storage/overlaybd/src/sys/release_space.rs
+++ b/storage/overlaybd/src/sys/release_space.rs
@@ -1,0 +1,287 @@
+//! Returning a file's storage to the filesystem without shrinking the file.
+
+use std::os::fd::BorrowedFd;
+
+use nix::errno::Errno;
+
+use super::{SysError, SysResult};
+
+/// Ask the filesystem to release the storage backing `[offset, offset + len)`,
+/// keeping the file's logical size unchanged.
+///
+/// This is a hint **about space, not about contents**. Two things it explicitly
+/// does not promise:
+///
+/// - That the range reads back as zeros. Linux's `fallocate(PUNCH_HOLE)` does
+///   zero it as a side effect, macOS's `F_PUNCHHOLE` only operates on whole
+///   blocks so partial edges keep their old bytes. Callers needing zeros must
+///   arrange it themselves, and both current callers do: `LSMTFile::discard_range`
+///   records the range in its index with `SegmentMapping::zeroed`, and
+///   `CacheEntry` eviction clears its bitmap before calling, so later reads miss
+///   and refill from the source either way.
+/// - That any particular amount is released. A range not covering a whole
+///   filesystem block releases nothing and still returns `Ok`.
+///
+/// What it *does* keep is diagnostics: best-effort applies to coverage, not to
+/// errors. A syscall that is attempted and fails — `EIO`, `EPERM`, `ENOSPC` —
+/// is still reported, so a cache eviction that cannot reclaim space does not
+/// silently look like it worked.
+///
+/// # Granularity
+///
+/// Linux accepts any range and frees the whole blocks inside it.
+///
+/// macOS requires both offset and length to be multiples of the filesystem block
+/// size (`man 2 fcntl`: "Holes must be aligned to file system block
+/// boundaries"), returning `EINVAL` otherwise, so the range is shrunk *inward*
+/// to block boundaries — never outward, which would discard data the caller
+/// never asked about.
+///
+/// Worth knowing for macOS: LSMT's own alignment is 512 bytes
+/// (`lsmt::file::types::ALIGNMENT`) while an APFS block is 4096 and its
+/// allocation granularity is 16 KiB. A 512-byte discard therefore releases
+/// nothing at all, and only ranges of 4096 or more, aligned to 4096, release
+/// anything. That is within contract, but it means fine-grained discards reclaim
+/// no space on macOS.
+///
+/// # Errors
+///
+/// A range whose end does not fit in a `u64` is rejected with `EOVERFLOW` rather
+/// than clamped. Clamping would turn a malformed request into a shorter
+/// well-formed one and release blocks the caller never named, and the macOS arm
+/// additionally rounds the offset upward, which on a near-`u64::MAX` offset
+/// panics in debug and wraps to zero in release — releasing from the start of
+/// the file. Both are worse than refusing the call.
+pub fn release_space_hint(fd: BorrowedFd<'_>, offset: u64, len: u64) -> SysResult<()> {
+    if len == 0 {
+        return Ok(());
+    }
+    if offset.checked_add(len).is_none() {
+        return Err(SysError::Errno(Errno::EOVERFLOW));
+    }
+    imp::release_space_hint(fd, offset, len)
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::os::fd::{AsRawFd, BorrowedFd};
+
+    use super::super::{to_off_t, SysError, SysResult};
+
+    pub(super) fn release_space_hint(fd: BorrowedFd<'_>, offset: u64, len: u64) -> SysResult<()> {
+        let offset = to_off_t(offset)?;
+        let len = to_off_t(len)?;
+        // SAFETY: `fd` is a live borrowed descriptor and `fallocate` only reads
+        // its scalar arguments.
+        let ret = unsafe {
+            libc::fallocate(
+                fd.as_raw_fd(),
+                libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE,
+                offset,
+                len,
+            )
+        };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::os::fd::{AsRawFd, BorrowedFd};
+
+    use nix::errno::Errno;
+
+    use super::super::{to_off_t, SysError, SysResult};
+
+    /// Fallback when `fstat` reports a block size that cannot be used for the
+    /// alignment arithmetic below.
+    const DEFAULT_BLOCK_SIZE: u64 = 4096;
+
+    /// Filesystem block size for `fd`, which `F_PUNCHHOLE` requires both the
+    /// offset and the length to be a multiple of.
+    fn block_size(fd: BorrowedFd<'_>) -> SysResult<u64> {
+        let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: `fd` is live and `fstat` fully initializes `st` when it
+        // returns 0.
+        let ret = unsafe { libc::fstat(fd.as_raw_fd(), st.as_mut_ptr()) };
+        if ret != 0 {
+            return Err(SysError::last());
+        }
+        // SAFETY: `fstat` returned 0, so `st` is initialized.
+        let st = unsafe { st.assume_init() };
+        let blk = u64::try_from(st.st_blksize).unwrap_or(0);
+        // The alignment arithmetic below assumes a power of two.
+        Ok(if blk.is_power_of_two() {
+            blk
+        } else {
+            DEFAULT_BLOCK_SIZE
+        })
+    }
+
+    pub(super) fn release_space_hint(fd: BorrowedFd<'_>, offset: u64, len: u64) -> SysResult<()> {
+        let blk = block_size(fd)?;
+        let end = offset
+            .checked_add(len)
+            .ok_or(SysError::Errno(Errno::EOVERFLOW))?;
+
+        // Shrink inward: start rounds up, end rounds down. Rounding either the
+        // other way would release blocks outside the requested range.
+        //
+        // Rounding up is checked separately from the range: an offset within
+        // `blk - 1` of `u64::MAX` has no next block boundary even though
+        // `offset + len` itself fits. Unchecked, that panics in debug and wraps
+        // to 0 in release, which would then punch from the start of the file.
+        let aligned_offset = offset
+            .checked_next_multiple_of(blk)
+            .ok_or(SysError::Errno(Errno::EOVERFLOW))?;
+        let aligned_end = end / blk * blk;
+        if aligned_end <= aligned_offset {
+            // The request covers no whole block, so there is nothing to release.
+            // This is a hint about space, so releasing none of it is success.
+            return Ok(());
+        }
+
+        let arg = libc::fpunchhole_t {
+            fp_flags: 0,
+            reserved: 0,
+            fp_offset: to_off_t(aligned_offset)?,
+            fp_length: to_off_t(aligned_end - aligned_offset)?,
+        };
+        // SAFETY: `fd` is live and `F_PUNCHHOLE` reads a single `fpunchhole_t`
+        // through the pointer, which stays valid for the call.
+        let ret = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_PUNCHHOLE, &arg) };
+        if ret != -1 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod imp {
+    use std::os::fd::BorrowedFd;
+
+    use super::super::SysResult;
+
+    /// No way to release a range here. Since this is only ever a hint about
+    /// space, reporting success while releasing nothing is the contract rather
+    /// than a violation of it.
+    pub(super) fn release_space_hint(
+        _fd: BorrowedFd<'_>,
+        _offset: u64,
+        _len: u64,
+    ) -> SysResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::{FileExt, MetadataExt};
+
+    /// A file of `len` bytes, fully written so every block is allocated.
+    fn written_file(len: usize) -> (tempfile::TempDir, File) {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(dir.path().join("release.bin"))
+            .expect("create file");
+        file.write_all_at(&vec![0xAB_u8; len], 0).expect("fill");
+        file.sync_all().expect("sync");
+        (dir, file)
+    }
+
+    #[test]
+    fn zero_length_is_a_noop() {
+        let (_dir, file) = written_file(4096);
+        release_space_hint(file.as_fd(), 0, 0).expect("zero length must succeed");
+        assert_eq!(file.metadata().expect("stat").len(), 4096);
+    }
+
+    /// A range that runs past `u64::MAX` is refused instead of being clamped to
+    /// something well-formed. Both offsets below also sit within a block of
+    /// `u64::MAX`, where rounding the offset up to the next block boundary
+    /// overflows on its own — unchecked that panics in debug and wraps to 0 in
+    /// release, which would release from the start of the file.
+    #[test]
+    fn an_overflowing_range_is_refused() {
+        let (_dir, file) = written_file(4096);
+        for (offset, len) in [(u64::MAX, 1), (u64::MAX - 16, 4096)] {
+            let err = release_space_hint(file.as_fd(), offset, len)
+                .expect_err("a range past u64::MAX must be refused");
+            assert!(
+                !err.is_unsupported(),
+                "expected an errno, got {err} for offset={offset} len={len}"
+            );
+        }
+        assert_eq!(
+            file.metadata().expect("stat").len(),
+            4096,
+            "a refused call must not touch the file"
+        );
+    }
+
+    /// A range too small to cover a whole block releases nothing and still
+    /// succeeds — that is the point of the "hint" in the name. Contents are
+    /// deliberately not asserted: Linux zeroes such a range as a side effect of
+    /// `fallocate` while macOS leaves it untouched, and this interface promises
+    /// neither.
+    #[test]
+    fn sub_block_range_succeeds_without_changing_file_size() {
+        let (_dir, file) = written_file(4096);
+        release_space_hint(file.as_fd(), 13, 499).expect("sub-block range must succeed");
+        assert_eq!(
+            file.metadata().expect("stat").len(),
+            4096,
+            "logical size must be preserved"
+        );
+    }
+
+    /// The whole point: an aligned range covering entire blocks actually returns
+    /// storage, while the file keeps its logical size.
+    #[test]
+    fn aligned_whole_file_range_releases_storage() {
+        let len = 64 * 1024;
+        let (_dir, file) = written_file(len);
+        let blocks_before = file.metadata().expect("stat").blocks();
+        assert!(blocks_before > 0, "a fully written file must have blocks");
+
+        release_space_hint(file.as_fd(), 0, len as u64).expect("aligned range must succeed");
+        file.sync_all().expect("sync");
+
+        let meta = file.metadata().expect("stat");
+        assert_eq!(meta.len(), len as u64, "logical size must be preserved");
+        assert!(
+            meta.blocks() < blocks_before,
+            "storage should be released: {} -> {} blocks",
+            blocks_before,
+            meta.blocks()
+        );
+    }
+
+    /// Releasing an interior range leaves the surrounding data alone.
+    #[test]
+    fn aligned_interior_range_keeps_surrounding_data() {
+        let len = 16 * 1024;
+        let (_dir, file) = written_file(len);
+
+        release_space_hint(file.as_fd(), 4096, 4096).expect("interior range must succeed");
+
+        let mut head = [0u8; 16];
+        file.read_exact_at(&mut head, 0).expect("read head");
+        assert_eq!(head, [0xAB; 16], "data before the range must survive");
+
+        let mut tail = [0u8; 16];
+        file.read_exact_at(&mut tail, 8192).expect("read tail");
+        assert_eq!(tail, [0xAB; 16], "data after the range must survive");
+    }
+}

--- a/storage/overlaybd/src/sys/reserve_space.rs
+++ b/storage/overlaybd/src/sys/reserve_space.rs
@@ -1,0 +1,190 @@
+//! Reserving storage for a byte range of a file without changing its size.
+
+use std::os::fd::BorrowedFd;
+
+use super::SysResult;
+
+/// Ask the filesystem to allocate storage for `[offset, offset + len)`, keeping
+/// the file's logical size unchanged.
+///
+/// This is the inverse of [`release_space_hint`](super::release_space_hint), and
+/// unlike that one it is **not** a hint: `Ok(())` means the blocks are reserved,
+/// so a later store into the range cannot fail for want of space.
+///
+/// The motivating caller is the full-file cache, which writes refilled blocks
+/// through a shared mmap over a sparse file. Storing into an unallocated hole
+/// makes the kernel allocate at page-fault time, where there is no way to report
+/// `ENOSPC` to the faulting instruction — Linux turns it into `SIGBUS` and kills
+/// the process. Reserving up front moves that failure to a plain error return.
+///
+/// # Platform support
+///
+/// Callers must handle [`SysError::Unsupported`](super::SysError::Unsupported)
+/// as "nothing was reserved", not as a failure: **macOS cannot do this at all**
+/// (see below), so treating it as an error would break every caller on that
+/// platform rather than degrading it. This is why `Unsupported` is a separate
+/// variant instead of an errno.
+///
+/// Linux also reports `Unsupported` when the filesystem lacks `fallocate`
+/// (`EOPNOTSUPP`/`ENOSYS`) — tmpfs and some network filesystems. Reserving is
+/// then impossible for the same reason, and the caller degrades identically.
+pub fn reserve_space(fd: BorrowedFd<'_>, offset: u64, len: u64) -> SysResult<()> {
+    if len == 0 {
+        return Ok(());
+    }
+    imp::reserve_space(fd, offset, len)
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::os::fd::{AsRawFd, BorrowedFd};
+
+    use nix::errno::Errno;
+
+    use super::super::{to_off_t, SysError, SysResult};
+
+    pub(super) fn reserve_space(fd: BorrowedFd<'_>, offset: u64, len: u64) -> SysResult<()> {
+        let offset = to_off_t(offset)?;
+        let len = to_off_t(len)?;
+        // KEEP_SIZE so the reservation never moves the file length: callers size
+        // their file up front and validate it on reload.
+        //
+        // SAFETY: `fd` is a live borrowed descriptor and `fallocate` only reads
+        // its scalar arguments.
+        let ret =
+            unsafe { libc::fallocate(fd.as_raw_fd(), libc::FALLOC_FL_KEEP_SIZE, offset, len) };
+        if ret == 0 {
+            return Ok(());
+        }
+        match Errno::last() {
+            // The filesystem has no fallocate. Distinguished from a real
+            // failure because the caller has to keep working without a
+            // reservation, exactly as it must on macOS.
+            Errno::EOPNOTSUPP | Errno::ENOSYS => Err(SysError::Unsupported("reserve_space")),
+            errno => Err(SysError::Errno(errno)),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::os::fd::BorrowedFd;
+
+    use super::super::{SysError, SysResult};
+
+    /// Darwin has no equivalent of `fallocate(FALLOC_FL_KEEP_SIZE)`, so this
+    /// always reports `Unsupported`.
+    ///
+    /// **Do not try to implement this with `F_PREALLOCATE`.** That call cannot
+    /// name an interior offset at all: with `F_PEOFPOSMODE` the kernel rejects
+    /// any non-zero `fst_offset` outright — `bsd/kern/kern_descrip.c` reads
+    ///
+    /// ```text
+    /// case F_PEOFPOSMODE:
+    ///         if (alloc_struct.fst_offset != 0) { error = EINVAL; goto outdrop; }
+    /// ```
+    ///
+    /// and `man 2 fcntl` documents the same `EINVAL`. The other position mode,
+    /// `F_VOLPOSMODE`, is not a file offset either despite the name: it is a
+    /// physical placement hint that becomes `blockHint` for the volume
+    /// allocator. Both modes only extend allocation past the fork's end, which
+    /// is why portable Rust wrappers (`fs2`, `fs3`, `fs4`) expose `allocate`
+    /// with no offset parameter. `posix_fallocate` does not exist on Darwin.
+    ///
+    /// Realizing an interior range therefore requires writing to it — the
+    /// approach Chromium's `AllocateFileRegion` and SQLite's `fcntlSizeHint`
+    /// fall back to (read a byte per block, write it back when the block reads
+    /// as zero). That trades one syscall pair per block and dirties the page
+    /// cache, so it belongs to the caller that can judge the cost, not to a
+    /// primitive that silently performs I/O. Reporting `Unsupported` keeps the
+    /// choice where the information is.
+    pub(super) fn reserve_space(_fd: BorrowedFd<'_>, _offset: u64, _len: u64) -> SysResult<()> {
+        Err(SysError::Unsupported("reserve_space"))
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod imp {
+    use std::os::fd::BorrowedFd;
+
+    use super::super::{SysError, SysResult};
+
+    pub(super) fn reserve_space(_fd: BorrowedFd<'_>, _offset: u64, _len: u64) -> SysResult<()> {
+        Err(SysError::Unsupported("reserve_space"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::MetadataExt;
+
+    /// A sparse file of `len` logical bytes with nothing allocated.
+    fn sparse_file(len: u64) -> (tempfile::TempDir, File) {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(dir.path().join("reserve.bin"))
+            .expect("create file");
+        file.set_len(len).expect("set_len");
+        (dir, file)
+    }
+
+    #[test]
+    fn zero_length_is_a_noop() {
+        let (_dir, file) = sparse_file(4096);
+        reserve_space(file.as_fd(), 0, 0).expect("zero length must succeed");
+        assert_eq!(file.metadata().expect("stat").len(), 4096);
+    }
+
+    /// On a platform that supports reserving, storage is actually allocated and
+    /// the logical size is untouched. Where it is unsupported the call must say
+    /// so through `Unsupported` rather than a bare errno, since callers branch
+    /// on exactly that to keep working.
+    #[test]
+    fn reserving_allocates_without_resizing() {
+        let len = 64 * 1024;
+        let (_dir, file) = sparse_file(len);
+        let blocks_before = file.metadata().expect("stat").blocks();
+
+        match reserve_space(file.as_fd(), 0, len) {
+            Ok(()) => {
+                let meta = file.metadata().expect("stat");
+                assert_eq!(meta.len(), len, "logical size must be preserved");
+                assert!(
+                    meta.blocks() > blocks_before,
+                    "storage should be reserved: {} -> {} blocks",
+                    blocks_before,
+                    meta.blocks()
+                );
+            }
+            Err(err) => assert!(
+                err.is_unsupported(),
+                "a platform without range reservation must report Unsupported, got {err}"
+            ),
+        }
+    }
+
+    /// Reserving an interior range must not change the file's logical size
+    /// either — the caller sized the file already and validates it on reload.
+    #[test]
+    fn reserving_an_interior_range_keeps_the_logical_size() {
+        let len = 64 * 1024;
+        let (_dir, file) = sparse_file(len);
+
+        match reserve_space(file.as_fd(), 16 * 1024, 16 * 1024) {
+            Ok(()) => {}
+            Err(err) => assert!(err.is_unsupported(), "unexpected failure: {err}"),
+        }
+        assert_eq!(
+            file.metadata().expect("stat").len(),
+            len,
+            "logical size must be preserved"
+        );
+    }
+}

--- a/storage/overlaybd/src/sys/sparse.rs
+++ b/storage/overlaybd/src/sys/sparse.rs
@@ -1,0 +1,37 @@
+//! Whether the filesystem's notion of "unwritten" is trustworthy.
+
+/// Whether this platform guarantees that regions of a file which were never
+/// written are reported as holes by `seek_data` / `seek_hole`.
+///
+/// Code that reconstructs "which blocks were written" from a file's extent map
+/// — see `lsmt::file::create_mappings_from_sparse` — depends on this. Getting it
+/// wrong is not a performance problem: a file that reports its *entire* range as
+/// data yields a mapping claiming every block belongs to the upper layer, which
+/// masks the lower layers with zeros.
+///
+/// # Linux
+///
+/// True. A region with no allocated extent is a hole, mechanically.
+///
+/// # macOS / APFS
+///
+/// False. Sparseness on APFS is a filesystem heuristic that the application
+/// cannot control — Apple's own description is that "APFS decides which are
+/// created as sparse files, and that can't be directly manipulated by the app or
+/// the user". Two measured consequences:
+///
+/// - There is a minimum file size below which APFS does not bother: the first
+///   write collapses the file to fully allocated, after which an extent scan
+///   reports one extent spanning the whole file. Measured on this Apple silicon
+///   host the threshold sits between 16 MiB and 24 MiB; published reports put it
+///   at 8 KiB on one Intel machine and 16 MiB on an M1, so it is neither
+///   documented nor portable.
+/// - Holes must be produced by seeking past them. Writing zeros does not create
+///   one, so "unwritten" and "reads as zero" are not the same thing.
+///
+/// `F_PUNCHHOLE` does reliably create reportable holes (that part is
+/// documented and measured), so this is specifically about inferring history
+/// from an extent map, not about hole punching.
+pub fn sparse_extents_are_reliable() -> bool {
+    cfg!(target_os = "linux")
+}

--- a/storage/overlaybd/src/sys/xattr.rs
+++ b/storage/overlaybd/src/sys/xattr.rs
@@ -1,0 +1,604 @@
+//! Extended attributes.
+//!
+//! Darwin's xattr calls carry two extra parameters (`position` and `options`)
+//! that Linux's do not, so every one of the eight entry points needs a
+//! per-platform shim. What does *not* need duplicating is the awkward part: the
+//! two-phase "ask for the size, then read" dance and the parsing of the
+//! NUL-separated name list. Those live here once and are shared by both
+//! platforms — before this module they existed as two separately written,
+//! subtly different copies in `backend/local.rs` and
+//! `backend/cache/cached_fs.rs`.
+//!
+//! Names and paths are taken as `&CStr` so that the "reject an interior NUL"
+//! policy, and the error context that goes with it, stay with the caller.
+
+use std::ffi::CStr;
+use std::os::fd::BorrowedFd;
+
+use nix::errno::Errno;
+
+use super::{SysError, SysResult};
+
+/// Read one attribute by descriptor.
+pub fn fgetxattr(fd: BorrowedFd<'_>, name: &CStr) -> SysResult<Vec<u8>> {
+    read_sized(|buf| imp::fgetxattr(fd, name, buf))
+}
+
+/// List attribute names by descriptor.
+pub fn flistxattr(fd: BorrowedFd<'_>) -> SysResult<Vec<String>> {
+    parse_nul_list(&read_sized(|buf| imp::flistxattr(fd, buf))?)
+}
+
+/// Write one attribute by descriptor.
+///
+/// `flags` carries Linux's `XATTR_*` semantics, and **only `0` is portable**.
+/// The numeric values do not line up: Linux uses 1 for `XATTR_CREATE` and 2 for
+/// `XATTR_REPLACE`, while Darwin uses 1 for `XATTR_NOFOLLOW`, 2 for
+/// `XATTR_CREATE` and 4 for `XATTR_REPLACE`. Forwarding a Linux flag to Darwin
+/// would therefore ask for a different operation — `XATTR_CREATE` would arrive
+/// as `XATTR_NOFOLLOW`, dropping the create-only guarantee without any error.
+///
+/// Rather than reinterpret the bits, the Darwin arms reject a non-zero value
+/// with [`SysError::Unsupported`](super::SysError::Unsupported). Every caller in
+/// this crate passes 0, so nothing is lost today; a caller that genuinely needs
+/// create/replace semantics should replace this parameter with a portable enum
+/// and translate it per arm, rather than have the current one silently mean two
+/// different things.
+pub fn fsetxattr(fd: BorrowedFd<'_>, name: &CStr, value: &[u8], flags: i32) -> SysResult<()> {
+    imp::fsetxattr(fd, name, value, flags)
+}
+
+/// Remove one attribute by descriptor.
+pub fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> SysResult<()> {
+    imp::fremovexattr(fd, name)
+}
+
+/// Read one attribute by path.
+pub fn getxattr(path: &CStr, name: &CStr) -> SysResult<Vec<u8>> {
+    read_sized(|buf| imp::getxattr(path, name, buf))
+}
+
+/// List attribute names by path.
+pub fn listxattr(path: &CStr) -> SysResult<Vec<String>> {
+    parse_nul_list(&read_sized(|buf| imp::listxattr(path, buf))?)
+}
+
+/// Write one attribute by path. See [`fsetxattr`] about `flags`.
+pub fn setxattr(path: &CStr, name: &CStr, value: &[u8], flags: i32) -> SysResult<()> {
+    imp::setxattr(path, name, value, flags)
+}
+
+/// Remove one attribute by path.
+pub fn removexattr(path: &CStr, name: &CStr) -> SysResult<()> {
+    imp::removexattr(path, name)
+}
+
+/// Run the two-phase size query shared by every reading xattr call.
+///
+/// `raw` is called with `None` to ask for the required length and with
+/// `Some(buf)` to fill it. The value can change between the two calls, and the
+/// two directions need different handling:
+///
+/// - It **shrank**: the fill call succeeds and reports fewer bytes than asked
+///   for, so the buffer is truncated to what it reported.
+/// - It **grew**: the buffer no longer fits and the fill call fails with
+///   `ERANGE`. Retrying re-queries the new size, so the read is retried a
+///   bounded number of times before giving up. Without this a concurrent
+///   attribute update turns an otherwise valid read into an error.
+///
+/// The retry is bounded rather than unbounded: a value being rewritten in a
+/// tight loop would otherwise spin here forever, and reporting `ERANGE` to the
+/// caller is the honest outcome once several attempts in a row have lost the
+/// race.
+fn read_sized(raw: impl Fn(Option<&mut [u8]>) -> SysResult<usize>) -> SysResult<Vec<u8>> {
+    /// Enough to ride out a racing writer without spinning on a pathological one.
+    const MAX_ATTEMPTS: usize = 4;
+
+    for _ in 0..MAX_ATTEMPTS {
+        let need = raw(None)?;
+        if need == 0 {
+            return Ok(Vec::new());
+        }
+        let mut buf = vec![0u8; need];
+        match raw(Some(&mut buf)) {
+            Ok(got) => {
+                buf.truncate(got.min(need));
+                return Ok(buf);
+            }
+            // Grew between the size query and the fill; ask again.
+            Err(SysError::Errno(Errno::ERANGE)) => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    Err(SysError::Errno(Errno::ERANGE))
+}
+
+/// Split the NUL-separated name list returned by `listxattr` / `flistxattr`.
+///
+/// Empty runs are dropped, which covers both the trailing NUL that terminates
+/// the last name and a zero-length buffer.
+///
+/// A name that is not valid UTF-8 is reported as `EILSEQ` rather than replaced
+/// lossily. Both platforms allow arbitrary bytes in an attribute name, and the
+/// surrounding API hands names back as `String` and builds a `CStr` from them to
+/// read or remove an attribute — so a name containing U+FFFD in place of the
+/// original bytes would not round-trip, and would quietly address a different
+/// attribute or none at all. Failing is recoverable; fabricating a name is not.
+fn parse_nul_list(buf: &[u8]) -> SysResult<Vec<String>> {
+    buf.split(|byte| *byte == 0)
+        .filter(|name| !name.is_empty())
+        .map(|name| {
+            std::str::from_utf8(name)
+                .map(str::to_owned)
+                .map_err(|_| SysError::Errno(Errno::EILSEQ))
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::ffi::CStr;
+    use std::os::fd::{AsRawFd, BorrowedFd};
+
+    use super::super::{SysError, SysResult};
+
+    /// Split a `read_sized` buffer argument into the raw pointer and length a
+    /// query-or-fill xattr call expects. `None` becomes a null pointer with
+    /// length 0, which every xattr call treats as "report the size".
+    fn dst(buf: Option<&mut [u8]>) -> (*mut libc::c_void, usize) {
+        match buf {
+            Some(buf) => (buf.as_mut_ptr() as *mut libc::c_void, buf.len()),
+            None => (std::ptr::null_mut(), 0),
+        }
+    }
+
+    pub(super) fn fgetxattr(
+        fd: BorrowedFd<'_>,
+        name: &CStr,
+        buf: Option<&mut [u8]>,
+    ) -> SysResult<usize> {
+        let (ptr, len) = dst(buf);
+        // SAFETY: `fd` and `name` are live; `ptr` is valid for `len` bytes, or
+        // null with `len == 0`.
+        let ret = unsafe { libc::fgetxattr(fd.as_raw_fd(), name.as_ptr(), ptr, len) };
+        // A negative return means the call failed; `try_from` rejects it and we
+        // read `errno` while it is still fresh.
+        usize::try_from(ret).map_err(|_| SysError::last())
+    }
+
+    pub(super) fn flistxattr(fd: BorrowedFd<'_>, buf: Option<&mut [u8]>) -> SysResult<usize> {
+        let (ptr, len) = dst(buf);
+        // SAFETY: as above; the list is written as `c_char` but the byte layout
+        // is identical.
+        let ret = unsafe { libc::flistxattr(fd.as_raw_fd(), ptr as *mut libc::c_char, len) };
+        // A negative return means the call failed; `try_from` rejects it and we
+        // read `errno` while it is still fresh.
+        usize::try_from(ret).map_err(|_| SysError::last())
+    }
+
+    pub(super) fn fsetxattr(
+        fd: BorrowedFd<'_>,
+        name: &CStr,
+        value: &[u8],
+        flags: i32,
+    ) -> SysResult<()> {
+        // SAFETY: `fd`, `name` and `value` are live for the call.
+        let ret = unsafe {
+            libc::fsetxattr(
+                fd.as_raw_fd(),
+                name.as_ptr(),
+                value.as_ptr() as *const libc::c_void,
+                value.len(),
+                flags,
+            )
+        };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+
+    pub(super) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> SysResult<()> {
+        // SAFETY: `fd` and `name` are live for the call.
+        let ret = unsafe { libc::fremovexattr(fd.as_raw_fd(), name.as_ptr()) };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+
+    pub(super) fn getxattr(path: &CStr, name: &CStr, buf: Option<&mut [u8]>) -> SysResult<usize> {
+        let (ptr, len) = dst(buf);
+        // SAFETY: `path` and `name` are live; `ptr` is valid for `len` bytes.
+        let ret = unsafe { libc::getxattr(path.as_ptr(), name.as_ptr(), ptr, len) };
+        // A negative return means the call failed; `try_from` rejects it and we
+        // read `errno` while it is still fresh.
+        usize::try_from(ret).map_err(|_| SysError::last())
+    }
+
+    pub(super) fn listxattr(path: &CStr, buf: Option<&mut [u8]>) -> SysResult<usize> {
+        let (ptr, len) = dst(buf);
+        // SAFETY: as above.
+        let ret = unsafe { libc::listxattr(path.as_ptr(), ptr as *mut libc::c_char, len) };
+        // A negative return means the call failed; `try_from` rejects it and we
+        // read `errno` while it is still fresh.
+        usize::try_from(ret).map_err(|_| SysError::last())
+    }
+
+    pub(super) fn setxattr(path: &CStr, name: &CStr, value: &[u8], flags: i32) -> SysResult<()> {
+        // SAFETY: all three pointers are live for the call.
+        let ret = unsafe {
+            libc::setxattr(
+                path.as_ptr(),
+                name.as_ptr(),
+                value.as_ptr() as *const libc::c_void,
+                value.len(),
+                flags,
+            )
+        };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+
+    pub(super) fn removexattr(path: &CStr, name: &CStr) -> SysResult<()> {
+        // SAFETY: both pointers are live for the call.
+        let ret = unsafe { libc::removexattr(path.as_ptr(), name.as_ptr()) };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::ffi::CStr;
+    use std::os::fd::{AsRawFd, BorrowedFd};
+
+    use super::super::{SysError, SysResult};
+
+    /// Darwin supports reading an attribute from a byte offset. Nothing in this
+    /// crate uses partial attributes, so every call starts at 0.
+    const POSITION: u32 = 0;
+
+    /// Darwin's `options` bitmask. 0 means "follow symlinks, no create/replace
+    /// constraint", matching the Linux calls being emulated.
+    const NO_OPTIONS: i32 = 0;
+
+    /// See the Linux arm: `None` becomes a null pointer with length 0.
+    fn dst(buf: Option<&mut [u8]>) -> (*mut libc::c_void, usize) {
+        match buf {
+            Some(buf) => (buf.as_mut_ptr() as *mut libc::c_void, buf.len()),
+            None => (std::ptr::null_mut(), 0),
+        }
+    }
+
+    /// Refuse a `flags` value that cannot be honoured here.
+    ///
+    /// The parameter carries Linux's `XATTR_*` numbering, and Darwin's differs:
+    /// Linux `XATTR_CREATE` (1) is Darwin `XATTR_NOFOLLOW`, and Linux
+    /// `XATTR_REPLACE` (2) is Darwin `XATTR_CREATE`. Passing the value straight
+    /// through would perform a *different, silently successful* operation, so
+    /// anything but 0 is refused. See [`super::fsetxattr`] for the full rationale.
+    fn reject_nonportable_flags(flags: i32) -> SysResult<()> {
+        if flags != 0 {
+            return Err(SysError::Unsupported(
+                "non-zero xattr flags on this platform",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn fgetxattr(
+        fd: BorrowedFd<'_>,
+        name: &CStr,
+        buf: Option<&mut [u8]>,
+    ) -> SysResult<usize> {
+        let (ptr, len) = dst(buf);
+        // SAFETY: `fd` and `name` are live; `ptr` is valid for `len` bytes, or
+        // null with `len == 0`.
+        let ret = unsafe {
+            libc::fgetxattr(
+                fd.as_raw_fd(),
+                name.as_ptr(),
+                ptr,
+                len,
+                POSITION,
+                NO_OPTIONS,
+            )
+        };
+        // A negative return means the call failed; `try_from` rejects it and we
+        // read `errno` while it is still fresh.
+        usize::try_from(ret).map_err(|_| SysError::last())
+    }
+
+    pub(super) fn flistxattr(fd: BorrowedFd<'_>, buf: Option<&mut [u8]>) -> SysResult<usize> {
+        let (ptr, len) = dst(buf);
+        // SAFETY: as above.
+        let ret =
+            unsafe { libc::flistxattr(fd.as_raw_fd(), ptr as *mut libc::c_char, len, NO_OPTIONS) };
+        // A negative return means the call failed; `try_from` rejects it and we
+        // read `errno` while it is still fresh.
+        usize::try_from(ret).map_err(|_| SysError::last())
+    }
+
+    pub(super) fn fsetxattr(
+        fd: BorrowedFd<'_>,
+        name: &CStr,
+        value: &[u8],
+        flags: i32,
+    ) -> SysResult<()> {
+        reject_nonportable_flags(flags)?;
+        // SAFETY: `fd`, `name` and `value` are live for the call.
+        let ret = unsafe {
+            libc::fsetxattr(
+                fd.as_raw_fd(),
+                name.as_ptr(),
+                value.as_ptr() as *const libc::c_void,
+                value.len(),
+                POSITION,
+                flags,
+            )
+        };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+
+    pub(super) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> SysResult<()> {
+        // SAFETY: `fd` and `name` are live for the call.
+        let ret = unsafe { libc::fremovexattr(fd.as_raw_fd(), name.as_ptr(), NO_OPTIONS) };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+
+    pub(super) fn getxattr(path: &CStr, name: &CStr, buf: Option<&mut [u8]>) -> SysResult<usize> {
+        let (ptr, len) = dst(buf);
+        // SAFETY: `path` and `name` are live; `ptr` is valid for `len` bytes.
+        let ret =
+            unsafe { libc::getxattr(path.as_ptr(), name.as_ptr(), ptr, len, POSITION, NO_OPTIONS) };
+        // A negative return means the call failed; `try_from` rejects it and we
+        // read `errno` while it is still fresh.
+        usize::try_from(ret).map_err(|_| SysError::last())
+    }
+
+    pub(super) fn listxattr(path: &CStr, buf: Option<&mut [u8]>) -> SysResult<usize> {
+        let (ptr, len) = dst(buf);
+        // SAFETY: as above.
+        let ret =
+            unsafe { libc::listxattr(path.as_ptr(), ptr as *mut libc::c_char, len, NO_OPTIONS) };
+        // A negative return means the call failed; `try_from` rejects it and we
+        // read `errno` while it is still fresh.
+        usize::try_from(ret).map_err(|_| SysError::last())
+    }
+
+    pub(super) fn setxattr(path: &CStr, name: &CStr, value: &[u8], flags: i32) -> SysResult<()> {
+        reject_nonportable_flags(flags)?;
+        // SAFETY: all three pointers are live for the call.
+        let ret = unsafe {
+            libc::setxattr(
+                path.as_ptr(),
+                name.as_ptr(),
+                value.as_ptr() as *const libc::c_void,
+                value.len(),
+                POSITION,
+                flags,
+            )
+        };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+
+    pub(super) fn removexattr(path: &CStr, name: &CStr) -> SysResult<()> {
+        // SAFETY: both pointers are live for the call.
+        let ret = unsafe { libc::removexattr(path.as_ptr(), name.as_ptr(), NO_OPTIONS) };
+        if ret == 0 {
+            return Ok(());
+        }
+        Err(SysError::last())
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod imp {
+    use std::ffi::CStr;
+    use std::os::fd::BorrowedFd;
+
+    use super::super::{SysError, SysResult};
+
+    macro_rules! unsupported {
+        ($name:ident) => {
+            Err(SysError::Unsupported(stringify!($name)))
+        };
+    }
+
+    pub(super) fn fgetxattr(
+        _fd: BorrowedFd<'_>,
+        _name: &CStr,
+        _buf: Option<&mut [u8]>,
+    ) -> SysResult<usize> {
+        unsupported!(fgetxattr)
+    }
+
+    pub(super) fn flistxattr(_fd: BorrowedFd<'_>, _buf: Option<&mut [u8]>) -> SysResult<usize> {
+        unsupported!(flistxattr)
+    }
+
+    pub(super) fn fsetxattr(
+        _fd: BorrowedFd<'_>,
+        _name: &CStr,
+        _value: &[u8],
+        _flags: i32,
+    ) -> SysResult<()> {
+        unsupported!(fsetxattr)
+    }
+
+    pub(super) fn fremovexattr(_fd: BorrowedFd<'_>, _name: &CStr) -> SysResult<()> {
+        unsupported!(fremovexattr)
+    }
+
+    pub(super) fn getxattr(
+        _path: &CStr,
+        _name: &CStr,
+        _buf: Option<&mut [u8]>,
+    ) -> SysResult<usize> {
+        unsupported!(getxattr)
+    }
+
+    pub(super) fn listxattr(_path: &CStr, _buf: Option<&mut [u8]>) -> SysResult<usize> {
+        unsupported!(listxattr)
+    }
+
+    pub(super) fn setxattr(
+        _path: &CStr,
+        _name: &CStr,
+        _value: &[u8],
+        _flags: i32,
+    ) -> SysResult<()> {
+        unsupported!(setxattr)
+    }
+
+    pub(super) fn removexattr(_path: &CStr, _name: &CStr) -> SysResult<()> {
+        unsupported!(removexattr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_nul_list_drops_the_trailing_terminator() {
+        assert_eq!(
+            parse_nul_list(b"user.a\0user.bb\0").expect("valid utf-8"),
+            vec!["user.a".to_string(), "user.bb".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_nul_list_handles_empty_and_unterminated_input() {
+        assert!(parse_nul_list(b"").expect("empty").is_empty());
+        assert!(parse_nul_list(b"\0\0")
+            .expect("only terminators")
+            .is_empty());
+        // An unterminated tail is still reported rather than silently dropped.
+        assert_eq!(
+            parse_nul_list(b"user.a").expect("valid utf-8"),
+            vec!["user.a".to_string()]
+        );
+    }
+
+    /// A name that is not UTF-8 must fail rather than come back with U+FFFD
+    /// substituted: the caller turns these names back into a `CStr` to read or
+    /// remove the attribute, and a substituted name addresses something else.
+    #[test]
+    fn parse_nul_list_rejects_a_non_utf8_name() {
+        let err = parse_nul_list(b"user.ok\0user.\xff\xfe\0")
+            .expect_err("a non-utf8 name must be rejected");
+        assert!(!err.is_unsupported(), "expected an errno, got {err}");
+    }
+
+    #[test]
+    fn read_sized_skips_the_second_call_when_empty() {
+        let calls = std::cell::Cell::new(0);
+        let out = read_sized(|_buf| {
+            calls.set(calls.get() + 1);
+            Ok(0)
+        })
+        .expect("read_sized");
+        assert!(out.is_empty());
+        assert_eq!(calls.get(), 1, "a zero-size attribute needs one call");
+    }
+
+    #[test]
+    fn read_sized_truncates_to_the_second_calls_result() {
+        // Size query reports 8, the fill reports only 3: the attribute shrank
+        // between the calls and the result must follow the fill.
+        let out = read_sized(|buf| match buf {
+            None => Ok(8),
+            Some(buf) => {
+                buf[..3].copy_from_slice(b"abc");
+                Ok(3)
+            }
+        })
+        .expect("read_sized");
+        assert_eq!(out, b"abc");
+    }
+
+    #[test]
+    fn read_sized_clamps_an_overlong_fill_result() {
+        let out = read_sized(|buf| match buf {
+            None => Ok(4),
+            Some(_) => Ok(99),
+        })
+        .expect("read_sized");
+        assert_eq!(out.len(), 4, "must not report more than was allocated");
+    }
+
+    /// The attribute grows between the size query and the fill, so the fill
+    /// reports `ERANGE`. Re-querying picks up the new size instead of failing a
+    /// read that is perfectly valid on the next attempt.
+    #[test]
+    fn read_sized_retries_when_the_value_grows_between_the_calls() {
+        let attempt = std::cell::Cell::new(0);
+        let out = read_sized(|buf| match buf {
+            // The first size query is already stale by the time it is used.
+            None => Ok(if attempt.get() == 0 { 3 } else { 6 }),
+            Some(buf) => {
+                if attempt.get() == 0 {
+                    attempt.set(1);
+                    return Err(SysError::Errno(Errno::ERANGE));
+                }
+                buf[..6].copy_from_slice(b"abcdef");
+                Ok(6)
+            }
+        })
+        .expect("a grown attribute must be re-read, not reported as an error");
+        assert_eq!(out, b"abcdef");
+    }
+
+    /// A value rewritten on every attempt must not spin forever; after a bounded
+    /// number of tries the race is reported rather than retried.
+    #[test]
+    fn read_sized_gives_up_on_an_endlessly_growing_value() {
+        let calls = std::cell::Cell::new(0);
+        let err = read_sized(|buf| match buf {
+            None => Ok(4),
+            Some(_) => {
+                calls.set(calls.get() + 1);
+                Err(SysError::Errno(Errno::ERANGE))
+            }
+        })
+        .expect_err("an unwinnable race must terminate with an error");
+        assert!(!err.is_unsupported(), "expected an errno, got {err}");
+        assert!(
+            calls.get() > 1 && calls.get() <= 8,
+            "expected a small bounded number of attempts, got {}",
+            calls.get()
+        );
+    }
+
+    /// Any other error from the fill is terminal — only `ERANGE` means "the size
+    /// moved under us".
+    #[test]
+    fn read_sized_does_not_retry_other_errors() {
+        let calls = std::cell::Cell::new(0);
+        let err = read_sized(|buf| match buf {
+            None => Ok(4),
+            Some(_) => {
+                calls.set(calls.get() + 1);
+                Err(SysError::Errno(Errno::EPERM))
+            }
+        })
+        .expect_err("EPERM must propagate");
+        assert!(!err.is_unsupported(), "expected an errno, got {err}");
+        assert_eq!(calls.get(), 1, "a non-ERANGE failure must not be retried");
+    }
+}

--- a/storage/overlaybd/src/tools/packaging.rs
+++ b/storage/overlaybd/src/tools/packaging.rs
@@ -159,3 +159,124 @@ pub async fn package_raw_as_overlaybd(source: &Path, output: &Path) -> Result<()
 
     build_result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lsmt::file::open_file_ro;
+    use std::os::unix::fs::FileExt;
+    use tempfile::TempDir;
+
+    const SECTOR: u64 = 512;
+
+    /// Create a `len`-byte file, then write `data_at` ranges into it, leaving the
+    /// rest unwritten. Whether the unwritten parts stay holes is up to the
+    /// filesystem — that is precisely the variable these tests must tolerate.
+    fn sparse_source(dir: &TempDir, len: u64, data_at: &[(u64, u8)]) -> std::path::PathBuf {
+        let path = dir.path().join("source.raw");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(len).unwrap();
+        for &(offset, fill) in data_at {
+            file.write_all_at(&vec![fill; SECTOR as usize], offset)
+                .unwrap();
+        }
+        file.sync_all().unwrap();
+        path
+    }
+
+    /// Read the whole sealed layer back in sector-aligned chunks.
+    async fn read_layer(path: &Path, len: u64) -> Vec<u8> {
+        let layer = open_file_ro(Arc::new(LocalFile::open_ro(path).unwrap()))
+            .await
+            .unwrap();
+        assert_eq!(
+            layer.size().await.unwrap(),
+            len,
+            "virtual size must survive"
+        );
+
+        let chunk = 1024 * 1024;
+        let mut out = Vec::with_capacity(len as usize);
+        let mut offset = 0u64;
+        while offset < len {
+            let want = chunk.min((len - offset) as usize);
+            out.extend_from_slice(&layer.read_at(offset, want).await.unwrap());
+            offset += want as u64;
+        }
+        out
+    }
+
+    /// The property that makes it safe to run this packager where allocation is
+    /// speculative: however much the filesystem allocated beyond what was
+    /// written, the packaged layer reads back byte-for-byte identical to the
+    /// source. Copying an allocated-but-never-written range costs space, never
+    /// correctness, because it is read out of the source, where it reads as
+    /// zeros.
+    #[tokio::test]
+    async fn package_raw_preserves_source_content_whatever_the_extent_map_says() {
+        let dir = TempDir::new().unwrap();
+        let len = 8 * 1024 * 1024;
+        let source = sparse_source(
+            &dir,
+            len,
+            &[(0, 0xAA), (1024 * 1024, 0xBB), (len - SECTOR, 0xCC)],
+        );
+        let output = dir.path().join("layer.commit");
+
+        package_raw_as_overlaybd(&source, &output).await.unwrap();
+
+        assert_eq!(
+            read_layer(&output, len).await,
+            std::fs::read(&source).unwrap(),
+            "packaged layer must read back identical to the source"
+        );
+
+        // Only assert the space saving where the filesystem actually guarantees
+        // it. APFS allocates across gaps below a ~16-20 MiB threshold, so this
+        // 8 MiB source is legitimately fully allocated there.
+        #[cfg(target_os = "linux")]
+        {
+            let packaged = std::fs::metadata(&output).unwrap().len();
+            assert!(
+                packaged < len / 2,
+                "sparse scan should have skipped the holes, but packaged {packaged} of {len}"
+            );
+        }
+    }
+
+    /// A source with nothing written at all: the scan yields no mappings, and
+    /// every absent mapping reads back as zeros.
+    #[tokio::test]
+    async fn package_raw_handles_a_source_with_no_data_at_all() {
+        let dir = TempDir::new().unwrap();
+        let len = 2 * 1024 * 1024;
+        let source = sparse_source(&dir, len, &[]);
+        let output = dir.path().join("layer.commit");
+
+        package_raw_as_overlaybd(&source, &output).await.unwrap();
+
+        assert!(
+            read_layer(&output, len).await.iter().all(|&b| b == 0),
+            "an all-holes source must read back as all zeros"
+        );
+    }
+
+    /// The block arithmetic in `create_mappings_from_sparse` truncates, so an
+    /// unaligned source size would drop its trailing partial sector from the
+    /// index and read back as zeros. That must be an error, not silent loss.
+    #[tokio::test]
+    async fn package_raw_rejects_a_source_whose_size_is_not_sector_aligned() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("source.raw");
+        std::fs::write(&path, vec![0xAB; 1000]).unwrap();
+
+        let err = package_raw_as_overlaybd(&path, &dir.path().join("layer.commit"))
+            .await
+            .expect_err("an unaligned source size must be rejected");
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("unaligned data extent"),
+            "expected an unaligned-extent error, got: {rendered}"
+        );
+    }
+}


### PR DESCRIPTION
## What

Makes overlaybd build and pass its tests on macOS (arm64). The starting point was 25 compile errors from a cargo check on a real macOS machine, every one of them a bare libc::/nix:: call whose ABI or availability differs on Darwin.

This adds storage/overlaybd/src/sys/, split by capability rather than by platform, each file owns one portable signature plus its own per-OS imp arms. The capabilities are extended attributes (8 entry points), space release, space reservation, page-cache eviction, filesystem capacity, the direct-IO open flag, and sparse-extent trustworthiness.

Two further commits reject the sparse upper layout on macOS at all three entry points that create or open an upper, and turn a pre-existing platform-independent hazard — a source file whose size is not a multiple of 512 silently losing its tail block from the index — into an explicit error.

## Why

Platform detail and overlaybd's own logic were interleaved. Syscall specifics sat inline in the cache, the LSMT layer, and the local-file backend, and the same two-phase xattr size query existed as two separately written, subtly different copies. Adding a second platform on those terms would have meant scattering cfg(target_os) through overlaybd code.

## Design and behavior changes

No changes for users.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed
