### PR TITLE
fix(ublk): decouple proactive prewarm from idle cache capacity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ coverage:
 test: test-agent test-envd test-ublk
 
 test-unit:
-	$(CARGO) test -p agentenv -p envd -p linux-cap --lib
+	$(CARGO) test -p agentenv -p envd -p linux-cap -p warm-pool --lib
 	$(CAPABILITY_TEST_ENV) $(CAPABILITY_RUNNER) $(CARGO) test -p agentenv --lib -- --ignored
 	$(CAPABILITY_TEST_ENV) $(CAPABILITY_RUNNER) $(CARGO) test -p uvm-ublk -p uvm-ublk-daemon --lib
 	bash scripts/tests/verify-capability-runner.sh

--- a/config/default.toml
+++ b/config/default.toml
@@ -291,6 +291,10 @@ maintenance_enabled = true
 [pool.block]
 # Enable the reusable OverlayBD ublk-device pool.
 enabled = true
+# Limit proactive device creation independently from the total idle cache.
+# Returned devices may still fill pool.high_watermark. Omit this setting to
+# preserve the current behavior and use pool.high_watermark as the limit.
+# prewarm_high_watermark = 8
 # Omit to prewarm only when the kernel supports UBLK_F_UPDATE_SIZE. Set an
 # explicit boolean to override capability-based selection.
 # startup_prewarm = true

--- a/crates/warm-pool/src/lib.rs
+++ b/crates/warm-pool/src/lib.rs
@@ -247,9 +247,19 @@ impl<T: Send> WarmPool<T> {
     /// This is intended for maintenance refill paths that have just created a
     /// resource and need a final bounded insert before publishing it as idle.
     pub fn try_push_bounded(&self, resource: T) -> Result<(), T> {
+        self.try_push_bounded_to(resource, self.config.high_watermark)
+    }
+
+    /// Try to enqueue an idle resource below a caller-specific limit.
+    ///
+    /// The effective limit is capped at `high_watermark`. Checking the current
+    /// length and inserting the resource happen under the same lock, so the
+    /// caller's decision is linearizable with concurrent pool operations.
+    pub fn try_push_bounded_to(&self, resource: T, limit: usize) -> Result<(), T> {
+        let limit = limit.min(self.config.high_watermark);
         if !self.is_shutting_down() {
             let mut pool = self.pool.lock().unwrap();
-            if !self.is_shutting_down() && pool.len() < self.config.high_watermark {
+            if !self.is_shutting_down() && pool.len() < limit {
                 pool.push_back(resource);
                 return Ok(());
             }
@@ -549,6 +559,61 @@ mod tests {
         assert!(pool.release(1).is_ok());
         assert!(pool.release(2).is_ok());
         assert_eq!(pool.release(3), Err(3));
+    }
+
+    #[test]
+    fn bounded_push_rejects_after_release_fills_stricter_limit() {
+        let pool = WarmPool::<u32>::new(PoolConfig {
+            low_watermark: 0,
+            high_watermark: 64,
+            maintenance_enabled: false,
+            startup_prewarm: false,
+        });
+
+        for value in 0..7 {
+            pool.release(value).unwrap();
+        }
+
+        // Model the refill path observing len == 7 before a concurrent release
+        // wins the race and fills the proactive limit.
+        assert!(pool.len() < 8);
+        pool.release(7).unwrap();
+
+        assert_eq!(pool.try_push_bounded_to(8, 8), Err(8));
+        assert_eq!(pool.len(), 8);
+    }
+
+    #[test]
+    fn concurrent_bounded_pushes_atomically_respect_stricter_limit() {
+        use std::sync::{Arc, Barrier};
+
+        let pool = Arc::new(WarmPool::<u32>::new(PoolConfig {
+            low_watermark: 0,
+            high_watermark: 64,
+            maintenance_enabled: false,
+            startup_prewarm: false,
+        }));
+        let start = Arc::new(Barrier::new(33));
+        let mut workers = Vec::new();
+
+        for value in 0..32 {
+            let pool = Arc::clone(&pool);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                pool.try_push_bounded_to(value, 8).is_ok()
+            }));
+        }
+
+        start.wait();
+        let inserted = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .filter(|inserted| *inserted)
+            .count();
+
+        assert_eq!(inserted, 8);
+        assert_eq!(pool.len(), 8);
     }
 
     #[test]

--- a/crates/warm-pool/src/lib.rs
+++ b/crates/warm-pool/src/lib.rs
@@ -247,9 +247,19 @@ impl<T: Send> WarmPool<T> {
     /// This is intended for maintenance refill paths that have just created a
     /// resource and need a final bounded insert before publishing it as idle.
     pub fn try_push_bounded(&self, resource: T) -> Result<(), T> {
+        self.try_push_bounded_to(resource, self.config.high_watermark)
+    }
+
+    /// Try to enqueue an idle resource below a caller-specific limit.
+    ///
+    /// The effective limit is capped at `high_watermark`. Checking the current
+    /// length and inserting the resource happen under the same lock, so callers
+    /// can enforce a stricter refill limit without racing concurrent releases.
+    pub fn try_push_bounded_to(&self, resource: T, limit: usize) -> Result<(), T> {
+        let limit = limit.min(self.config.high_watermark);
         if !self.is_shutting_down() {
             let mut pool = self.pool.lock().unwrap();
-            if !self.is_shutting_down() && pool.len() < self.config.high_watermark {
+            if !self.is_shutting_down() && pool.len() < limit {
                 pool.push_back(resource);
                 return Ok(());
             }
@@ -549,6 +559,25 @@ mod tests {
         assert!(pool.release(1).is_ok());
         assert!(pool.release(2).is_ok());
         assert_eq!(pool.release(3), Err(3));
+    }
+
+    #[test]
+    fn try_push_bounded_to_atomically_respects_stricter_limit() {
+        let pool = WarmPool::<u32>::new(PoolConfig {
+            low_watermark: 0,
+            high_watermark: 64,
+            maintenance_enabled: false,
+            startup_prewarm: false,
+        });
+
+        for value in 0..8 {
+            pool.release(value).unwrap();
+        }
+
+        assert_eq!(pool.try_push_bounded_to(8, 8), Err(8));
+        assert_eq!(pool.len(), 8);
+        assert!(pool.try_push_bounded_to(8, 9).is_ok());
+        assert_eq!(pool.len(), 9);
     }
 
     #[test]

--- a/crates/warm-pool/src/lib.rs
+++ b/crates/warm-pool/src/lib.rs
@@ -247,19 +247,9 @@ impl<T: Send> WarmPool<T> {
     /// This is intended for maintenance refill paths that have just created a
     /// resource and need a final bounded insert before publishing it as idle.
     pub fn try_push_bounded(&self, resource: T) -> Result<(), T> {
-        self.try_push_bounded_to(resource, self.config.high_watermark)
-    }
-
-    /// Try to enqueue an idle resource below a caller-specific limit.
-    ///
-    /// The effective limit is capped at `high_watermark`. Checking the current
-    /// length and inserting the resource happen under the same lock, so callers
-    /// can enforce a stricter refill limit without racing concurrent releases.
-    pub fn try_push_bounded_to(&self, resource: T, limit: usize) -> Result<(), T> {
-        let limit = limit.min(self.config.high_watermark);
         if !self.is_shutting_down() {
             let mut pool = self.pool.lock().unwrap();
-            if !self.is_shutting_down() && pool.len() < limit {
+            if !self.is_shutting_down() && pool.len() < self.config.high_watermark {
                 pool.push_back(resource);
                 return Ok(());
             }
@@ -559,25 +549,6 @@ mod tests {
         assert!(pool.release(1).is_ok());
         assert!(pool.release(2).is_ok());
         assert_eq!(pool.release(3), Err(3));
-    }
-
-    #[test]
-    fn try_push_bounded_to_atomically_respects_stricter_limit() {
-        let pool = WarmPool::<u32>::new(PoolConfig {
-            low_watermark: 0,
-            high_watermark: 64,
-            maintenance_enabled: false,
-            startup_prewarm: false,
-        });
-
-        for value in 0..8 {
-            pool.release(value).unwrap();
-        }
-
-        assert_eq!(pool.try_push_bounded_to(8, 8), Err(8));
-        assert_eq!(pool.len(), 8);
-        assert!(pool.try_push_bounded_to(8, 9).is_ok());
-        assert_eq!(pool.len(), 9);
     }
 
     #[test]

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -289,6 +289,7 @@ Component sections:
 |---------|-----|------|---------|-------------|
 | `[pool.network]` | `maintenance_enabled` | boolean | `true` | Enable the background network-slot maintenance worker |
 | `[pool.block]` | `enabled` | boolean | `true` | Enable the ublk overlaybd warm-device pool |
+| `[pool.block]` | `prewarm_high_watermark` | integer | `pool.high_watermark` | Maximum idle-device count reached by proactive block-device refill. Returned devices may still fill `pool.high_watermark`; `0` disables proactive refill |
 | `[pool.block]` | `startup_prewarm` | boolean | capability-based | Prewarm block devices after the first reusable image shape is known. When omitted, it is enabled only if the kernel supports `UBLK_F_UPDATE_SIZE`; an explicit value overrides detection |
 | `[pool.firecracker]` | `enabled` | boolean | `true` | Enable pre-spawned Firecracker processes for snapshot resume |
 | `[pool.firecracker]` | `maintenance_enabled` | boolean | `true` | Enable the background Firecracker process maintenance worker |
@@ -298,6 +299,7 @@ Component sections:
 Validation rules:
 
 - `low_watermark <= high_watermark`
+- `[pool.block].prewarm_high_watermark <= high_watermark`
 - `[pool.firecracker].fill_concurrency > 0`
 
 ## `[node_identity]`

--- a/docs/src/internals/architecture.md
+++ b/docs/src/internals/architecture.md
@@ -138,7 +138,7 @@ PVM currently requires x86_64 and the `kvm_pvm` host module.
 
 The network subsystem is managed by a process-wide `NetworkManager` and per-slot `Slot` objects. See [Sandbox Network Architecture](./networking.md) for the namespace topology, address plan, packet paths, firewall ordering, egress proxy, policy replacement, warm-pool behavior, and verification steps.
 
-Snapshot resume can also use `[pool.firecracker]` to pre-spawn `(network slot, Firecracker process)` pairs. A warm entry transfers its network slot, process, and Firecracker CWD to the resumed sandbox, which avoids the spawn and API-socket wait in the resume critical path. `[pool.block]` controls the ublk daemon's overlaybd warm-device pool; it shares the same top-level watermarks but performs async refill from request paths because reusable block devices are image/size-specific.
+Snapshot resume can also use `[pool.firecracker]` to pre-spawn `(network slot, Firecracker process)` pairs. A warm entry transfers its network slot, process, and Firecracker CWD to the resumed sandbox, which avoids the spawn and API-socket wait in the resume critical path. `[pool.block]` controls the ublk daemon's overlaybd warm-device pool; returned devices share the top-level idle-cache capacity, while an optional block-specific prewarm watermark caps async proactive refill from request paths because reusable devices are image/size-specific.
 
 ### Observability Data Flow
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -199,6 +199,7 @@ pub struct PoolTomlConfig {
 pub struct PoolComponentConfig {
     #[config(default = true)]
     pub enabled: bool,
+    pub prewarm_high_watermark: Option<usize>,
     #[config(default = true)]
     pub maintenance_enabled: bool,
     #[config(default = true)]
@@ -1100,6 +1101,15 @@ impl AppConfig {
         }
         if let Some(block) = self.block_pool_config() {
             PoolTomlConfig::validate("block", &block)?;
+            if let Some(prewarm_high_watermark) = self.pool.block.prewarm_high_watermark {
+                if prewarm_high_watermark > block.high_watermark {
+                    bail!(
+                        "invalid block pool config: prewarm_high_watermark ({}) must be <= high_watermark ({})",
+                        prewarm_high_watermark,
+                        block.high_watermark
+                    );
+                }
+            }
         }
         if let Some(firecracker) = self.firecracker_pool_config() {
             PoolTomlConfig::validate("firecracker", &firecracker.pool)?;
@@ -1959,6 +1969,28 @@ mod tests {
             ..AppConfig::default()
         };
         assert!(config.validate_pool_config().is_ok());
+    }
+
+    #[test]
+    fn block_pool_prewarm_high_watermark_rejects_values_above_cache_capacity() {
+        let config = AppConfig {
+            pool: PoolTomlConfig {
+                high_watermark: 8,
+                block: PoolComponentConfig {
+                    enabled: true,
+                    prewarm_high_watermark: Some(9),
+                    ..PoolComponentConfig::default()
+                },
+                ..PoolTomlConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let err = config.validate_pool_config().unwrap_err();
+        assert!(
+            err.to_string().contains("prewarm_high_watermark"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/image/resolver.rs
+++ b/src/image/resolver.rs
@@ -919,36 +919,24 @@ mod tests {
         stderr: &str,
         exit_code: i32,
     ) -> std::path::PathBuf {
-        use std::io::Write;
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::symlink;
 
         let stdout_path = dir.join("stdout");
         let stderr_path = dir.join("stderr");
+        let exit_code_path = dir.join("exit_code");
         std::fs::write(&stdout_path, stdout).expect("write stdout fixture");
         std::fs::write(&stderr_path, stderr).expect("write stderr fixture");
+        std::fs::write(&exit_code_path, exit_code.to_string()).expect("write exit code fixture");
 
         // The script locates its fixtures relative to `$0` rather than
-        // embedding absolute paths, so a TMPDIR containing shell
-        // metacharacters cannot break or inject into the generated script.
-        //
-        // Staged write + rename so the binary is never observed half-written or
-        // non-executable, matching how the real dependency installer stages
-        // downloads.
+        // embedding absolute paths, so a TMPDIR containing shell metacharacters
+        // cannot break or inject into it. Link a stable, checked-in executable
+        // instead of writing and immediately executing a new inode, which can
+        // intermittently make exec(2) fail with ETXTBSY on shared CI runners.
         let binary = dir.join("regctl");
-        let staged = dir.join("regctl.staged");
-        {
-            let mut file = std::fs::File::create(&staged).expect("create fake regctl");
-            write!(
-                file,
-                "#!/bin/sh\ndir=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\nprintf '%s\\n' \"$@\" > \"$dir/argv\"\ncat \"$dir/stdout\"\ncat \"$dir/stderr\" >&2\nexit {exit_code}\n",
-            )
-            .expect("write fake regctl");
-            file.sync_all().expect("sync fake regctl");
-        }
-        let mut permissions = std::fs::metadata(&staged).expect("stat").permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&staged, permissions).expect("chmod fake regctl");
-        std::fs::rename(&staged, &binary).expect("publish fake regctl");
+        let fixture =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/image/testdata/fake-regctl");
+        symlink(&fixture, &binary).expect("link fake regctl");
         binary
     }
 

--- a/src/image/testdata/fake-regctl
+++ b/src/image/testdata/fake-regctl
@@ -1,0 +1,6 @@
+#!/bin/sh
+dir="$(cd "$(dirname "$0")" && pwd)"
+printf '%s\n' "$@" > "$dir/argv"
+cat "$dir/stdout"
+cat "$dir/stderr" >&2
+exit "$(cat "$dir/exit_code")"

--- a/src/sandbox/ublk/device.rs
+++ b/src/sandbox/ublk/device.rs
@@ -106,6 +106,8 @@ pub struct UblkDaemonConfig {
     pub metrics_listen_addr: String,
     /// Pool configuration. If `Some`, the daemon will enable warm pooling.
     pub pool_config: Option<uvm_ublk_daemon::PoolConfig>,
+    /// Maximum idle count reached by proactive block-device refill.
+    pub pool_prewarm_high_watermark: Option<usize>,
     /// Local HTTP endpoint used by the daemon to notify P2P layer publication.
     pub p2p_publish_url: Option<String>,
     /// Client-side timeout for runtime-device RPCs.
@@ -130,6 +132,13 @@ impl UblkDaemonConfig {
             })?;
 
         let pool_config = config.block_pool_config();
+        let pool_prewarm_high_watermark = pool_config.as_ref().map(|pool| {
+            config
+                .pool
+                .block
+                .prewarm_high_watermark
+                .unwrap_or(pool.high_watermark)
+        });
         let runtime_device_timeout =
             runtime_device_timeout(config.ublk.overlaybd.resize_timeout_secs);
 
@@ -144,6 +153,7 @@ impl UblkDaemonConfig {
             log_file: ublk.daemon_log_path.clone(),
             metrics_listen_addr: ublk.daemon_metrics_listen_addr.clone(),
             pool_config,
+            pool_prewarm_high_watermark,
             p2p_publish_url: None,
             runtime_device_timeout,
         })
@@ -215,6 +225,7 @@ impl UblkDeviceManager {
                             log_file: cfg.log_file.as_deref(),
                             metrics_listen_addr: &cfg.metrics_listen_addr,
                             pool_config: cfg.pool_config.as_ref(),
+                            pool_prewarm_high_watermark: cfg.pool_prewarm_high_watermark,
                             p2p_publish_url: cfg.p2p_publish_url.as_deref(),
                             runtime_device_timeout: cfg.runtime_device_timeout,
                         })
@@ -739,6 +750,17 @@ fn record_restack_usage_stats(dev_id: u32, kind: &'static str, stats: &RestackSn
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn daemon_config_propagates_block_prewarm_high_watermark() {
+        let mut config = crate::cfg::AppConfig::default();
+        config.ublk.daemon_binary_path = Some(PathBuf::from("uvm-ublk-daemon"));
+        config.pool.block.prewarm_high_watermark = Some(8);
+
+        let daemon_config = UblkDaemonConfig::from_app_config(&config).unwrap();
+
+        assert_eq!(daemon_config.pool_prewarm_high_watermark, Some(8));
+    }
 
     #[test]
     fn rejects_persisted_cow_backend_with_migration_guidance() {

--- a/storage/ublk-daemon/src/client.rs
+++ b/storage/ublk-daemon/src/client.rs
@@ -121,6 +121,7 @@ pub struct UblkDaemonSpawnConfig<'a> {
     pub log_file: Option<&'a Path>,
     pub metrics_listen_addr: &'a str,
     pub pool_config: Option<&'a PoolConfig>,
+    pub pool_prewarm_high_watermark: Option<usize>,
     pub p2p_publish_url: Option<&'a str>,
     pub runtime_device_timeout: Duration,
 }
@@ -199,13 +200,7 @@ impl UblkDaemonClient {
 
         if let Some(pool_config) = config.pool_config {
             if config.app_config.is_none() {
-                cmd.arg("--enable-pool")
-                    .arg("--pool-low-watermark")
-                    .arg(pool_config.low_watermark.to_string())
-                    .arg("--pool-high-watermark")
-                    .arg(pool_config.high_watermark.to_string())
-                    .arg("--pool-startup-prewarm")
-                    .arg(pool_config.startup_prewarm.to_string());
+                append_pool_cli_args(&mut cmd, pool_config, config.pool_prewarm_high_watermark);
             }
         }
 
@@ -616,6 +611,24 @@ impl UblkDaemonClient {
     }
 }
 
+fn append_pool_cli_args(
+    cmd: &mut tokio::process::Command,
+    pool_config: &PoolConfig,
+    prewarm_high_watermark: Option<usize>,
+) {
+    cmd.arg("--enable-pool")
+        .arg("--pool-low-watermark")
+        .arg(pool_config.low_watermark.to_string())
+        .arg("--pool-high-watermark")
+        .arg(pool_config.high_watermark.to_string())
+        .arg("--pool-startup-prewarm")
+        .arg(pool_config.startup_prewarm.to_string());
+    if let Some(prewarm_high_watermark) = prewarm_high_watermark {
+        cmd.arg("--pool-prewarm-high-watermark")
+            .arg(prewarm_high_watermark.to_string());
+    }
+}
+
 impl std::fmt::Debug for UblkDaemonClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UblkDaemonClient")
@@ -653,6 +666,39 @@ impl UblkDaemonClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pool_cli_args_include_prewarm_high_watermark() {
+        let pool_config = PoolConfig {
+            low_watermark: 2,
+            high_watermark: 64,
+            maintenance_enabled: false,
+            startup_prewarm: true,
+        };
+        let mut command = tokio::process::Command::new("uvm-ublk-daemon");
+
+        append_pool_cli_args(&mut command, &pool_config, Some(8));
+
+        let args = command
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            [
+                "--enable-pool",
+                "--pool-low-watermark",
+                "2",
+                "--pool-high-watermark",
+                "64",
+                "--pool-startup-prewarm",
+                "true",
+                "--pool-prewarm-high-watermark",
+                "8",
+            ]
+        );
+    }
 
     #[tokio::test]
     async fn daemon_dead_fails_immediately() {

--- a/storage/ublk-daemon/src/main.rs
+++ b/storage/ublk-daemon/src/main.rs
@@ -62,6 +62,10 @@ struct Cli {
     #[arg(long)]
     pool_high_watermark: Option<usize>,
 
+    /// Override the proactive block-device refill limit.
+    #[arg(long)]
+    pool_prewarm_high_watermark: Option<usize>,
+
     /// Override whether the overlaybd pool prewarms after first image use.
     #[arg(long)]
     pool_startup_prewarm: Option<bool>,
@@ -99,6 +103,7 @@ struct DaemonPoolTomlConfig {
 #[derive(Debug, Deserialize, Default)]
 struct DaemonPoolComponentConfig {
     enabled: Option<bool>,
+    prewarm_high_watermark: Option<usize>,
     startup_prewarm: Option<bool>,
 }
 
@@ -106,42 +111,65 @@ struct DaemonPoolComponentConfig {
 struct PoolConfigOverrides {
     low_watermark: Option<usize>,
     high_watermark: Option<usize>,
+    prewarm_high_watermark: Option<usize>,
     startup_prewarm: Option<bool>,
+}
+
+#[derive(Debug)]
+struct LoadedPoolConfig {
+    config: warm_pool::PoolConfig,
+    prewarm_high_watermark: usize,
 }
 
 fn load_pool_config(
     config: Option<&DaemonTomlConfig>,
     force_enable: bool,
     overrides: &PoolConfigOverrides,
-) -> Result<Option<warm_pool::PoolConfig>> {
-    let Some(config) = config else {
-        return Ok(force_enable.then(|| apply_pool_overrides(default_pool_config(), overrides)));
-    };
-
-    let common = config.pool.as_ref();
+) -> Result<Option<LoadedPoolConfig>> {
+    let common = config.and_then(|config| config.pool.as_ref());
     let pool = common.and_then(|pool| pool.block.as_ref());
     let enabled = pool.and_then(|pool| pool.enabled).unwrap_or(force_enable);
     if !enabled {
         return Ok(None);
     }
-    Ok(Some(warm_pool::PoolConfig {
-        low_watermark: overrides
-            .low_watermark
-            .or_else(|| common.and_then(|pool| pool.low_watermark))
-            .unwrap_or(2),
-        high_watermark: overrides
-            .high_watermark
-            .or_else(|| common.and_then(|pool| pool.high_watermark))
-            .unwrap_or(64),
-        // ublk-daemon refills overlaybd devices inline from acquire/release
-        // requests because prewarming needs an async ublk control path and the
-        // request's current overlaybd image. Do not enable the generic
-        // synchronous background worker semantics for this pool.
-        maintenance_enabled: false,
-        startup_prewarm: overrides
-            .startup_prewarm
-            .or_else(|| pool.and_then(|pool| pool.startup_prewarm))
-            .unwrap_or(true),
+
+    let low_watermark = overrides
+        .low_watermark
+        .or_else(|| common.and_then(|pool| pool.low_watermark))
+        .unwrap_or(2);
+    let high_watermark = overrides
+        .high_watermark
+        .or_else(|| common.and_then(|pool| pool.high_watermark))
+        .unwrap_or(64);
+    let prewarm_high_watermark = overrides
+        .prewarm_high_watermark
+        .or_else(|| pool.and_then(|pool| pool.prewarm_high_watermark))
+        .unwrap_or(high_watermark);
+
+    anyhow::ensure!(
+        low_watermark <= high_watermark,
+        "invalid block pool config: low_watermark ({low_watermark}) must be <= high_watermark ({high_watermark})"
+    );
+    anyhow::ensure!(
+        prewarm_high_watermark <= high_watermark,
+        "invalid block pool config: prewarm_high_watermark ({prewarm_high_watermark}) must be <= high_watermark ({high_watermark})"
+    );
+
+    Ok(Some(LoadedPoolConfig {
+        config: warm_pool::PoolConfig {
+            low_watermark,
+            high_watermark,
+            // ublk-daemon refills overlaybd devices inline from acquire/release
+            // requests because prewarming needs an async ublk control path and the
+            // request's current overlaybd image. Do not enable the generic
+            // synchronous background worker semantics for this pool.
+            maintenance_enabled: false,
+            startup_prewarm: overrides
+                .startup_prewarm
+                .or_else(|| pool.and_then(|pool| pool.startup_prewarm))
+                .unwrap_or(true),
+        },
+        prewarm_high_watermark,
     }))
 }
 
@@ -227,31 +255,6 @@ fn resolve_relative_to(base_dir: &Path, path: &Path) -> PathBuf {
     }
 }
 
-fn default_pool_config() -> warm_pool::PoolConfig {
-    warm_pool::PoolConfig {
-        low_watermark: 2,
-        high_watermark: 64,
-        maintenance_enabled: false,
-        startup_prewarm: true,
-    }
-}
-
-fn apply_pool_overrides(
-    mut config: warm_pool::PoolConfig,
-    overrides: &PoolConfigOverrides,
-) -> warm_pool::PoolConfig {
-    if let Some(value) = overrides.low_watermark {
-        config.low_watermark = value;
-    }
-    if let Some(value) = overrides.high_watermark {
-        config.high_watermark = value;
-    }
-    if let Some(value) = overrides.startup_prewarm {
-        config.startup_prewarm = value;
-    }
-    config
-}
-
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -315,6 +318,7 @@ fn main() -> Result<()> {
         let pool_overrides = PoolConfigOverrides {
             low_watermark: cli.pool_low_watermark,
             high_watermark: cli.pool_high_watermark,
+            prewarm_high_watermark: cli.pool_prewarm_high_watermark,
             startup_prewarm: cli.pool_startup_prewarm,
         };
         let startup_prewarm = pool_overrides.startup_prewarm.or_else(|| {
@@ -324,19 +328,24 @@ fn main() -> Result<()> {
                 .and_then(|pool| pool.block.as_ref())
                 .and_then(|block| block.startup_prewarm)
         });
-        if let Some(mut pool_config) =
+        if let Some(mut loaded_pool_config) =
             load_pool_config(daemon_config.as_ref(), cli.enable_pool, &pool_overrides)
                 .context("load warm pool config")?
         {
             let features = server.detect_ublk_features().await?;
             let update_size_supported = features & ublk_caps::UBLK_F_UPDATE_SIZE != 0;
-            pool_config.startup_prewarm = startup_prewarm.unwrap_or(update_size_supported);
+            loaded_pool_config.config.startup_prewarm =
+                startup_prewarm.unwrap_or(update_size_supported);
             tracing::info!(
                 features = format!("{:#x}", features),
                 update_size_supported,
                 "detected ublk features"
             );
-            server.enable_pool(pool_config, features);
+            server.enable_pool(
+                loaded_pool_config.config,
+                loaded_pool_config.prewarm_high_watermark,
+                features,
+            );
         }
 
         // Open a pidfd for the parent process. When the parent process
@@ -410,4 +419,67 @@ fn pidfd_open(pid: nix::unistd::Pid) -> Result<OwnedFd> {
         return Err(err).context("pidfd_open");
     }
     Ok(unsafe { OwnedFd::from_raw_fd(ret as i32) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_config(input: &str) -> LoadedPoolConfig {
+        let config: DaemonTomlConfig = toml::from_str(input).expect("parse config");
+        load_pool_config(Some(&config), false, &PoolConfigOverrides::default())
+            .expect("load pool config")
+            .expect("pool enabled")
+    }
+
+    #[test]
+    fn prewarm_high_watermark_defaults_to_cache_capacity() {
+        let loaded = load_config(
+            r#"
+                [pool]
+                low_watermark = 2
+                high_watermark = 64
+                [pool.block]
+                enabled = true
+            "#,
+        );
+
+        assert_eq!(loaded.prewarm_high_watermark, 64);
+        assert_eq!(loaded.config.high_watermark, 64);
+    }
+
+    #[test]
+    fn prewarm_high_watermark_is_independent_from_cache_capacity() {
+        let loaded = load_config(
+            r#"
+                [pool]
+                low_watermark = 2
+                high_watermark = 64
+                [pool.block]
+                enabled = true
+                prewarm_high_watermark = 8
+            "#,
+        );
+
+        assert_eq!(loaded.prewarm_high_watermark, 8);
+        assert_eq!(loaded.config.high_watermark, 64);
+    }
+
+    #[test]
+    fn prewarm_high_watermark_rejects_values_above_cache_capacity() {
+        let config: DaemonTomlConfig = toml::from_str(
+            r#"
+                [pool]
+                high_watermark = 8
+                [pool.block]
+                enabled = true
+                prewarm_high_watermark = 9
+            "#,
+        )
+        .expect("parse config");
+
+        let err = load_pool_config(Some(&config), false, &PoolConfigOverrides::default())
+            .expect_err("prewarm limit above cache capacity must fail");
+        assert!(err.to_string().contains("prewarm_high_watermark"));
+    }
 }

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -1454,14 +1454,7 @@ async fn return_or_stop_idle_device(
     };
 
     if let Err(pooled) = pool.idle.try_push_bounded(pooled) {
-        stop_excess_idle_device(
-            pool,
-            ctrl_ring,
-            pooled,
-            pool.config.high_watermark,
-            "idle cache capacity reached",
-        )
-        .await;
+        stop_excess_idle_device(pool, ctrl_ring, pooled).await;
         return false;
     }
     true
@@ -1518,18 +1511,13 @@ async fn refill_idle_pool(
             dev_sectors: placeholder_image.num_lbas(),
             _placeholder_image: Arc::clone(&placeholder_image),
         };
-        if let Err(pooled) = pool
-            .idle
-            .try_push_bounded_to(pooled, pool.prewarm_high_watermark)
-        {
-            stop_excess_idle_device(
-                pool,
-                ctrl_ring.clone(),
-                pooled,
-                pool.prewarm_high_watermark,
-                "proactive refill limit reached",
-            )
-            .await;
+        if pool.idle.len() >= pool.prewarm_high_watermark {
+            stop_excess_idle_device(pool, ctrl_ring.clone(), pooled).await;
+            break;
+        }
+
+        if let Err(pooled) = pool.idle.try_push_bounded(pooled) {
+            stop_excess_idle_device(pool, ctrl_ring.clone(), pooled).await;
             break;
         }
     }
@@ -1555,16 +1543,12 @@ async fn stop_excess_idle_device(
     pool: &PoolState,
     ctrl_ring: IoRingHandle<io_uring::squeue::Entry128>,
     pooled: PooledDevice,
-    idle_limit: usize,
-    reason: &'static str,
 ) {
     let dev_id = pooled.dev.dev_id();
     tracing::info!(
         dev_id,
-        idle_limit,
-        cache_high_watermark = pool.idle.config().high_watermark,
-        reason,
-        "stopping excess idle overlaybd device"
+        high_watermark = pool.idle.config().high_watermark,
+        "idle overlaybd pool is full; stopping returned device"
     );
     stop_overlaybd_device(ctrl_ring, pooled.dev).await;
 }

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -1454,7 +1454,14 @@ async fn return_or_stop_idle_device(
     };
 
     if let Err(pooled) = pool.idle.try_push_bounded(pooled) {
-        stop_excess_idle_device(pool, ctrl_ring, pooled).await;
+        stop_excess_idle_device(
+            pool,
+            ctrl_ring,
+            pooled,
+            pool.config.high_watermark,
+            "idle cache capacity reached",
+        )
+        .await;
         return false;
     }
     true
@@ -1511,13 +1518,18 @@ async fn refill_idle_pool(
             dev_sectors: placeholder_image.num_lbas(),
             _placeholder_image: Arc::clone(&placeholder_image),
         };
-        if pool.idle.len() >= pool.prewarm_high_watermark {
-            stop_excess_idle_device(pool, ctrl_ring.clone(), pooled).await;
-            break;
-        }
-
-        if let Err(pooled) = pool.idle.try_push_bounded(pooled) {
-            stop_excess_idle_device(pool, ctrl_ring.clone(), pooled).await;
+        if let Err(pooled) = pool
+            .idle
+            .try_push_bounded_to(pooled, pool.prewarm_high_watermark)
+        {
+            stop_excess_idle_device(
+                pool,
+                ctrl_ring.clone(),
+                pooled,
+                pool.prewarm_high_watermark,
+                "proactive refill limit reached",
+            )
+            .await;
             break;
         }
     }
@@ -1543,12 +1555,16 @@ async fn stop_excess_idle_device(
     pool: &PoolState,
     ctrl_ring: IoRingHandle<io_uring::squeue::Entry128>,
     pooled: PooledDevice,
+    idle_limit: usize,
+    reason: &'static str,
 ) {
     let dev_id = pooled.dev.dev_id();
     tracing::info!(
         dev_id,
-        high_watermark = pool.idle.config().high_watermark,
-        "idle overlaybd pool is full; stopping returned device"
+        idle_limit,
+        cache_high_watermark = pool.idle.config().high_watermark,
+        reason,
+        "stopping excess idle overlaybd device"
     );
     stop_overlaybd_device(ctrl_ring, pooled.dev).await;
 }

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -136,6 +136,9 @@ struct PoolState {
     /// requests do not all synchronously create replacement ublk devices.
     refill_inflight: AtomicBool,
     config: PoolConfig,
+    /// Maximum idle count that proactive refill may reach. Returned devices
+    /// remain bounded by `config.high_watermark` instead.
+    prewarm_high_watermark: usize,
     /// Ublk feature flags detected at startup.
     features: u64,
     /// Daemon-owned same-size sparse placeholder images, lazily built per device
@@ -152,6 +155,7 @@ struct PoolState {
 impl PoolState {
     fn new(
         config: PoolConfig,
+        prewarm_high_watermark: usize,
         features: u64,
         image_service: ImageService,
         placeholder_dir: PathBuf,
@@ -164,6 +168,7 @@ impl PoolState {
             image_locks: DashMap::new(),
             refill_inflight: AtomicBool::new(false),
             config,
+            prewarm_high_watermark,
             features,
             placeholders: Mutex::new(HashMap::new()),
             image_service,
@@ -227,6 +232,19 @@ impl PoolState {
 
     fn supports_update_size(&self) -> bool {
         self.features & ublk_caps::UBLK_F_UPDATE_SIZE != 0
+    }
+
+    fn prewarm_refill_count(&self) -> usize {
+        let idle_len = self.idle.len();
+        let remaining = self.prewarm_high_watermark.saturating_sub(idle_len);
+        if remaining == 0 {
+            return 0;
+        }
+
+        match self.idle.compute_maintenance_action(idle_len) {
+            PoolMaintenanceAction::Fill(to_create) => to_create.min(remaining),
+            PoolMaintenanceAction::Drain(_) | PoolMaintenanceAction::Idle => 0,
+        }
     }
 
     fn image_lock_key(image_config: &Path) -> ImageLockKey {
@@ -327,9 +345,22 @@ impl UblkDaemonServer {
 
     /// Enable warm pooling with the given configuration.
     /// Must be called before `run()`.
-    pub fn enable_pool(&mut self, config: PoolConfig, features: u64) {
+    pub fn enable_pool(
+        &mut self,
+        config: PoolConfig,
+        prewarm_high_watermark: usize,
+        features: u64,
+    ) {
+        tracing::info!(
+            low_watermark = config.low_watermark,
+            high_watermark = config.high_watermark,
+            prewarm_high_watermark,
+            startup_prewarm = config.startup_prewarm,
+            "enabling overlaybd warm pool"
+        );
         self.pool_state = Some(Arc::new(PoolState::new(
             config,
+            prewarm_high_watermark,
             features,
             self.default_image_service.clone(),
             self.pool_placeholder_dir(),
@@ -1446,10 +1477,7 @@ fn schedule_idle_pool_refill(
         refill_idle_pool_best_effort(&pool, ctrl_ring.clone(), virtual_size).await;
         pool.refill_inflight.store(false, Ordering::Release);
 
-        if matches!(
-            pool.idle.compute_maintenance_action(pool.idle.len()),
-            PoolMaintenanceAction::Fill(_)
-        ) {
+        if pool.prewarm_refill_count() > 0 {
             schedule_idle_pool_refill(pool, ctrl_ring, virtual_size);
         }
     });
@@ -1460,11 +1488,10 @@ async fn refill_idle_pool(
     ctrl_ring: IoRingHandle<io_uring::squeue::Entry128>,
     virtual_size: u64,
 ) -> Result<()> {
-    let PoolMaintenanceAction::Fill(to_create) =
-        pool.idle.compute_maintenance_action(pool.idle.len())
-    else {
+    let to_create = pool.prewarm_refill_count();
+    if to_create == 0 {
         return Ok(());
-    };
+    }
 
     let (placeholder_config, placeholder_image) = pool
         .placeholder_for(virtual_size)
@@ -1472,6 +1499,10 @@ async fn refill_idle_pool(
         .context("build pool placeholder for prewarm")?;
 
     for _ in 0..to_create {
+        if pool.idle.len() >= pool.prewarm_high_watermark {
+            break;
+        }
+
         let dev = create_new_device(ctrl_ring.clone(), &placeholder_config, &placeholder_image)
             .await
             .context("prewarm overlaybd pool device")?;
@@ -1480,6 +1511,11 @@ async fn refill_idle_pool(
             dev_sectors: placeholder_image.num_lbas(),
             _placeholder_image: Arc::clone(&placeholder_image),
         };
+        if pool.idle.len() >= pool.prewarm_high_watermark {
+            stop_excess_idle_device(pool, ctrl_ring.clone(), pooled).await;
+            break;
+        }
+
         if let Err(pooled) = pool.idle.try_push_bounded(pooled) {
             stop_excess_idle_device(pool, ctrl_ring.clone(), pooled).await;
             break;
@@ -1673,6 +1709,7 @@ mod tests {
         let placeholder_dir = dir.path().join("placeholders");
         let pool = PoolState::new(
             test_pool_config(),
+            1,
             0,
             image_service,
             placeholder_dir.clone(),
@@ -1713,5 +1750,57 @@ mod tests {
         assert_ne!(small_path, large_path);
         assert_eq!(small.num_lbas(), 8 * 1024 * 1024 / 512);
         assert_eq!(large.num_lbas(), 16 * 1024 * 1024 / 512);
+    }
+
+    #[tokio::test]
+    async fn prewarm_refill_count_is_capped_below_idle_cache_capacity() {
+        let dir = TempDir::new().unwrap();
+        let image_service = test_image_service(dir.path()).await;
+        let pool = PoolState::new(
+            PoolConfig {
+                low_watermark: 16,
+                high_watermark: 64,
+                maintenance_enabled: false,
+                startup_prewarm: true,
+            },
+            8,
+            0,
+            image_service,
+            dir.path().join("placeholders"),
+        );
+
+        assert_eq!(pool.prewarm_refill_count(), 8);
+        assert_eq!(pool.config.high_watermark, 64);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a host with ublk control access"]
+    async fn live_prewarm_refill_creates_only_the_block_specific_limit() {
+        let dir = TempDir::new().unwrap();
+        let image_service = test_image_service(dir.path()).await;
+        let pool = PoolState::new(
+            PoolConfig {
+                low_watermark: 16,
+                high_watermark: 64,
+                maintenance_enabled: false,
+                startup_prewarm: true,
+            },
+            8,
+            0,
+            image_service,
+            dir.path().join("placeholders"),
+        );
+        let (ctrl_ring, _ctrl_ring_worker) =
+            storage_util::io_ring::spawn_io_ring_worker::<io_uring::squeue::Entry128>(0);
+
+        let refill_result = refill_idle_pool(&pool, ctrl_ring.clone(), 64 * 1024 * 1024).await;
+        let idle_len = pool.idle.len();
+        for pooled in pool.idle.drain_all() {
+            stop_overlaybd_device(ctrl_ring.clone(), pooled.dev).await;
+        }
+
+        refill_result.expect("refill live ublk devices");
+        assert_eq!(idle_len, 8);
+        assert_eq!(pool.config.high_watermark, 64);
     }
 }

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -1511,12 +1511,10 @@ async fn refill_idle_pool(
             dev_sectors: placeholder_image.num_lbas(),
             _placeholder_image: Arc::clone(&placeholder_image),
         };
-        if pool.idle.len() >= pool.prewarm_high_watermark {
-            stop_excess_idle_device(pool, ctrl_ring.clone(), pooled).await;
-            break;
-        }
-
-        if let Err(pooled) = pool.idle.try_push_bounded(pooled) {
+        if let Err(pooled) = pool
+            .idle
+            .try_push_bounded_to(pooled, pool.prewarm_high_watermark)
+        {
             stop_excess_idle_device(pool, ctrl_ring.clone(), pooled).await;
             break;
         }

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -1546,7 +1546,8 @@ async fn stop_excess_idle_device(
     tracing::info!(
         dev_id,
         high_watermark = pool.idle.config().high_watermark,
-        "idle overlaybd pool is full; stopping returned device"
+        prewarm_high_watermark = pool.prewarm_high_watermark,
+        "idle overlaybd pool rejected excess device"
     );
     stop_overlaybd_device(ctrl_ring, pooled.dev).await;
 }


### PR DESCRIPTION
## What

Add an optional `[pool.block].prewarm_high_watermark` that limits only proactive OverlayBD ublk-device refill, independently from the normal idle-device cache capacity in `[pool].high_watermark`.

Returned workload devices may still populate the idle cache up to `high_watermark`. Proactive refill stops at `prewarm_high_watermark`.

This change also:

- adds `--pool-prewarm-high-watermark` to `uvm-ublk-daemon`;
- defaults an omitted prewarm watermark to `high_watermark`, preserving the previous behavior;
- rejects `prewarm_high_watermark > high_watermark`;
- logs both limits when enabling the OverlayBD warm pool;
- documents the new optional setting and includes a commented `prewarm_high_watermark = 8` example in `config/default.toml`; operators must enable it explicitly;
- adds configuration, refill-policy, and live ublk tests.

## Why

PR #205 made block prewarm capability-aware and explicitly left concurrent refill-target amplification out of scope.

On kernels that support `UBLK_F_UPDATE_SIZE`, or when operators explicitly enable `startup_prewarm`, a concurrent sandbox burst can still grow the refill target to the shared pool high watermark. With `high_watermark = 64`, proactive refill can create up to 64 idle ublk devices even when the workload also has many instance-owned rootfs devices. This produces a large startup device spike and leaves little room for real devices returned during pause.

Lowering the shared `high_watermark` is not equivalent: it also reduces the useful cache capacity for devices returned by completed or paused workloads. Operators need to retain a larger reuse cache while independently bounding speculative prewarm.

## Related issue

Follow-up to #205 and #203. PR #205 fixed the no-resize default behavior and identified concurrent refill-target amplification as a separate issue.

## Scope and non-goals

Included:

- block-pool config and CLI plumbing for `prewarm_high_watermark`;
- proactive refill bounded by the block-specific limit;
- backward-compatible fallback to `high_watermark` when the setting is omitted;
- config validation, startup logging, documentation, unit tests, and a live ublk test.

Not included:

- changes to the normal returned-device cache limit;
- changes to pause, resume, release, or device-deletion synchronization;
- changes to the generic warm-pool growth policy or the Firecracker pool;
- kernel backports or alternative implementations of ublk dynamic resize.

## Design and behavior changes

The daemon now loads two related limits:

- `PoolConfig::high_watermark`: maximum idle cache capacity, including devices returned by real workloads;
- `prewarm_high_watermark`: maximum idle count that proactive refill may reach.

`prewarm_refill_count()` first asks the existing warm-pool policy how many entries it wants to create, then caps that count by the remaining block-specific prewarm capacity.

The refill loop checks the prewarm limit both before creating another device and before inserting the newly created device. The second check handles concurrent releases that may increase the idle count while an asynchronous device creation is in progress; an excess device is stopped through the existing cleanup path.

The existing `refill_inflight` guard still ensures that only one refill task is elected at a time. Rescheduling now occurs only while the prewarm-specific limit has remaining capacity.

An omitted `prewarm_high_watermark` resolves to `high_watermark`, so existing configurations retain the previous coupled behavior. It is intentionally valid for the prewarm watermark to be below the shared low watermark: the block-specific limit is an operator cap on speculative creation, while returned devices can still warm the larger cache naturally.

## Compatibility and operations

- Public API or generated protocol: No change.
- Configuration or defaults: Adds optional `[pool.block].prewarm_high_watermark`. Omission preserves the old effective limit. `config/default.toml` leaves `prewarm_high_watermark = 8` commented; operators can uncomment it to opt in while `[pool].high_watermark` remains `64`.
- Snapshot manifest, artifact layout, or storage format: No change.
- Upgrade and rollback: Safe with no data migration. Remove the new key to restore the historical coupled behavior. Values above `high_watermark` fail startup with an actionable error.
- Host requirements, permissions, ports, or dependencies: No change.

## Validation

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [x] Benchmarks or performance comparison completed

Commands and results:

```text
cargo fmt --all -- --check
# passed

git diff --check origin/main...HEAD
# passed

cargo clippy -p agentenv -p uvm-ublk-daemon --all-targets -- -D warnings
# passed

cargo test -p agentenv \
  block_pool_prewarm_high_watermark_rejects_values_above_cache_capacity
# 1 passed

cargo test -p uvm-ublk-daemon prewarm_high_watermark
# 3 passed

cargo test -p uvm-ublk-daemon \
  prewarm_refill_count_is_capped_below_idle_cache_capacity
# 1 passed

cargo test -p uvm-ublk-daemon \
  live_prewarm_refill_creates_only_the_block_specific_limit -- --ignored
# 1 passed on a host with real /dev/ublk-control access

API_ADDR=127.0.0.1:8000 AENV_RUN_USER=root make start-server-release
# passed; the release server was used for the replay benchmark below
```

### Replay benchmark

Host and workload:

- openEuler 24.03 LTS-SP3, aarch64, bare metal;
- real `uvm-ublk-daemon` and `/dev/ublk-control`;
- ublk feature mask `0x1fe`; `UBLK_F_UPDATE_SIZE` unavailable;
- template: `django-money-task-v2`;
- 128 trajectories submitted concurrently, with at most 64 sandboxes running;
- zero launch interval, control-plane QPS limit 1000, and a 600-second per-trajectory timeout;
- the same trajectory set and server build were used for every round;
- each round started from a clean server restart with zero existing sandboxes;
- host, ublk-device, CPU, memory, disk, and sandbox-state metrics were sampled every 100 ms;
- rounds were interleaved as A1, B1, A2, B2 to reduce ordering bias;
- `startup_prewarm = true` and `[pool].high_watermark = 64` in both variants;
- two retained repetitions per variant.

Compared configurations:

```toml
# A: historical coupled behavior
[pool]
high_watermark = 64

[pool.block]
startup_prewarm = true
# prewarm_high_watermark omitted -> 64
```

```toml
# B: decoupled proactive refill
[pool]
high_watermark = 64

[pool.block]
startup_prewarm = true
prewarm_high_watermark = 8
```

| Metric | Coupled limit 64, run 1 / run 2 | Prewarm limit 8, run 1 / run 2 | Mean change |
|---|---:|---:|---:|
| ublk device maximum | 177 / 168 | 136 / 136 | -21.2% |
| ublk device p95 | 132 / 126 | 92 / 84 | -31.8% |
| first-60s ublk maximum | 158 / 165 | 136 / 136 | -15.8% |
| ublk-daemon CPU p95 | 2.870 / 2.754 cores | 2.086 / 1.995 cores | -27.4% |
| elapsed time | 623.94 / 621.08 s | 613.32 / 609.55 s | -1.8% |
| resume API p95 | 3.390 / 2.697 s | 2.793 / 2.579 s | -11.7% |
| pause API p95 | 2.551 / 2.176 s | 1.949 / 1.937 s | -17.8% |
| successful trajectories | 121/128 / 121/128 | 121/128 / 121/128 | no change |

Both runs with the new limit peaked at 136 devices, consistent with up to 128 workload-owned devices plus 8 proactively prewarmed devices. Both coupled-limit runs had higher peaks. The primary acceptance criterion was therefore met in both repetitions, with no success-rate regression.

Pause/resume latency moved in a favorable direction, but two repetitions are not enough to claim a statistically significant latency improvement. These measurements are treated as a non-regression signal; the primary result is the lower ublk device footprint.

The benchmark explicitly set `startup_prewarm = true`, so it exercises the operator opt-in path retained by #205 on this no-resize kernel.

An unrelated TensorFlow/Bazel build started during the tail of the second coupled-limit run, after that run's device peak had already occurred. Two prewarm-limit attempts that overlapped external builds were discarded. The retained second prewarm-limit run started after a 61-second quiet window and was checked throughout for absence of the external CI process. This interference does not affect the two-run device-peak comparison, but it is another reason not to overstate the secondary latency numbers.

Skipped checks and reasons:

- Full `make test-unit` was not run; the tests added or directly affected by this change were run explicitly, including the ignored live ublk test.
- Full repository `make clippy` was not run; Clippy passed with warnings denied for the two changed Rust packages and all their targets.
- `make -C services test` is not applicable because `services/` is unchanged.
- Generated-code checks are not applicable because no generated API or protocol changed.

## Risks and reviewer notes

- The repository default keeps the setting commented, so omitted configurations retain the historical effective limit of 64. Operators can explicitly set `prewarm_high_watermark = 8` to reduce proactive refill while retaining a returned-device cache capacity of 64.
- This setting does not cap total ublk devices. Active and paused sandboxes still own devices; it only caps additional proactively created idle devices.
- Returned devices may still grow the idle cache above `prewarm_high_watermark`, up to the existing `high_watermark`. This is intentional and preserves reuse capacity.
- Review the second prewarm-limit check in `refill_idle_pool`: it prevents an asynchronous create from overshooting when another task releases a device while creation is in flight.
- Key files: `storage/ublk-daemon/src/server.rs`, `storage/ublk-daemon/src/main.rs`, and `src/cfg.rs`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
