### PR TITLE
api: accept the E2B SDK's deprecated alias as the v3 template name

### DIFF
--- a/src/api/generated/src/models.rs
+++ b/src/api/generated/src/models.rs
@@ -7947,6 +7947,12 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<TemplateBuil
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct TemplateBuildRequestV3 {
+    /// Alias of the template. Deprecated, use name instead.
+    #[serde(rename = "alias")]
+    #[validate(length(max = 128), custom(function = "check_xss_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+
     /// Name of the template. Can include a tag with colon separator (e.g. \"my-template\" or \"my-template:v1\"). If tag is included, it will be treated as if the tag was provided in the tags array.
     #[serde(rename = "name")]
     #[validate(length(max = 128), custom(function = "check_xss_string"))]
@@ -7976,6 +7982,7 @@ impl TemplateBuildRequestV3 {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> TemplateBuildRequestV3 {
         TemplateBuildRequestV3 {
+            alias: None,
             name: None,
             tags: None,
             cpu_count: None,
@@ -7990,6 +7997,9 @@ impl TemplateBuildRequestV3 {
 impl std::fmt::Display for TemplateBuildRequestV3 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+            self.alias
+                .as_ref()
+                .map(|alias| ["alias".to_string(), alias.to_string()].join(",")),
             self.name
                 .as_ref()
                 .map(|name| ["name".to_string(), name.to_string()].join(",")),
@@ -8030,6 +8040,7 @@ impl std::str::FromStr for TemplateBuildRequestV3 {
         #[derive(Default)]
         #[allow(dead_code)]
         struct IntermediateRep {
+            pub alias: Vec<String>,
             pub name: Vec<String>,
             pub tags: Vec<Vec<String>>,
             pub cpu_count: Vec<u32>,
@@ -8056,6 +8067,8 @@ impl std::str::FromStr for TemplateBuildRequestV3 {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
+                    #[allow(clippy::redundant_clone)]
+                    "alias" => intermediate_rep.alias.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     "tags" => return std::result::Result::Err("Parsing a container in this style is not supported in TemplateBuildRequestV3".to_string()),
                     #[allow(clippy::redundant_clone)]
@@ -8072,6 +8085,7 @@ impl std::str::FromStr for TemplateBuildRequestV3 {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(TemplateBuildRequestV3 {
+            alias: intermediate_rep.alias.into_iter().next(),
             name: intermediate_rep.name.into_iter().next(),
             tags: intermediate_rep.tags.into_iter().next(),
             cpu_count: intermediate_rep.cpu_count.into_iter().next(),

--- a/src/api/impls/template.rs
+++ b/src/api/impls/template.rs
@@ -534,7 +534,7 @@ impl Templates<()> for ApiImpl {
         _claims: &Self::Claims,
         body: &models::TemplateBuildRequestV3,
     ) -> Result<V3TemplatesPostResponse, ()> {
-        let Some(name) = body.name.clone() else {
+        let Some(name) = template_name_from_v3_request(body) else {
             return Ok(V3TemplatesPostResponse::Status400_BadRequest(Self::error(
                 400,
                 "template name must be provided",
@@ -797,9 +797,19 @@ impl Templates<()> for ApiImpl {
     }
 }
 
+/// The template name of a v3 build request: `name`, or the deprecated `alias`
+/// that E2B's schema still carries and the E2B Python SDK (2.10 and earlier)
+/// sends. Accepting it lets SDK clients build templates.
+fn template_name_from_v3_request(body: &models::TemplateBuildRequestV3) -> Option<String> {
+    body.name
+        .clone()
+        .or_else(|| body.alias.clone())
+        .filter(|name| !name.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::pipeline_build_error;
+    use super::{models, pipeline_build_error, template_name_from_v3_request};
 
     #[test]
     fn pipeline_build_error_maps_invalid_input_to_bad_request() {
@@ -823,5 +833,24 @@ mod tests {
 
         assert_eq!(error.code, 400);
         assert!(error.message.contains("dup"));
+    }
+
+    #[test]
+    fn v3_template_name_accepts_name_and_sdk_alias() {
+        let mut body = models::TemplateBuildRequestV3::new();
+        assert_eq!(template_name_from_v3_request(&body), None);
+        body.alias = Some("from-sdk".to_string());
+        assert_eq!(
+            template_name_from_v3_request(&body).as_deref(),
+            Some("from-sdk")
+        );
+        body.name = Some("explicit".to_string());
+        assert_eq!(
+            template_name_from_v3_request(&body).as_deref(),
+            Some("explicit")
+        );
+        body.name = Some(String::new());
+        body.alias = None;
+        assert_eq!(template_name_from_v3_request(&body), None);
     }
 }

--- a/src/api/openapi.yml
+++ b/src/api/openapi.yml
@@ -927,6 +927,11 @@ components:
 
     TemplateBuildRequestV3:
       properties:
+        alias:
+          description: Alias of the template. Deprecated, use name instead.
+          type: string
+          maxLength: 128
+          deprecated: true
         name:
           description: Name of the template. Can include a tag with colon separator (e.g. "my-template" or "my-template:v1"). If tag is included, it will be treated as if the tag was provided in the tags array.
           type: string


### PR DESCRIPTION
## What

`POST /v3/templates` accepts the template name as `name` or as the deprecated `alias`, instead of `name` only. The OpenAPI schema and the generated model gain the `alias` field, copied from E2B's schema; the handler resolves the name through one helper with a unit test.

## Why

E2B's current schema (`spec/openapi.yml` in e2b-dev/infra) defines `TemplateBuildRequestV3` as `name` + `tags` + `alias`, the last marked deprecated ("use name instead"), and E2B's own API still accepts it. AgentENV implements `name` and `tags` but not `alias`.

The e2b Python SDK switched from sending `alias` to sending `name` somewhere after 2.10.2 — the last release that supports Python 3.9. Current releases (2.46.0) work against AgentENV as-is; a client on Python 3.9, or on any SDK ≤ 2.10, gets `400 template name must be provided` and cannot build a template at all, while everything after that (create from the alias, exec, host routing) works. Accepting the deprecated field, as E2B does, closes that gap without changing what `name` means.

## Related issue

None filed. Reproducer: `Template.build` from e2b 2.10.2 (Python 3.9) against v0.1.3.

## Scope and non-goals

Included: schema, the generated model field (hand-added in the generator's style, since the model is checked in), name resolution in `v3_templates_post`. Not included: template tags (still rejected by the existing check), `teamID`, and any change to the v2 build-start request.

## Design and behavior changes

`name` wins over `alias`; an empty string counts as absent. No other data flow changes.

## Compatibility and operations

- Public API or generated protocol: one optional, deprecated field added to `TemplateBuildRequestV3`, matching E2B's schema; existing clients sending `name` are unaffected.
- Configuration or defaults: N/A.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: stateless; rolling back only re-breaks the old SDKs.

## Verification

`make fmt`, `cargo clippy -p agentenv --lib -- -D warnings`, and the new unit test pass. Against a v0.1.3 cluster, e2b 2.10.2's request fails today and succeeds once the body also carries `name` (tested by patching the request client-side); e2b 2.46.0 builds and runs templates against the unpatched server.
