### PR TITLE
refactor(overlaybd): stream object-store uploads through one implementation

### DIFF
--- a/src/snapshot/repository/backends/oss/client.rs
+++ b/src/snapshot/repository/backends/oss/client.rs
@@ -10,7 +10,8 @@ use object_store_operator::{
     CredentialSource, ObjectStoreOperatorConfig, ObjectStoreOperatorError, OperatorWithCredential,
 };
 use opendal::{Error as OpenDalError, ErrorKind as OpenDalErrorKind, Operator};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use overlaybd::backend::oss::upload_file_streaming;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::RwLock;
 use tracing::info;
 use url::Url;
@@ -22,6 +23,12 @@ use crate::observability::prometheus::MetricGuard;
 /// (~625 GiB at 64 MiB). Must be passed explicitly to opendal via
 /// `writer_with().chunk()`: without it opendal falls back to the service's
 /// minimum multipart part size (5 MiB), capping uploads at ~50 GiB.
+///
+/// Note the memory cost, which is `(2 * UPLOAD_CONCURRENCY + 2) * CHUNK_SIZE`
+/// rather than the product of the two — **measured at 1040 MiB for these
+/// figures**. See `overlaybd::backend::oss::upload_file_streaming` for why.
+/// Deliberately left as it was when the upload loop moved there: shrinking it
+/// would also shrink the largest uploadable object.
 const CHUNK_SIZE: usize = 64 * 1024 * 1024;
 /// Number of multipart parts uploaded concurrently per file. A single
 /// sequential stream tops out at roughly 100 MB/s to the OSS internal
