### PR TITLE
fix(privileges): make scoped-spawn capability tests root-aware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ sudo -E cargo test -p agentenv --test orchestrator_integration orchestrator::tes
 
 Integration tests require root (network namespaces), `/dev/kvm`, host modules matching `AENV_VIRTUALIZATION_MODE`, and `AENV_CONFIG_PATH` pointing to a valid config.
 
+`make test-unit` is expected to run as a non-root user (CI parity). Capability assertions in `src/privileges.rs` tests are root-aware: under root, `execve` regrants an euid-0 child the full bounding set in `CapPrm`/`CapEff`, so only `CapInh`/`CapAmb` are asserted (they stay zero, or exactly the delegated capability, regardless of uid). Some unit tests (for example the image resolver tests) also need network access to their test registries.
+
 ## Architecture
 
 See `docs/src/internals/architecture.md` for detailed design with data flow diagrams.

--- a/src/privileges.rs
+++ b/src/privileges.rs
@@ -170,8 +170,25 @@ mod tests {
             .collect())
     }
 
+    /// Status fields whose values prove the scoped-spawn capability contract.
+    ///
+    /// On `execve` the kernel regrants an euid-0 child the full bounding set
+    /// in `CapPrm`/`CapEff` unless `SECBIT_NOROOT` is set, so under root those
+    /// two fields say nothing about what the scoped spawn delegated. The
+    /// inheritable set survives `execve` unchanged and the ambient set can
+    /// only survive within the permitted ∩ inheritable intersection, so
+    /// `CapInh`/`CapAmb` stay zero (or exactly the requested capability)
+    /// regardless of the runner's uid.
+    fn capability_assertion_fields() -> &'static [&'static str] {
+        if nix::unistd::Uid::effective().is_root() {
+            &["CapInh:", "CapAmb:"]
+        } else {
+            &CAPABILITY_STATUS_FIELDS
+        }
+    }
+
     fn assert_child_has_no_capabilities(status: &str) {
-        for field in CAPABILITY_STATUS_FIELDS {
+        for field in capability_assertion_fields() {
             assert_eq!(
                 status_field(status, field),
                 "0000000000000000",
@@ -258,7 +275,9 @@ mod tests {
         let status = String::from_utf8(output.stdout)?;
 
         assert!(output.status.success());
-        for field in CAPABILITY_STATUS_FIELDS {
+        // Under root, execve regrants CapPrm/CapEff from the bounding set;
+        // CapInh/CapAmb keep exactly the delegated capability either way.
+        for field in capability_assertion_fields() {
             assert_eq!(
                 status_field(&status, field),
                 "0000000000001000",


### PR DESCRIPTION
## What

Makes the `src/privileges.rs` scoped-spawn capability tests pass when run as root: under root, assertions now cover only `CapInh`/`CapAmb` instead of all four capability sets.

## Why

On `execve`, the kernel regrants an euid-0 child the full bounding set in `CapPrm`/`CapEff` unless `SECBIT_NOROOT` is set — so the all-sets-zero expectation only holds for non-root runners (CI). Under root, `CapInh` (preserved across `execve`) and `CapAmb` (survives only within the permitted ∩ inheritable intersection) are the sets that actually prove what the scoped spawn delegated.

## Related issue

Closes #169

## Scope and non-goals

Included: root-aware capability assertions shared by the three scoped-spawn tests; a `make test-unit` environment note in `CLAUDE.md`.

Excluded: enforcing isolation under root via `SECBIT_NOROOT` — that changes scoped-spawn semantics for root deployments and deserves its own discussion (follow-up #2 in the issue).

## Compatibility and operations

Test-only change plus a documentation note; no runtime behavior, API, config, or storage impact.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`

Commands and results:

```text
cargo test -p agentenv --lib privileges            # as root: 4/4 pass (was 1 failed)
cargo test -p agentenv --lib privileges -- --ignored  # as root: 2/2 pass
cargo test -p agentenv --lib privileges            # as non-root: 4/4 pass
make test-unit                                     # as root: 789 passed; 1 failed
  # remaining failure is the pre-existing, unrelated image::resolver test
  # that needs registry network access (passes once the registry is reachable)
```

## Risks and reviewer notes

None — test assertions and docs only. The non-root assertion set is unchanged, so CI behavior is identical.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
