### PR TITLE
docs: polish API reference layout

### DIFF
--- a/docs/src/stoplight-elements.html
+++ b/docs/src/stoplight-elements.html
@@ -8,6 +8,15 @@
   <style>
     html, body { margin: 0; padding: 0; height: 100%; }
     elements-api { display: block; height: 100vh; }
+    [data-testid="two-column-right"] {
+      width: 46%;
+      max-width: 640px !important;
+      margin-left: 48px;
+    }
+    [data-testid="two-column-right"] .sl-code-viewer,
+    [data-testid="two-column-right"] .sl-code-editor {
+      --fs-code: 15px !important;
+    }
   </style>
 </head>
 <body>
@@ -53,11 +62,18 @@
 
     const spec = jsyaml.load(await response.text());
 
-    // Keep the documentation navigation task-oriented without changing the
-    // source OpenAPI document used by the server and generated clients.
+    const tagDisplayNames = new Map([
+      ['sandboxes', 'Sandboxes'],
+      ['templates', 'Templates'],
+      ['snapshots', 'Snapshots'],
+      ['admin', 'Admin'],
+    ]);
     const tagByName = new Map((spec.tags || []).map(tag => [tag.name, tag]));
-    spec.tags = ['sandboxes', 'templates', 'snapshots', 'admin']
-      .map(name => tagByName.get(name) || { name });
+    spec.tags = [...tagDisplayNames]
+      .map(([name, displayName]) => ({
+        ...(tagByName.get(name) || {}),
+        name: displayName,
+      }));
 
     // Stoplight uses summary as the operation label in the sidebar.
     for (const [path, pathItem] of Object.entries(spec.paths || {})) {
@@ -71,6 +87,8 @@
         }
 
         operation.summary ||= operationTitles[`${method.toUpperCase()} ${path}`];
+        operation.tags = (operation.tags || [])
+          .map(tag => tagDisplayNames.get(tag) || tag);
 
         // The deployed control plane authenticates every protected operation
         // with X-API-Key, including operations whose compatibility schema


### PR DESCRIPTION
## What

Polish the API reference navigation and layout.

## Why

Improve readability and make API groups and request samples easier to scan.

## Related issue

N/A

## Scope and non-goals

Documentation-only changes.

## Design and behavior changes

- Capitalize API navigation group names.
- Widen the request sample panel.
- Increase the request and response sample font size.

## Compatibility and operations

- Public API or generated protocol: N/A.
- Configuration or defaults: N/A.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: N/A.
- Host requirements, permissions, ports, or dependencies: N/A.

## Validation

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Skipped checks and reasons:

Rust, service, generated-code, and benchmark checks were skipped because this PR only changes documentation presentation.

## Risks and reviewer notes

N/A.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by documentation build validation; runtime tests are not applicable.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.