@@ -243,7 +250,16 @@ impl OssClient {
             self.run_with_operator(|operator| {
                 let oss_key = oss_key.clone();
                 let path = path.clone();
-                async move { upload_file_to_operator(&operator, &oss_key, &path).await }
+                async move {
+                    upload_file_streaming(
+                        &operator,
+                        &oss_key,
+                        &path,
+                        CHUNK_SIZE,
+                        UPLOAD_CONCURRENCY,
+                    )
+                    .await
+                }
             })
             .await
             .with_context(|| format!("oss put file '{key}'"))?;
@@ -432,34 +448,6 @@ async fn write_bytes_to_operator(
     data: Bytes,
 ) -> opendal::Result<()> {
     operator.write(key, data).await.map(|_| ())
-}
-
-async fn upload_file_to_operator(
-    operator: &Operator,
-    key: &str,
-    path: &Path,
-) -> opendal::Result<()> {
-    let mut writer = operator
-        .writer_with(key)
-        .chunk(CHUNK_SIZE)
-        .concurrent(UPLOAD_CONCURRENCY)
-        .await?;
-    let mut file = tokio::fs::File::open(path)
-        .await
-        .map_err(|err| io_error_to_opendal(err, "open upload source file"))?;
-    let mut buf = vec![0_u8; CHUNK_SIZE];
-    loop {
-        let read = file
-            .read(&mut buf)
-            .await
-            .map_err(|err| io_error_to_opendal(err, "read upload source file"))?;
-        if read == 0 {
-            break;
-        }
-        writer.write(buf[..read].to_vec()).await?;
-    }
-    writer.close().await?;
-    Ok(())
 }
 
 fn io_error_to_opendal(error: std::io::Error, message: &'static str) -> OpenDalError {

--- a/src/snapshot/repository/backends/oss/client.rs
+++ b/src/snapshot/repository/backends/oss/client.rs
@@ -257,6 +257,7 @@ impl OssClient {
                         &path,
                         CHUNK_SIZE,
                         UPLOAD_CONCURRENCY,
+                        None,
                     )
                     .await
                 }

--- a/storage/overlaybd/src/backend/oss.rs
+++ b/storage/overlaybd/src/backend/oss.rs
@@ -14,6 +14,7 @@ use reqwest::Url;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
@@ -136,12 +137,16 @@ impl OssBackend {
     /// credential refresh restarts the upload from byte zero rather than
     /// resuming a partly written multipart, which is the only outcome the object
     /// store guarantees is coherent.
+    ///
+    /// `progress`, when supplied, is polled by the caller while this runs; see
+    /// [`upload_file_streaming`] for what it holds and what it does not.
     pub async fn upload_path(
         &self,
         url: impl AsRef<str>,
         path: impl AsRef<Path>,
         part_size: usize,
         concurrency: usize,
+        progress: Option<&AtomicU64>,
     ) -> Result<()> {
         let location = ParsedOssUrl::parse(
             url.as_ref(),
@@ -157,7 +162,8 @@ impl OssBackend {
                 let key = key.clone();
                 let path = path.clone();
                 async move {
-                    upload_file_streaming(&operator, &key, &path, part_size, concurrency).await
+                    upload_file_streaming(&operator, &key, &path, part_size, concurrency, progress)
+                        .await
                 }
             })
             .await
@@ -559,6 +565,32 @@ impl VirtualFile for OssFile {
 /// the writer buffers up to the part size itself, so the part boundaries the
 /// endpoint sees do not follow the read boundaries here.
 ///
+/// # Progress
+///
+/// `progress`, when supplied, holds the bytes handed to the writer so far, for a
+/// caller reporting on an upload measured in GiB — a layer-sized upload is
+/// otherwise a single `await` that returns nothing for minutes, which reads the
+/// same as a hang.
+///
+/// A counter the caller *polls* rather than a callback it is pushed to, because
+/// the one consumer samples on a timer. That also keeps the caller's reporting
+/// cadence independent of the write rate: it still prints during `close()`, where
+/// the multipart is completed and no bytes move at all, which is exactly the phase
+/// where a large upload was seen to stall.
+///
+/// Two things it is not:
+///
+/// - **Not bytes the endpoint has taken.** Parts are buffered and uploaded
+///   concurrently, so this runs ahead of anything durable.
+/// - **Not monotonic.** It is reset at entry, because *this function* is the unit
+///   [`OssBackend::upload_path`] retries: on a `PermissionDenied` the credential is
+///   refreshed and the whole upload restarts from byte zero
+///   (`object-store-operator/src/operator.rs:121-148`). So the counter is the
+///   position within the current attempt and can drop back to zero once. A reader
+///   must treat it as an absolute position and never difference two samples —
+///   letting it accumulate across the retry instead would report ~169 % of a
+///   file's size as uploaded.
+///
 /// # Memory
 ///
 /// **Peak memory is roughly `(2 * concurrency + 2) * part_size`, not the product
@@ -587,7 +619,13 @@ pub async fn upload_file_streaming(
     path: &Path,
     part_size: usize,
     concurrency: usize,
+    progress: Option<&AtomicU64>,
 ) -> OpenDalResult<()> {
+    // First statement of the retried unit, so the count always describes the
+    // attempt now underway. See the `# Progress` section above.
+    if let Some(progress) = progress {
+        progress.store(0, Ordering::Relaxed);
+    }
     let mut writer = operator
         .writer_with(key)
         .chunk(part_size)
@@ -608,6 +646,10 @@ pub async fn upload_file_streaming(
             break;
         }
         writer.write(buf[..read].to_vec()).await?;
+        // After the writer accepts it: "handed off", not "acknowledged".
+        if let Some(progress) = progress {
+            progress.fetch_add(read as u64, Ordering::Relaxed);
+        }
     }
 
     // Only `close` completes the multipart upload. Dropping the writer abandons

--- a/storage/overlaybd/src/backend/oss.rs
+++ b/storage/overlaybd/src/backend/oss.rs
@@ -16,10 +16,18 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::io::AsyncReadExt;
 use tokio::sync::{Mutex, RwLock};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_RETRY_COUNT: u32 = 3;
+
+/// Read granularity for the upload source.
+///
+/// Matches tokio's `DEFAULT_MAX_BUF_SIZE` (`tokio/src/io/blocking.rs:27`), which
+/// caps what one `tokio::fs::File::read` returns regardless of the buffer handed
+/// to it. A larger buffer here would sit resident with 97% of it never written to.
+const UPLOAD_READ_SIZE: usize = 2 * 1024 * 1024;
 
 #[derive(Clone, Debug)]
 pub struct OssBackend {
@@ -117,11 +125,84 @@ impl OssBackend {
         Ok(file)
     }
 
-    pub async fn upload_path(&self, url: impl AsRef<str>, path: impl AsRef<Path>) -> Result<()> {
-        let body = tokio::fs::read(path.as_ref())
+    /// Upload a local file as one object, streamed in `part_size` parts with
+    /// `concurrency` of them in flight. Both figures carry consequences — peak
+    /// memory and the largest uploadable object — documented on
+    /// [`upload_file_streaming`], which is where to look before picking them.
+    ///
+    /// Streaming rather than reading the file in matters because the callers
+    /// upload sealed LSMT layers, whose size is the guest's written data — GiB,
+    /// not MiB. Note that the file is opened *inside* the retried closure: a
+    /// credential refresh restarts the upload from byte zero rather than
+    /// resuming a partly written multipart, which is the only outcome the object
+    /// store guarantees is coherent.
+    pub async fn upload_path(
+        &self,
+        url: impl AsRef<str>,
+        path: impl AsRef<Path>,
+        part_size: usize,
+        concurrency: usize,
+    ) -> Result<()> {
+        let location = ParsedOssUrl::parse(
+            url.as_ref(),
+            &self.inner.default_endpoint,
+            &self.inner.default_region,
+            self.inner.addressing_override,
+        )?;
+        let key = location.key.clone();
+        let path = path.as_ref().to_path_buf();
+
+        self.inner
+            .run_with_operator(&location, |operator| {
+                let key = key.clone();
+                let path = path.clone();
+                async move {
+                    upload_file_streaming(&operator, &key, &path, part_size, concurrency).await
+                }
+            })
             .await
-            .with_context(|| format!("read staged oss upload file {}", path.as_ref().display()))?;
-        self.upload_bytes(url, body).await
+            .with_context(|| {
+                format!(
+                    "upload oss object '{}' from {}",
+                    url.as_ref(),
+                    path.display()
+                )
+            })
+    }
+
+    /// Content length of an object, or `None` when it does not exist.
+    ///
+    /// Exists so a caller can skip re-uploading a content-addressed object, and
+    /// so that deciding "absent" does not require the caller to name
+    /// `opendal::Error`. Doing so would make the caller's `downcast_ref` depend on
+    /// resolving to the same `opendal` version this crate does — a mismatch
+    /// compiles, then silently never matches.
+    ///
+    /// `NotFound` is folded into `None` inside the closure, where `error.kind()`
+    /// is still available directly. That keeps this independent of how faithfully
+    /// [`map_object_store_operator_error`] preserves the kind afterwards.
+    pub async fn object_size(&self, url: impl AsRef<str>) -> Result<Option<u64>> {
+        let location = ParsedOssUrl::parse(
+            url.as_ref(),
+            &self.inner.default_endpoint,
+            &self.inner.default_region,
+            self.inner.addressing_override,
+        )?;
+        let key = location.key.clone();
+
+        self.inner
+            .run_with_operator(&location, |operator| {
+                let key = key.clone();
+                async move {
+                    match operator.stat(&key).await {
+                        Ok(metadata) => Ok(Some(metadata.content_length())),
+                        Err(error) if error.kind() == OpenDalErrorKind::NotFound => Ok(None),
+                        Err(error) => Err(error),
+                    }
+                }
+            })
+            .await
+            .with_context(|| format!("stat oss object '{}'", url.as_ref()))
     }
 
     pub async fn upload_bytes(&self, url: impl AsRef<str>, body: Vec<u8>) -> Result<()> {
@@ -434,10 +515,116 @@ impl VirtualFile for OssFile {
     }
 }
 
+/// Stream `path` into `key`, in parts of `part_size` with `concurrency` of them
+/// in flight.
+///
+/// Shared by every caller that uploads a file to object storage, including
+/// AgentENV's snapshot repository, which reaches it through its own `Operator`
+/// rather than through [`OssBackend`]. **Deliberately no defaults for the two
+/// figures**: each is a real trade with consequences that differ per caller — a
+/// snapshot service that must handle huge images and a tool sharing a host with
+/// running VMs should not land on the same numbers by inheriting them. Pick them
+/// where the constraints are known and record the reasoning there.
+///
+/// # Part size
+///
+/// `part_size` is a request, not a guarantee: OpenDAL clamps it into the service's
+/// `[write_multi_min_size, write_multi_max_size]`
+/// (`opendal/src/types/context/write.rs:79-92`), which for S3 is
+/// **[5 MiB, 5 GiB]** (`opendal/src/services/s3/backend.rs:927-938`, citing AWS's
+/// rule that every part but the last is at least 5 MiB). Asking for less than the
+/// floor is silently raised, so a caller's memory estimate would come out low
+/// rather than the upload failing. That bound belongs to the service, which is why
+/// it is not re-checked here.
+///
+/// **It also bounds the largest object that can be uploaded**, because S3 caps a
+/// multipart upload at 10,000 parts:
+///
+/// | part size | largest object | peak memory at concurrency 4 |
+/// |---|---|---|
+/// | 5 MiB (the service floor) | 50 GiB | ~50 MiB |
+/// | 16 MiB | 156 GiB | ~132 MiB |
+/// | 32 MiB | 312 GiB | ~260 MiB |
+/// | 64 MiB | 625 GiB | ~1040 MiB |
+///
+/// **Nothing checks that ceiling.** OpenDAL mentions it only in a comment next to
+/// the code that shifts the part index from 0-based to 1-based
+/// (`opendal/src/services/s3/writer.rs:115`), and its capability model has no field
+/// for a part count at all. Part 10,001 is sent and the *endpoint* rejects it, so
+/// exceeding it surfaces partway through an upload as a server-side
+/// `InvalidArgument` rather than up front. A caller uploading something that could
+/// exceed its ceiling has to raise the part size itself.
+///
+/// Short reads are forwarded as-is rather than being gathered into full parts:
+/// the writer buffers up to the part size itself, so the part boundaries the
+/// endpoint sees do not follow the read boundaries here.
+///
+/// # Memory
+///
+/// **Peak memory is roughly `(2 * concurrency + 2) * part_size`, not the product
+/// of the two.** Measured against a live endpoint with a 1 GiB object: 1040 MiB at
+/// 64 MiB × 8 and 132 MiB at 16 MiB × 4, against bounds of 1152 and 160. Where the
+/// parts are held, top to bottom through OpenDAL 0.55:
+///
+/// - `WriteGenerator` accumulates writes into a `QueueBuf` until they reach the
+///   part size, then hands them on via `take().collect()`. That collect is *not*
+///   a copy: `FromIterator<Bytes> for Buffer` allocates only an `Arc<[Bytes]>`
+///   index over the pieces already there, so the accumulating queue and the
+///   collected buffer are the same memory, counted once.
+/// - `MultipartWriter` holds one part in `cache`, dispatching it only when the
+///   next one arrives — it cannot know a part is the last until another shows up,
+///   and a lone part is uploaded with `write_once` (a single PutObject) instead of
+///   paying three round trips for a multipart.
+/// - `ConcurrentTasks` admits a new task while
+///   `tasks.len() < concurrent + min(completed_but_unretrieved, prefetch)`, and
+///   `MultipartWriter` hardcodes `prefetch` to 8192 while never draining results
+///   before `close()`. A finished task keeps its input buffer alive for retry, so
+///   every completed part raises that ceiling by one. It settles near twice
+///   `concurrent` rather than growing with the file, but it is twice, not once.
+pub async fn upload_file_streaming(
+    operator: &Operator,
+    key: &str,
+    path: &Path,
+    part_size: usize,
+    concurrency: usize,
+) -> OpenDalResult<()> {
+    let mut writer = operator
+        .writer_with(key)
+        .chunk(part_size)
+        .concurrent(concurrency)
+        .await?;
+    let mut file = tokio::fs::File::open(path).await.map_err(|err| {
+        OpenDalError::new(OpenDalErrorKind::Unexpected, "open oss upload source file")
+            .set_source(err)
+    })?;
+
+    let mut buf = vec![0u8; UPLOAD_READ_SIZE];
+    loop {
+        let read = file.read(&mut buf).await.map_err(|err| {
+            OpenDalError::new(OpenDalErrorKind::Unexpected, "read oss upload source file")
+                .set_source(err)
+        })?;
+        if read == 0 {
+            break;
+        }
+        writer.write(buf[..read].to_vec()).await?;
+    }
+
+    // Only `close` completes the multipart upload. Dropping the writer abandons
+    // it, so the object either appears whole or not at all.
+    writer.close().await?;
+    Ok(())
+}
+
 fn map_object_store_operator_error(error: ObjectStoreOperatorError) -> anyhow::Error {
     match error {
         ObjectStoreOperatorError::OpenDal(error) => match error.kind() {
-            OpenDalErrorKind::NotFound => anyhow::anyhow!("Object not found"),
+            // Keep the `OpenDalError` on the chain rather than replacing it with a
+            // fresh message. `NotFound` is the one kind a caller routinely needs to
+            // act on — "absent" and "cannot tell" call for opposite decisions — and
+            // discarding it left only the message text to match on. The top-level
+            // `to_string()` is unchanged, so anything doing that still works.
+            OpenDalErrorKind::NotFound => anyhow::Error::from(error).context("Object not found"),
             OpenDalErrorKind::PermissionDenied => anyhow::anyhow!("Access denied").context(error),
             _ => error.into(),
         },

--- a/storage/overlaybd/src/image/image_service.rs
+++ b/storage/overlaybd/src/image/image_service.rs
@@ -505,6 +505,7 @@ impl ImageService {
                 &stage_path,
                 OSS_SEALED_UPLOAD_PART_SIZE,
                 OSS_SEALED_UPLOAD_CONCURRENCY,
+                None,
             )
             .await;
         // Always clean up the staging file regardless of upload outcome.

--- a/storage/overlaybd/src/image/image_service.rs
+++ b/storage/overlaybd/src/image/image_service.rs
@@ -211,6 +211,22 @@ impl ImageService {
         &self.inner.global_config
     }
 
+    /// The object-store backend, or `None` when `ossConfig.enable` is false.
+    ///
+    /// Exposed so a caller that needs object storage for its own purposes — reading
+    /// a metadata object, uploading a sealed layer — shares this one instead of
+    /// constructing a second `OssBackend` from the same `ossConfig`. A second one
+    /// would work, but it would carry its own operator cache and its own resolved
+    /// credentials, and a `credentialProcess` costs a subprocess per cache miss.
+    /// `OssBackend` is `Arc`-backed, so a clone of the returned value shares both.
+    ///
+    /// **This initializes the whole remote runtime**, including the registry client
+    /// and the file cache, because they share one `OnceCell` with the backend. A
+    /// caller serving only local images should check `ossConfig.enable` and not ask.
+    pub async fn oss_backend(&self) -> Result<Option<&OssBackend>> {
+        Ok(self.remote_runtime().await?.oss_backend.as_ref())
+    }
+
     pub fn io_engine(&self) -> u32 {
         self.inner.global_config.io_engine
     }

--- a/storage/overlaybd/src/image/image_service.rs
+++ b/storage/overlaybd/src/image/image_service.rs
@@ -23,6 +23,21 @@ use uuid::Uuid;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Upload shape for [`ImageService::export_upper_as_oss_sealed`].
+///
+/// Sized for the ceiling rather than for memory, because this entry point is
+/// library surface: it can be handed an image of any size, and the part size is
+/// what bounds how large that may be. S3 allows 10,000 parts, so 64 MiB caps a
+/// single object at ~625 GiB, where 16 MiB would cap it at 156 GiB — and
+/// exceeding the cap is not caught up front, it fails partway through the upload.
+///
+/// The price is memory: peak is `(2 * concurrency + 2) * part_size`, so ~640 MiB
+/// here. Concurrency stays at 4 to keep that from doubling; past the point where
+/// it covers the round-trip time, more parts in flight buy little. See
+/// `backend::oss::upload_file_streaming` for both derivations.
+const OSS_SEALED_UPLOAD_PART_SIZE: usize = 64 * 1024 * 1024;
+const OSS_SEALED_UPLOAD_CONCURRENCY: usize = 4;
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum RemoteOpenMode {
     Direct,
@@ -484,7 +499,14 @@ impl ImageService {
         }
 
         stage_file.sync().await?;
-        let upload_result = oss.upload_path(dest_url, &stage_path).await;
+        let upload_result = oss
+            .upload_path(
+                dest_url,
+                &stage_path,
+                OSS_SEALED_UPLOAD_PART_SIZE,
+                OSS_SEALED_UPLOAD_CONCURRENCY,
+            )
+            .await;
         // Always clean up the staging file regardless of upload outcome.
         // The staging file is a full copy of the sealed upper layer and can
         // be large; leaving it on disk across failures would accumulate waste.

--- a/storage/overlaybd/tests/oss_backend_minio.rs
+++ b/storage/overlaybd/tests/oss_backend_minio.rs
@@ -3,6 +3,11 @@ use anyhow::Error;
 use overlaybd::backend::oss::OssBackend;
 use overlaybd::config::OssConfig;
 
+/// Upload shape for the probes. 16 MiB is what a layer upload uses in practice;
+/// the seam assertions below are derived from it rather than hardcoded.
+const PROBE_PART_SIZE: usize = 16 * 1024 * 1024;
+const PROBE_CONCURRENCY: usize = 4;
+
 // Run with: cargo test -p overlaybd --test oss_backend_minio -- --ignored
 
 fn backend(fixture: &MinioFixture) -> OssBackend {
@@ -176,5 +181,77 @@ async fn minio_read_nonexistent_object_returns_error() {
             || error_chain_contains(&err, "Not Found")
             || error_chain_contains(&err, "NotFound"),
         "expected not-found error, got: {err}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires docker"]
+async fn minio_upload_path_streams_a_file_larger_than_one_part() {
+    let fixture = MinioFixture::start().await.expect("start minio");
+    let backend = backend(&fixture);
+    let url = fixture.object_url("stream-test/layer");
+
+    // Larger than the part size, so the upload actually takes the multipart
+    // path rather than a single PUT. A byte pattern that varies with
+    // the offset would catch parts being uploaded in the wrong order.
+    let size = 70 * 1024 * 1024usize;
+    let temp = tempfile::NamedTempFile::new().expect("create upload source");
+    let payload: Vec<u8> = (0..size).map(|offset| (offset % 251) as u8).collect();
+    std::fs::write(temp.path(), &payload).expect("write upload source");
+
+    backend
+        .upload_path(&url, temp.path(), PROBE_PART_SIZE, PROBE_CONCURRENCY)
+        .await
+        .expect("stream upload to minio");
+
+    let file = backend
+        .open_with_size_hint(&url, None)
+        .expect("open the streamed object");
+    assert_eq!(file.size().await.expect("size"), size as u64);
+    let head = file.read_at(0, 4096).await.expect("read the first chunk");
+    assert_eq!(head.as_ref(), &payload[..4096]);
+    // Straddles the first part boundary, where a mis-ordered or truncated part
+    // would show up.
+    let seam = PROBE_PART_SIZE - 2048;
+    let got = file
+        .read_at(seam as u64, 4096)
+        .await
+        .expect("read the seam");
+    assert_eq!(got.as_ref(), &payload[seam..seam + 4096]);
+}
+
+#[tokio::test]
+#[ignore = "requires docker"]
+async fn minio_object_size_distinguishes_missing_from_empty() {
+    let fixture = MinioFixture::start().await.expect("start minio");
+    let backend = backend(&fixture);
+
+    let missing = fixture.object_url("size-probe/absent");
+    assert_eq!(
+        backend.object_size(&missing).await.expect("probe missing"),
+        None,
+        "a missing object must be None rather than an error"
+    );
+
+    // An empty object exists and has length zero, which must not be confused
+    // with absence: callers skip an upload on Some(_) and perform one on None.
+    let empty = fixture.object_url("size-probe/empty");
+    backend
+        .upload_bytes(&empty, Vec::new())
+        .await
+        .expect("upload an empty object");
+    assert_eq!(
+        backend.object_size(&empty).await.expect("probe empty"),
+        Some(0)
+    );
+
+    let present = fixture.object_url("size-probe/present");
+    backend
+        .upload_bytes(&present, b"twelve bytes".to_vec())
+        .await
+        .expect("upload");
+    assert_eq!(
+        backend.object_size(&present).await.expect("probe present"),
+        Some(12)
     );
 }

--- a/storage/overlaybd/tests/oss_backend_minio.rs
+++ b/storage/overlaybd/tests/oss_backend_minio.rs
@@ -200,7 +200,7 @@ async fn minio_upload_path_streams_a_file_larger_than_one_part() {
     std::fs::write(temp.path(), &payload).expect("write upload source");
 
     backend
-        .upload_path(&url, temp.path(), PROBE_PART_SIZE, PROBE_CONCURRENCY)
+        .upload_path(&url, temp.path(), PROBE_PART_SIZE, PROBE_CONCURRENCY, None)
         .await
         .expect("stream upload to minio");
 


### PR DESCRIPTION
## What

Moves AgentENV's streaming multipart upload loop into overlaybd as backend::oss::upload_file_streaming, and routes both callers through it: the snapshot repository's put_file and OssBackend::upload_path. Part size and concurrency are passed in by the caller rather than baked in.

Also adds OssBackend::object_size, an optional progress counter, and an ImageService::oss_backend() accessor so a caller can share the existing backend instead of constructing a second one.

## Why

AgentENV's snapshot repository already uploaded files as a streaming multipart. overlaybd's own OssBackend::upload_path did not: it read the entire file into memory, and upload_bytes then cloned that buffer again inside the retry closure. Layers are gigabytes, so a 3 GiB layer needed roughly 6 GiB of resident memory, and the cost grows with the layer, which becomes acceptable.

Rather than add a second implementation, the streaming loop moves into overlaybd and both callers use it, leaving one upload path with one set of retry semantics. Part size and concurrency stay caller-supplied because they set both the memory ceiling and the largest uploadable object (S3 caps a multipart at 10,000 parts), and the two callers do not want the same trade-off.

## Design and behavior changes

No changes to existing behaviors, only update interfaces for overlaybd crate users.

## Validation

<!-- Check only commands you actually ran. Add focused tests and exact commands below. -->

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed