### PR TITLE
feat(sandbox): bind running Firecracker threads to host CPUs

### DIFF
--- a/crates/aenv/src/client/sandboxes.rs
+++ b/crates/aenv/src/client/sandboxes.rs
@@ -1,5 +1,5 @@
 use super::{handle_status, Client};
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
@@ -156,6 +156,9 @@ impl Client {
         vcpu: &str,
         core: &str,
     ) -> Result<SandboxCpuAffinity> {
+        let id = uuid::Uuid::parse_str(id)
+            .with_context(|| format!("invalid sandbox ID {id:?}"))?
+            .to_string();
         let body = SandboxCpuAffinityRequest { vcpu, core };
         let resp = handle_status(
             self.post(&format!("/sandboxes/{id}/cpu-affinity"))
@@ -330,14 +333,16 @@ mod tests {
     #[test]
     fn bind_cpu_affinity_uses_expected_http_contract() {
         let (url, request) = serve_json_once(
-            r#"{"sandboxID":"sandbox-1","vcpu":"*","cores":"2-3","ignoredOfflineCores":"","boundThreadCount":4}"#,
+            r#"{"sandboxID":"01936f8e-72f5-7000-8000-0000000000ab","vcpu":"*","cores":"2-3","ignoredOfflineCores":"","boundThreadCount":4}"#,
         );
         let client = Client::new(&url, "secret-key").unwrap();
-        let result = client.bind_cpu_affinity("sandbox-1", "*", "2-3").unwrap();
+        let result = client
+            .bind_cpu_affinity("01936F8E-72F5-7000-8000-0000000000AB", "*", "2-3")
+            .unwrap();
         assert_eq!(
             result,
             SandboxCpuAffinity {
-                sandbox_id: "sandbox-1".into(),
+                sandbox_id: "01936f8e-72f5-7000-8000-0000000000ab".into(),
                 vcpu: "*".into(),
                 cores: "2-3".into(),
                 ignored_offline_cores: String::new(),
@@ -346,11 +351,23 @@ mod tests {
         );
 
         let request = request.recv().unwrap();
-        assert!(request.starts_with("POST /sandboxes/sandbox-1/cpu-affinity HTTP/1.1\r\n"));
+        assert!(request.starts_with(
+            "POST /sandboxes/01936f8e-72f5-7000-8000-0000000000ab/cpu-affinity HTTP/1.1\r\n"
+        ));
         let body = request.split_once("\r\n\r\n").unwrap().1;
         assert_eq!(
             serde_json::from_str::<serde_json::Value>(body).unwrap(),
             serde_json::json!({"vcpu": "*", "core": "2-3"})
         );
+    }
+
+    #[test]
+    fn bind_cpu_affinity_rejects_path_special_sandbox_ids() {
+        let client = Client::new("http://127.0.0.1:1", "secret-key").unwrap();
+
+        for id in ["sandbox/other", "sandbox?admin=true"] {
+            let error = client.bind_cpu_affinity(id, "*", "0").unwrap_err();
+            assert!(error.to_string().contains("invalid sandbox ID"));
+        }
     }
 }

--- a/crates/aenv/src/client/sandboxes.rs
+++ b/crates/aenv/src/client/sandboxes.rs
@@ -1,5 +1,5 @@
 use super::{handle_status, Client};
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
@@ -75,6 +75,24 @@ pub struct ListedSandbox {
     pub end_at: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct SandboxCpuAffinityRequest<'a> {
+    vcpu: &'a str,
+    core: &'a str,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SandboxCpuAffinity {
+    #[serde(rename = "sandboxID")]
+    pub sandbox_id: String,
+    pub vcpu: String,
+    pub cores: String,
+    #[serde(rename = "ignoredOfflineCores")]
+    pub ignored_offline_cores: String,
+    #[serde(rename = "boundThreadCount")]
+    pub bound_thread_count: u32,
+}
+
 impl Client {
     pub fn create_sandbox(
         &self,
@@ -132,6 +150,26 @@ impl Client {
         Ok(())
     }
 
+    pub fn bind_cpu_affinity(
+        &self,
+        id: &str,
+        vcpu: &str,
+        core: &str,
+    ) -> Result<SandboxCpuAffinity> {
+        let body = SandboxCpuAffinityRequest { vcpu, core };
+        let resp = handle_status(
+            self.post(&format!("/sandboxes/{id}/cpu-affinity"))
+                .send_json(&body),
+        )?;
+        let result: SandboxCpuAffinity = resp.into_json()?;
+        ensure!(
+            result.sandbox_id == id,
+            "CPU affinity response sandbox mismatch: requested {id}, got {}",
+            result.sandbox_id
+        );
+        Ok(result)
+    }
+
     pub fn sandbox_state_with_timeout(
         &self,
         id: &str,
@@ -184,7 +222,58 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use super::{NewColdSandbox, NewSandbox, RefreshSandbox};
+    use super::{NewColdSandbox, NewSandbox, RefreshSandbox, SandboxCpuAffinity};
+    use crate::client::Client;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+
+    fn serve_json_once(response_body: &'static str) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 4096];
+            loop {
+                let read = stream.read(&mut buffer).unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                let Some(header_end) = request.windows(4).position(|part| part == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        if name.eq_ignore_ascii_case("content-length") {
+                            value.trim().parse::<usize>().ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(0);
+                if request.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+            let _ = request_tx.send(String::from_utf8(request).unwrap());
+
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            )
+            .unwrap();
+        });
+        (format!("http://{address}"), request_rx)
+    }
 
     #[test]
     fn new_sandbox_serializes_template_start() {
@@ -236,5 +325,32 @@ mod tests {
 
         let empty = serde_json::to_value(RefreshSandbox { duration: None }).unwrap();
         assert!(empty.get("duration").is_none());
+    }
+
+    #[test]
+    fn bind_cpu_affinity_uses_expected_http_contract() {
+        let (url, request) = serve_json_once(
+            r#"{"sandboxID":"sandbox-1","vcpu":"*","cores":"2-3","ignoredOfflineCores":"","boundThreadCount":4}"#,
+        );
+        let client = Client::new(&url, "secret-key").unwrap();
+        let result = client.bind_cpu_affinity("sandbox-1", "*", "2-3").unwrap();
+        assert_eq!(
+            result,
+            SandboxCpuAffinity {
+                sandbox_id: "sandbox-1".into(),
+                vcpu: "*".into(),
+                cores: "2-3".into(),
+                ignored_offline_cores: String::new(),
+                bound_thread_count: 4,
+            }
+        );
+
+        let request = request.recv().unwrap();
+        assert!(request.starts_with("POST /sandboxes/sandbox-1/cpu-affinity HTTP/1.1\r\n"));
+        let body = request.split_once("\r\n\r\n").unwrap().1;
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(body).unwrap(),
+            serde_json::json!({"vcpu": "*", "core": "2-3"})
+        );
     }
 }

--- a/crates/aenv/src/commands/cpu_bind.rs
+++ b/crates/aenv/src/commands/cpu_bind.rs
@@ -1,0 +1,50 @@
+use crate::client::Client;
+use anyhow::Result;
+use clap::Args as ClapArgs;
+
+#[derive(ClapArgs)]
+#[command(after_help = "Examples:
+  aenv cpu-bind <sandbox-id> --vcpu '*' --core 2-3")]
+pub struct Args {
+    #[arg(add = crate::commands::completion::add_running_sandbox_candidates())]
+    sandbox_id: String,
+    /// Firecracker vCPU list, or '*' for every current Firecracker thread
+    #[arg(long)]
+    vcpu: String,
+    /// Host CPU list (0-1023)
+    #[arg(long)]
+    core: String,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let client = Client::from_env()?;
+    let result = client.bind_cpu_affinity(&args.sandbox_id, &args.vcpu, &args.core)?;
+    println!(
+        "Sandbox {}: bound {} thread(s) (vCPU {}) to cores {}",
+        result.sandbox_id, result.bound_thread_count, result.vcpu, result.cores
+    );
+    if !result.ignored_offline_cores.is_empty() {
+        println!("Ignored offline cores: {}", result.ignored_offline_cores);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(flatten)]
+        args: Args,
+    }
+
+    #[test]
+    fn parses_arguments() {
+        let args = Cli::parse_from(["test", "sandbox-1", "--vcpu", "*", "--core", "2-3"]).args;
+        assert_eq!(args.sandbox_id, "sandbox-1");
+        assert_eq!(args.vcpu, "*");
+        assert_eq!(args.core, "2-3");
+    }
+}

--- a/crates/aenv/src/commands/mod.rs
+++ b/crates/aenv/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod build;
 pub mod completion;
 pub mod connect;
+pub mod cpu_bind;
 pub mod delete;
 pub mod download;
 pub mod exec;

--- a/crates/aenv/src/main.rs
+++ b/crates/aenv/src/main.rs
@@ -42,6 +42,8 @@ enum Cmd {
     Connect(commands::connect::Args),
     /// Pause a running sandbox
     Pause(commands::pause::Args),
+    /// Bind selected Firecracker threads to online host CPUs
+    CpuBind(commands::cpu_bind::Args),
     /// Resume a paused sandbox
     Resume(commands::resume::Args),
     /// List sandboxes
@@ -76,6 +78,7 @@ fn main() -> Result<()> {
         Cmd::Completion(a) => commands::completion::run(a),
         Cmd::Connect(a) => commands::connect::run(a),
         Cmd::Pause(a) => commands::pause::run(a),
+        Cmd::CpuBind(a) => commands::cpu_bind::run(a),
         Cmd::Resume(a) => commands::resume::run(a),
         Cmd::List(a) => commands::list::run(a),
         Cmd::Delete(a) => commands::delete::run(a),

--- a/docs/src/concepts/sandboxes.md
+++ b/docs/src/concepts/sandboxes.md
@@ -250,6 +250,9 @@ platform affinity mask. Offline requested CPUs are ignored; if the remaining
 online set is empty, the request fails before making changes.
 
 Affinity applies to the current Firecracker process and its current threads.
+To prevent a thread ID from being reused during the update, AgentENV briefly
+stops the complete Firecracker process and resumes it as soon as the update
+finishes or fails.
 Reapply it after a pause and resume, which replaces the runtime process. The
 operation is exposed through the admin API because incorrect placement can
 affect other workloads on the node. It uses the deployment API key and has no

--- a/docs/src/concepts/sandboxes.md
+++ b/docs/src/concepts/sandboxes.md
@@ -227,6 +227,34 @@ By default, the sandbox automatically pauses when it reaches its TTL. See
 [Auto-Eviction](#auto-eviction) for how the deadline is set and how to delete
 instead of pause.
 
+### Runtime CPU Affinity
+
+Administrators can restrict a running sandbox's Firecracker threads to a set
+of host logical CPUs without restarting the sandbox:
+
+```bash
+aenv cpu-bind <sandbox-id> --vcpu 0-1 --core 4-7
+aenv cpu-bind <sandbox-id> --vcpu '*' --core 0-10:2
+```
+
+This changes scheduler eligibility, not sandbox resources: it does not change
+the sandbox vCPU count, reserve host CPUs, or prevent other processes from
+using the same CPUs. For a numeric `--vcpu` list, indices select threads named
+`fc_vcpu N`. The special value `*` selects every Firecracker thread present at
+the time of the request, including non-vCPU threads. Every selected thread is
+assigned the same `--core` set rather than a one-to-one vCPU-to-CPU mapping.
+
+Host CPU lists accept individual IDs, inclusive ranges, and range strides such
+as `0-10:2`. IDs are logical CPU numbers and are limited to 0-1023 by the
+platform affinity mask. Offline requested CPUs are ignored; if the remaining
+online set is empty, the request fails before making changes.
+
+Affinity applies to the current Firecracker process and its current threads.
+Reapply it after a pause and resume, which replaces the runtime process. The
+operation is exposed through the admin API because incorrect placement can
+affect other workloads on the node. It uses the deployment API key and has no
+separate feature flag.
+
 ### Persistent Snapshots
 
 A snapshot is a durable, reusable checkpoint of a running sandbox. Creating one

--- a/docs/src/getting-started/aenv-cli.md
+++ b/docs/src/getting-started/aenv-cli.md
@@ -160,6 +160,23 @@ Set or extend the sandbox expiration to `<seconds>` from now.
 aenv timeout <sandbox-id> 600
 ```
 
+### `aenv cpu-bind <sandbox-id> --vcpu <list|*> --core <list>`
+
+Set CPU affinity for a running Firecracker sandbox.
+
+```bash
+aenv cpu-bind <sandbox-id> --vcpu 0-1 --core 4-7
+aenv cpu-bind <sandbox-id> --vcpu '*' --core 0-10:2
+```
+
+| Flag | Description |
+|------|-------------|
+| `--vcpu <list\|*>` | Firecracker vCPU indices, or `*` for every current Firecracker thread. |
+| `--core <list>` | Host logical CPU IDs (0-1023), with ranges and optional strides. |
+
+This is an admin-only operation. See
+[Runtime CPU Affinity](../concepts/sandboxes.md#runtime-cpu-affinity) for details.
+
 ### `aenv connect <sandbox-id>`
 
 Attach an interactive shell to a running or paused sandbox. Alias: `aenv cn`.

--- a/services/gateway/internal/server.go
+++ b/services/gateway/internal/server.go
@@ -614,6 +614,8 @@ func isSandboxControlPlaneRequest(r *http.Request) bool {
 	switch parts[2] {
 	case "pause", "resume", "fork", "connect", "timeout", "refreshes", "snapshots":
 		return r.Method == http.MethodPost
+	case "cpu-affinity":
+		return r.Method == http.MethodPost
 	case "network":
 		return r.Method == http.MethodPut
 	case "custom-extension-params":

--- a/services/gateway/internal/server_test.go
+++ b/services/gateway/internal/server_test.go
@@ -449,6 +449,8 @@ func TestIsSandboxControlPlaneRequest(t *testing.T) {
 		{name: "sandbox delete", method: http.MethodDelete, path: "/sandboxes/sbx-123", want: true},
 		{name: "sandbox pause", method: http.MethodPost, path: "/sandboxes/sbx-123/pause", want: true},
 		{name: "sandbox fork", method: http.MethodPost, path: "/sandboxes/sbx-123/fork", want: true},
+		{name: "sandbox CPU affinity", method: http.MethodPost, path: "/sandboxes/sbx-123/cpu-affinity", want: true},
+		{name: "sandbox CPU affinity wrong method", method: http.MethodGet, path: "/sandboxes/sbx-123/cpu-affinity", want: false},
 		{name: "sandbox network update", method: http.MethodPut, path: "/sandboxes/sbx-123/network", want: true},
 		{name: "network update wrong method", method: http.MethodPost, path: "/sandboxes/sbx-123/network", want: false},
 		{name: "sandbox custom extension params get", method: http.MethodGet, path: "/sandboxes/sbx-123/custom-extension-params", want: true},
@@ -744,6 +746,51 @@ func TestSandboxControlPlaneRequestWithE2BHeadersUsesPathRoute(t *testing.T) {
 	}
 	if upstreamReq.sandboxID != "sbx-path" {
 		t.Fatalf("forwarded e2b sandbox id = %q, want %q", upstreamReq.sandboxID, "sbx-path")
+	}
+}
+
+func TestCPUControlPlaneRequestUsesSandboxLookupAndPreservesUpstreamRequest(t *testing.T) {
+	type upstreamRequest struct {
+		method string
+		path   string
+		body   string
+	}
+	requests := make(chan upstreamRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests <- upstreamRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			body:   string(body),
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	server := newTestServer(t, stubSchedulerClient{
+		lookupNodeFunc: func(_ context.Context, req *schedulerv1.LookupNodeRequest, _ ...grpc.CallOption) (*schedulerv1.LookupNodeResponse, error) {
+			if req.GetSandboxId() != "sbx-cpu" {
+				return nil, fmt.Errorf("lookup sandbox id = %q, want sbx-cpu", req.GetSandboxId())
+			}
+			return &schedulerv1.LookupNodeResponse{Node: &schedulerv1.Node{
+				NodeId:   "node-cpu",
+				Endpoint: upstream.URL,
+			}}, nil
+		},
+	}, time.Second, 1024)
+
+	const body = `{"vcpu":"*","core":"2-3"}`
+	request := httptest.NewRequest(http.MethodPost, "http://gateway.test/sandboxes/sbx-cpu/cpu-affinity", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	authenticatedTestHandler(server).ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", response.Code, http.StatusOK, response.Body.String())
+	}
+	snapshot := <-requests
+	if snapshot.method != http.MethodPost || snapshot.path != "/sandboxes/sbx-cpu/cpu-affinity" || snapshot.body != body {
+		t.Fatalf("unexpected upstream request: %#v", snapshot)
 	}
 }
 

--- a/src/api/generated/src/apis/admin.rs
+++ b/src/api/generated/src/apis/admin.rs
@@ -34,6 +34,26 @@ pub enum NodesNodeIdGetResponse {
     Status500_ServerError(models::Error),
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+#[allow(clippy::large_enum_variant)]
+pub enum SandboxesSandboxIdCpuAffinityPostResponse {
+    /// CPU affinity applied and verified successfully
+    Status200_CPUAffinityAppliedAndVerifiedSuccessfully(models::SandboxCpuAffinity),
+    /// Bad request
+    Status400_BadRequest(models::Error),
+    /// Conflict
+    Status409_Conflict(models::Error),
+    /// Not found
+    Status404_NotFound(models::Error),
+    /// Authentication error
+    Status401_AuthenticationError(models::Error),
+    /// Server error
+    Status500_ServerError(models::Error),
+    /// Service unavailable
+    Status503_ServiceUnavailable(models::Error),
+}
+
 /// Admin
 #[async_trait]
 #[allow(clippy::ptr_arg)]
@@ -66,4 +86,18 @@ pub trait Admin<E: std::fmt::Debug + Send + Sync + 'static = ()>: super::ErrorHa
         path_params: &models::NodesNodeIdGetPathParams,
         query_params: &models::NodesNodeIdGetQueryParams,
     ) -> Result<NodesNodeIdGetResponse, E>;
+
+    /// Bind running sandbox CPUs.
+    ///
+    /// SandboxesSandboxIdCpuAffinityPost - POST /sandboxes/{sandboxID}/cpu-affinity
+    async fn sandboxes_sandbox_id_cpu_affinity_post(
+        &self,
+
+        method: &Method,
+        host: &Host,
+        cookies: &CookieJar,
+        claims: &Self::Claims,
+        path_params: &models::SandboxesSandboxIdCpuAffinityPostPathParams,
+        body: &models::SandboxCpuAffinityRequest,
+    ) -> Result<SandboxesSandboxIdCpuAffinityPostResponse, E>;
 }

--- a/src/api/generated/src/models.rs
+++ b/src/api/generated/src/models.rs
@@ -94,6 +94,12 @@ pub struct NodesNodeIdGetQueryParams {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SandboxesSandboxIdCpuAffinityPostPathParams {
+    pub sandbox_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct SandboxesGetQueryParams {
     /// Metadata query used to filter the sandboxes (e.g. \"user=abc&app=prod\"). Each key and values must be URL encoded.
     #[serde(rename = "metadata")]
@@ -5133,6 +5139,372 @@ impl std::ops::Deref for SandboxAutoResumeEnabled {
 impl std::ops::DerefMut for SandboxAutoResumeEnabled {
     fn deref_mut(&mut self) -> &mut bool {
         &mut self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SandboxCpuAffinity {
+    #[serde(rename = "sandboxID")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub sandbox_id: String,
+
+    #[serde(rename = "vcpu")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub vcpu: String,
+
+    /// Normalized online host CPUs that were applied.
+    #[serde(rename = "cores")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub cores: String,
+
+    /// Normalized requested CPUs that were offline, or an empty string.
+    #[serde(rename = "ignoredOfflineCores")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub ignored_offline_cores: String,
+
+    #[serde(rename = "boundThreadCount")]
+    #[validate(range(min = 1u32))]
+    pub bound_thread_count: u32,
+}
+
+impl SandboxCpuAffinity {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(
+        sandbox_id: String,
+        vcpu: String,
+        cores: String,
+        ignored_offline_cores: String,
+        bound_thread_count: u32,
+    ) -> SandboxCpuAffinity {
+        SandboxCpuAffinity {
+            sandbox_id,
+            vcpu,
+            cores,
+            ignored_offline_cores,
+            bound_thread_count,
+        }
+    }
+}
+
+/// Converts the SandboxCpuAffinity value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for SandboxCpuAffinity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("sandboxID".to_string()),
+            Some(self.sandbox_id.to_string()),
+            Some("vcpu".to_string()),
+            Some(self.vcpu.to_string()),
+            Some("cores".to_string()),
+            Some(self.cores.to_string()),
+            Some("ignoredOfflineCores".to_string()),
+            Some(self.ignored_offline_cores.to_string()),
+            Some("boundThreadCount".to_string()),
+            Some(self.bound_thread_count.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a SandboxCpuAffinity value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for SandboxCpuAffinity {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub sandbox_id: Vec<String>,
+            pub vcpu: Vec<String>,
+            pub cores: Vec<String>,
+            pub ignored_offline_cores: Vec<String>,
+            pub bound_thread_count: Vec<u32>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing SandboxCpuAffinity".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "sandboxID" => intermediate_rep.sandbox_id.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "vcpu" => intermediate_rep.vcpu.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "cores" => intermediate_rep.cores.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "ignoredOfflineCores" => intermediate_rep.ignored_offline_cores.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "boundThreadCount" => intermediate_rep.bound_thread_count.push(
+                        <u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing SandboxCpuAffinity".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(SandboxCpuAffinity {
+            sandbox_id: intermediate_rep
+                .sandbox_id
+                .into_iter()
+                .next()
+                .ok_or_else(|| "sandboxID missing in SandboxCpuAffinity".to_string())?,
+            vcpu: intermediate_rep
+                .vcpu
+                .into_iter()
+                .next()
+                .ok_or_else(|| "vcpu missing in SandboxCpuAffinity".to_string())?,
+            cores: intermediate_rep
+                .cores
+                .into_iter()
+                .next()
+                .ok_or_else(|| "cores missing in SandboxCpuAffinity".to_string())?,
+            ignored_offline_cores: intermediate_rep
+                .ignored_offline_cores
+                .into_iter()
+                .next()
+                .ok_or_else(|| "ignoredOfflineCores missing in SandboxCpuAffinity".to_string())?,
+            bound_thread_count: intermediate_rep
+                .bound_thread_count
+                .into_iter()
+                .next()
+                .ok_or_else(|| "boundThreadCount missing in SandboxCpuAffinity".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<SandboxCpuAffinity> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<SandboxCpuAffinity>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<SandboxCpuAffinity>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for SandboxCpuAffinity - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<SandboxCpuAffinity> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <SandboxCpuAffinity as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into SandboxCpuAffinity - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SandboxCpuAffinityRequest {
+    /// Firecracker vCPU list, or '*' to select every current Firecracker thread.
+    #[serde(rename = "vcpu")]
+    #[validate(length(max = 16384), custom(function = "check_xss_string"))]
+    pub vcpu: String,
+
+    /// Host CPU list with optional range strides such as 0-10:2. Supported CPU IDs are 0-1023. Offline CPUs are ignored unless the online intersection is empty.
+    #[serde(rename = "core")]
+    #[validate(length(max = 16384), custom(function = "check_xss_string"))]
+    pub core: String,
+}
+
+impl SandboxCpuAffinityRequest {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(vcpu: String, core: String) -> SandboxCpuAffinityRequest {
+        SandboxCpuAffinityRequest { vcpu, core }
+    }
+}
+
+/// Converts the SandboxCpuAffinityRequest value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for SandboxCpuAffinityRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("vcpu".to_string()),
+            Some(self.vcpu.to_string()),
+            Some("core".to_string()),
+            Some(self.core.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a SandboxCpuAffinityRequest value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for SandboxCpuAffinityRequest {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub vcpu: Vec<String>,
+            pub core: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing SandboxCpuAffinityRequest".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "vcpu" => intermediate_rep.vcpu.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "core" => intermediate_rep.core.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing SandboxCpuAffinityRequest".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(SandboxCpuAffinityRequest {
+            vcpu: intermediate_rep
+                .vcpu
+                .into_iter()
+                .next()
+                .ok_or_else(|| "vcpu missing in SandboxCpuAffinityRequest".to_string())?,
+            core: intermediate_rep
+                .core
+                .into_iter()
+                .next()
+                .ok_or_else(|| "core missing in SandboxCpuAffinityRequest".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<SandboxCpuAffinityRequest> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<SandboxCpuAffinityRequest>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<SandboxCpuAffinityRequest>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for SandboxCpuAffinityRequest - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<SandboxCpuAffinityRequest> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <SandboxCpuAffinityRequest as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into SandboxCpuAffinityRequest - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
     }
 }
 

--- a/src/api/generated/src/server/mod.rs
+++ b/src/api/generated/src/server/mod.rs
@@ -61,6 +61,10 @@ where
             post(sandboxes_sandbox_id_connect_post::<I, A, E, C>),
         )
         .route(
+            "/sandboxes/{sandbox_id}/cpu-affinity",
+            post(sandboxes_sandbox_id_cpu_affinity_post::<I, A, E, C>),
+        )
+        .route(
             "/sandboxes/{sandbox_id}/custom-extension-params",
             get(sandboxes_sandbox_id_custom_extension_params_get::<I, A, E, C>)
                 .patch(sandboxes_sandbox_id_custom_extension_params_patch::<I, A, E, C>),
@@ -409,6 +413,226 @@ where
                 .await;
         }
     };
+
+    resp.map_err(|e| {
+        error!(error = ?e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+#[derive(validator::Validate)]
+#[allow(dead_code)]
+struct SandboxesSandboxIdCpuAffinityPostBodyValidator<'a> {
+    #[validate(nested)]
+    body: &'a models::SandboxCpuAffinityRequest,
+}
+
+#[tracing::instrument(skip_all)]
+fn sandboxes_sandbox_id_cpu_affinity_post_validation(
+    path_params: models::SandboxesSandboxIdCpuAffinityPostPathParams,
+    body: models::SandboxCpuAffinityRequest,
+) -> std::result::Result<
+    (
+        models::SandboxesSandboxIdCpuAffinityPostPathParams,
+        models::SandboxCpuAffinityRequest,
+    ),
+    ValidationErrors,
+> {
+    path_params.validate()?;
+    let b = SandboxesSandboxIdCpuAffinityPostBodyValidator { body: &body };
+    b.validate()?;
+
+    Ok((path_params, body))
+}
+/// SandboxesSandboxIdCpuAffinityPost - POST /sandboxes/{sandboxID}/cpu-affinity
+#[tracing::instrument(skip_all)]
+async fn sandboxes_sandbox_id_cpu_affinity_post<I, A, E, C>(
+    method: Method,
+    TypedHeader(host): TypedHeader<Host>,
+    cookies: CookieJar,
+    headers: HeaderMap,
+    Path(path_params): Path<models::SandboxesSandboxIdCpuAffinityPostPathParams>,
+    State(api_impl): State<I>,
+    Json(body): Json<models::SandboxCpuAffinityRequest>,
+) -> Result<Response, StatusCode>
+where
+    I: AsRef<A> + Send + Sync,
+    A: apis::admin::Admin<E, Claims = C> + apis::ApiKeyAuthHeader<Claims = C> + Send + Sync,
+    E: std::fmt::Debug + Send + Sync + 'static,
+{
+    // Authentication
+    let claims_in_header = api_impl
+        .as_ref()
+        .extract_claims_from_header(&headers, "X-Admin-Token")
+        .await;
+    let claims = None.or(claims_in_header);
+    let Some(claims) = claims else {
+        return response_with_status_code_only(StatusCode::UNAUTHORIZED);
+    };
+
+    #[allow(clippy::redundant_closure)]
+    let validation = tokio::task::spawn_blocking(move || {
+        sandboxes_sandbox_id_cpu_affinity_post_validation(path_params, body)
+    })
+    .await
+    .unwrap();
+
+    let Ok((path_params, body)) = validation else {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::from(validation.unwrap_err().to_string()))
+            .map_err(|_| StatusCode::BAD_REQUEST);
+    };
+
+    let result = api_impl
+        .as_ref()
+        .sandboxes_sandbox_id_cpu_affinity_post(
+            &method,
+            &host,
+            &cookies,
+            &claims,
+            &path_params,
+            &body,
+        )
+        .await;
+
+    let mut response = Response::builder();
+
+    let resp = match result {
+                                            Ok(rsp) => match rsp {
+                                                apis::admin::SandboxesSandboxIdCpuAffinityPostResponse::Status200_CPUAffinityAppliedAndVerifiedSuccessfully
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(200);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::admin::SandboxesSandboxIdCpuAffinityPostResponse::Status400_BadRequest
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(400);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::admin::SandboxesSandboxIdCpuAffinityPostResponse::Status409_Conflict
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(409);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::admin::SandboxesSandboxIdCpuAffinityPostResponse::Status404_NotFound
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(404);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::admin::SandboxesSandboxIdCpuAffinityPostResponse::Status401_AuthenticationError
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(401);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::admin::SandboxesSandboxIdCpuAffinityPostResponse::Status500_ServerError
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(500);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::admin::SandboxesSandboxIdCpuAffinityPostResponse::Status503_ServiceUnavailable
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(503);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                            },
+                                            Err(why) => {
+                                                    // Application code returned an error. This should not happen, as the implementation should
+                                                    // return a valid response.
+                                                    return api_impl.as_ref().handle_error(&method, &host, &cookies, why).await;
+                                            },
+                                        };
 
     resp.map_err(|e| {
         error!(error = ?e);

--- a/src/api/impls/admin.rs
+++ b/src/api/impls/admin.rs
@@ -4,8 +4,11 @@ use headers::Host;
 use http::Method;
 
 use crate::observability::{DiskMetric, MachineInfo, NodeMetricsSnapshot, NodeSnapshot};
+use crate::orchestrator::{CpuAffinityRequest, OrchestratorError};
+use crate::types::SandboxId;
 use agentenv_http_server::{apis::admin::*, models};
 
+use super::sandbox::sandbox_not_found;
 use super::ApiImpl;
 
 impl From<MachineInfo> for models::MachineInfo {
@@ -165,5 +168,67 @@ impl Admin<()> for ApiImpl {
             node.paused_sandbox_count,
         );
         Ok(NodesNodeIdGetResponse::Status200_SuccessfullyReturnedTheNode(detail))
+    }
+
+    async fn sandboxes_sandbox_id_cpu_affinity_post(
+        &self,
+        _method: &Method,
+        _host: &Host,
+        _cookies: &CookieJar,
+        _claims: &Self::Claims,
+        path_params: &models::SandboxesSandboxIdCpuAffinityPostPathParams,
+        body: &models::SandboxCpuAffinityRequest,
+    ) -> Result<SandboxesSandboxIdCpuAffinityPostResponse, ()> {
+        let path_id = &path_params.sandbox_id;
+        let Ok(sandbox_id) = SandboxId::parse_str(path_id) else {
+            return Ok(
+                SandboxesSandboxIdCpuAffinityPostResponse::Status404_NotFound(sandbox_not_found(
+                    path_id,
+                )),
+            );
+        };
+        let request = CpuAffinityRequest {
+            vcpu: body.vcpu.clone(),
+            core: body.core.clone(),
+        };
+
+        match self
+            .orchestrator
+            .bind_sandbox_cpu_affinity(sandbox_id, request)
+            .await
+        {
+            Ok(outcome) => Ok(SandboxesSandboxIdCpuAffinityPostResponse::Status200_CPUAffinityAppliedAndVerifiedSuccessfully(
+                models::SandboxCpuAffinity::new(
+                    path_id.clone(),
+                    outcome.vcpu,
+                    outcome.cores,
+                    outcome.ignored_offline_cores,
+                    outcome.bound_thread_count,
+                ),
+            )),
+            Err(OrchestratorError::SandboxNotFound(id)) => Ok(
+                SandboxesSandboxIdCpuAffinityPostResponse::Status404_NotFound(sandbox_not_found(
+                    id,
+                )),
+            ),
+            Err(err @ OrchestratorError::InvalidCpuAffinityRequest { .. }) => {
+                Ok(SandboxesSandboxIdCpuAffinityPostResponse::Status400_BadRequest(err.into()))
+            }
+            Err(
+                err @ (OrchestratorError::InvalidSandboxState { .. }
+                | OrchestratorError::SandboxOperationConflict { .. }),
+            ) => Ok(
+                SandboxesSandboxIdCpuAffinityPostResponse::Status409_Conflict(Self::error(
+                    409,
+                    err.to_string(),
+                )),
+            ),
+            Err(err @ OrchestratorError::ShuttingDown) => Ok(
+                SandboxesSandboxIdCpuAffinityPostResponse::Status503_ServiceUnavailable(err.into()),
+            ),
+            Err(err) => {
+                Ok(SandboxesSandboxIdCpuAffinityPostResponse::Status500_ServerError(err.into()))
+            }
+        }
     }
 }

--- a/src/api/impls/sandbox.rs
+++ b/src/api/impls/sandbox.rs
@@ -34,7 +34,7 @@ use super::pagination::PaginationCursor;
 use super::volumes::{error_response as volume_error_response, resolve_volume_mounts};
 use super::ApiImpl;
 
-fn sandbox_not_found(id: impl Into<String>) -> models::Error {
+pub(crate) fn sandbox_not_found(id: impl Into<String>) -> models::Error {
     ApiImpl::error(404, format!("sandbox {} not found", id.into()))
 }
 
@@ -58,6 +58,7 @@ impl From<OrchestratorError> for models::Error {
             }
             OrchestratorError::SandboxNotFound(id) => sandbox_not_found(id),
             OrchestratorError::InvalidSandboxState { .. } => Self::new(400, err.to_string()),
+            OrchestratorError::InvalidCpuAffinityRequest { .. } => Self::new(400, err.to_string()),
             OrchestratorError::SandboxOperationFailed {
                 sandbox_id,
                 operation,
@@ -1877,6 +1878,18 @@ impl Sandboxes<()> for ApiImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cpu_affinity_errors_have_stable_http_codes() {
+        let invalid = models::Error::from(OrchestratorError::InvalidCpuAffinityRequest {
+            message: "bad cpu list".to_string(),
+        });
+        assert_eq!(invalid.code, 400);
+        assert!(invalid.message.contains("bad cpu list"));
+
+        let shutting_down = models::Error::from(OrchestratorError::ShuttingDown);
+        assert_eq!(shutting_down.code, 503);
+    }
 
     #[test]
     fn parse_metadata_filter_with_none_returns_none() {

--- a/src/api/openapi.yml
+++ b/src/api/openapi.yml
@@ -156,6 +156,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    "503":
+      description: Service unavailable
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
 
   schemas:
     CPUCount:
@@ -163,6 +169,47 @@ components:
       format: int32
       minimum: 1
       description: CPU cores for the sandbox
+
+    SandboxCpuAffinityRequest:
+      type: object
+      required:
+        - vcpu
+        - core
+      properties:
+        vcpu:
+          type: string
+          maxLength: 16384
+          description: Firecracker vCPU list, or '*' to select every current Firecracker thread.
+          example: "0-1"
+        core:
+          type: string
+          maxLength: 16384
+          description: Host CPU list with optional range strides such as 0-10:2. Supported CPU IDs are 0-1023. Offline CPUs are ignored unless the online intersection is empty.
+          example: "4-5"
+
+    SandboxCpuAffinity:
+      type: object
+      required:
+        - sandboxID
+        - vcpu
+        - cores
+        - ignoredOfflineCores
+        - boundThreadCount
+      properties:
+        sandboxID:
+          type: string
+        vcpu:
+          type: string
+        cores:
+          type: string
+          description: Normalized online host CPUs that were applied.
+        ignoredOfflineCores:
+          type: string
+          description: Normalized requested CPUs that were offline, or an empty string.
+        boundThreadCount:
+          type: integer
+          format: int32
+          minimum: 1
 
     MemoryMB:
       type: integer
@@ -2467,3 +2514,38 @@ paths:
           $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
+
+  /sandboxes/{sandboxID}/cpu-affinity:
+    post:
+      summary: Bind running sandbox CPUs
+      description: Bind selected Firecracker vCPU threads, or every current thread, to online host CPUs. Requires knowledge of the host CPU topology and can interfere with load balancing, so it is exposed on the admin interface.
+      tags: [admin]
+      security:
+        - AdminApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/sandboxID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SandboxCpuAffinityRequest"
+      responses:
+        "200":
+          description: CPU affinity applied and verified successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxCpuAffinity"
+        "400":
+          $ref: "#/components/responses/400"
+        "409":
+          $ref: "#/components/responses/409"
+        "404":
+          $ref: "#/components/responses/404"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+        "503":
+          $ref: "#/components/responses/503"

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -9,6 +9,8 @@ mod types;
 use crate::types::SandboxId;
 use crate::virtualization::VirtualizationMode;
 
+pub use crate::sandbox::{CpuAffinityOutcome, CpuAffinityRequest};
+
 pub use metrics::OrchestratorMetrics;
 pub use persistence::{
     DisabledSandboxPersister, FileBackedSandboxPersister, PersistenceResult,
@@ -40,6 +42,7 @@ pub enum SandboxOperation {
     Fork,
     UpdateNetwork,
     PatchCustomExtensionParams,
+    BindCpuAffinity,
     Stop,
 }
 
@@ -82,6 +85,9 @@ pub enum OrchestratorError {
         sandbox_id: SandboxId,
         operation: SandboxOperation,
     },
+
+    #[error("invalid sandbox CPU affinity request: {message}")]
+    InvalidCpuAffinityRequest { message: String },
 
     #[error("store operation failed: {0}")]
     StoreOperationFailed(#[source] store::StoreError),

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -15,6 +15,7 @@ use crate::image::cache::{
     local_image_services_from_global_config, RuntimeImageOwner, RuntimeImageRefs,
 };
 use crate::sandbox::{
+    bind_process_cpu_affinity, CpuAffinityError, CpuAffinityOutcome, CpuAffinityRequest,
     CustomExtensionClient, CustomExtensionParams, EnvdAccessToken, FirecrackerSandboxFactory,
     FreshSandboxBuildSpec, PausedSandboxState, RuntimeArtifactSet, SandboxAccessTokenGenerator,
     SandboxBackend, SandboxBackendFactory, SandboxCaptureError, SandboxForkSpec,
@@ -826,6 +827,123 @@ where
     #[tracing::instrument(skip(self), fields(sandbox_id = %sandbox_id))]
     pub async fn get_sandbox(&self, sandbox_id: &SandboxId) -> Result<Option<SandboxMetadata>> {
         Ok(self.store.get(sandbox_id).await?)
+    }
+
+    /// Bind selected threads of a running Firecracker process to host CPUs.
+    pub async fn bind_sandbox_cpu_affinity(
+        self: &Arc<Self>,
+        sandbox_id: SandboxId,
+        request: CpuAffinityRequest,
+    ) -> Result<CpuAffinityOutcome> {
+        self.ensure_accepting_lifecycle_operations()?;
+        let this = Arc::clone(self);
+        self.run_cancellation_safe("bind_cpu_affinity", sandbox_id, async move {
+            this.bind_sandbox_cpu_affinity_inner(sandbox_id, request)
+                .await
+        })
+        .await
+    }
+
+    async fn bind_sandbox_cpu_affinity_inner(
+        &self,
+        sandbox_id: SandboxId,
+        request: CpuAffinityRequest,
+    ) -> Result<CpuAffinityOutcome> {
+        let (pid, outcome) = self
+            .run_cpu_affinity_operation(sandbox_id, SandboxOperation::BindCpuAffinity, move |pid| {
+                bind_process_cpu_affinity(pid, request)
+            })
+            .await?;
+        info!(
+            sandbox_id = %sandbox_id,
+            firecracker_pid = pid,
+            vcpu = %outcome.vcpu,
+            cores = %outcome.cores,
+            ignored_offline_cores = %outcome.ignored_offline_cores,
+            bound_thread_count = outcome.bound_thread_count,
+            "bound sandbox CPU affinity"
+        );
+        Ok(outcome)
+    }
+
+    /// Resolves the Firecracker process behind a running sandbox and runs a
+    /// blocking CPU-affinity operation against it, mapping
+    /// [`CpuAffinityError`]s to orchestrator errors. The sandbox handle lock
+    /// is held across the operation so pause, snapshot and delete cannot
+    /// replace the Firecracker process midway. Returns the resolved pid
+    /// alongside the operation result so callers can log or report it.
+    async fn run_cpu_affinity_operation<T, R>(
+        &self,
+        sandbox_id: SandboxId,
+        operation: SandboxOperation,
+        run: R,
+    ) -> Result<(i32, T)>
+    where
+        T: Send + 'static,
+        R: FnOnce(i32) -> std::result::Result<T, CpuAffinityError> + Send + 'static,
+    {
+        let metadata = self
+            .store
+            .get(&sandbox_id)
+            .await?
+            .ok_or(OrchestratorError::SandboxNotFound(sandbox_id))?;
+        if metadata.state != SandboxState::Running {
+            return Err(OrchestratorError::InvalidSandboxState {
+                sandbox_id,
+                state: metadata.state,
+            });
+        }
+
+        let handle = self
+            .sandboxes
+            .read()
+            .await
+            .get(&sandbox_id)
+            .cloned()
+            .ok_or(OrchestratorError::SandboxOperationConflict {
+                sandbox_id,
+                operation,
+            })?;
+        let sandbox = handle.lock().await;
+        let metadata = self
+            .store
+            .get(&sandbox_id)
+            .await?
+            .ok_or(OrchestratorError::SandboxNotFound(sandbox_id))?;
+        if metadata.state != SandboxState::Running {
+            return Err(OrchestratorError::InvalidSandboxState {
+                sandbox_id,
+                state: metadata.state,
+            });
+        }
+        let pid = sandbox.runtime_process_id().map_err(|source| {
+            OrchestratorError::SandboxOperationFailed {
+                sandbox_id,
+                operation,
+                source,
+            }
+        })?;
+
+        let outcome = tokio::task::spawn_blocking(move || run(pid))
+            .await
+            .map_err(|source| OrchestratorError::SandboxOperationFailed {
+                sandbox_id,
+                operation,
+                source: anyhow::Error::new(source).context("join CPU affinity worker"),
+            })?;
+        match outcome {
+            Ok(value) => Ok((pid, value)),
+            Err(CpuAffinityError::InvalidRequest(message)) => {
+                Err(OrchestratorError::InvalidCpuAffinityRequest { message })
+            }
+            Err(CpuAffinityError::Operation(source)) => {
+                Err(OrchestratorError::SandboxOperationFailed {
+                    sandbox_id,
+                    operation,
+                    source,
+                })
+            }
+        }
     }
 
     /// Lists all sandboxes with their metadata.

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -904,7 +904,7 @@ where
                 sandbox_id,
                 operation,
             })?;
-        let sandbox = handle.lock().await;
+        let mut sandbox = handle.lock().await;
         let metadata = self
             .store
             .get(&sandbox_id)
@@ -916,6 +916,11 @@ where
                 state: metadata.state,
             });
         }
+        // The sandbox-level lock stays held until the blocking operation
+        // finishes. `runtime_process_id` also polls the owned child before
+        // returning its PID, so an already-exited Firecracker is rejected and
+        // an exit after this point remains unreaped (and therefore cannot have
+        // its PID reused) for the duration of this operation.
         let pid = sandbox.runtime_process_id().map_err(|source| {
             OrchestratorError::SandboxOperationFailed {
                 sandbox_id,
@@ -931,6 +936,7 @@ where
                 operation,
                 source: anyhow::Error::new(source).context("join CPU affinity worker"),
             })?;
+        drop(sandbox);
         match outcome {
             Ok(value) => Ok((pid, value)),
             Err(CpuAffinityError::InvalidRequest(message)) => {

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -904,7 +904,7 @@ where
                 sandbox_id,
                 operation,
             })?;
-        let mut sandbox = handle.lock().await;
+        let mut sandbox = handle.lock_owned().await;
         let metadata = self
             .store
             .get(&sandbox_id)
@@ -916,27 +916,27 @@ where
                 state: metadata.state,
             });
         }
-        // The sandbox-level lock stays held until the blocking operation
-        // finishes. `runtime_process_id` also polls the owned child before
-        // returning its PID, so an already-exited Firecracker is rejected and
-        // an exit after this point remains unreaped (and therefore cannot have
-        // its PID reused) for the duration of this operation.
-        let pid = sandbox.runtime_process_id().map_err(|source| {
-            OrchestratorError::SandboxOperationFailed {
+        // Move the owned sandbox guard into the blocking worker so the backend
+        // and its child process outlive the affinity operation even if the
+        // awaiting async task is dropped during runtime shutdown.
+        let worker_result = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let pid = sandbox.runtime_process_id()?;
+            let outcome = run(pid);
+            drop(sandbox);
+            Ok((pid, outcome))
+        })
+        .await
+        .map_err(|source| OrchestratorError::SandboxOperationFailed {
+            sandbox_id,
+            operation,
+            source: anyhow::Error::new(source).context("join CPU affinity worker"),
+        })?;
+        let (pid, outcome) =
+            worker_result.map_err(|source| OrchestratorError::SandboxOperationFailed {
                 sandbox_id,
                 operation,
                 source,
-            }
-        })?;
-
-        let outcome = tokio::task::spawn_blocking(move || run(pid))
-            .await
-            .map_err(|source| OrchestratorError::SandboxOperationFailed {
-                sandbox_id,
-                operation,
-                source: anyhow::Error::new(source).context("join CPU affinity worker"),
             })?;
-        drop(sandbox);
         match outcome {
             Ok(value) => Ok((pid, value)),
             Err(CpuAffinityError::InvalidRequest(message)) => {

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -838,6 +838,69 @@ fn paused_resume_metadata(sandbox_id: SandboxId) -> SandboxMetadata {
     }
 }
 
+#[tokio::test]
+async fn cpu_affinity_rejects_when_shutting_down() {
+    let orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::new(),
+        DisabledSandboxPersister,
+    );
+    let sandbox_id = SandboxId::new();
+
+    orchestrator.is_shutting_down.store(true, Ordering::Release);
+    assert!(matches!(
+        orchestrator
+            .bind_sandbox_cpu_affinity(
+                sandbox_id,
+                CpuAffinityRequest {
+                    vcpu: "*".to_string(),
+                    core: "0".to_string(),
+                },
+            )
+            .await,
+        Err(OrchestratorError::ShuttingDown)
+    ));
+}
+
+#[tokio::test]
+async fn oversized_cpu_affinity_request_is_invalid() {
+    let orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::new(),
+        DisabledSandboxPersister,
+    );
+    let sandbox_id = SandboxId::new();
+
+    orchestrator
+        .set_metadata_state_for_test(sandbox_id, SandboxState::Running)
+        .await
+        .unwrap();
+
+    let handle: SandboxHandle = Arc::new(Mutex::new(Box::new(MockSandboxBackend::new(Arc::new(
+        MockBehavior::new(),
+    )))));
+    orchestrator
+        .sandboxes
+        .write()
+        .await
+        .insert(sandbox_id, handle);
+
+    let error = orchestrator
+        .bind_sandbox_cpu_affinity(
+            sandbox_id,
+            CpuAffinityRequest {
+                vcpu: "*".repeat(16 * 1024 + 1),
+                core: "0".to_string(),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        OrchestratorError::InvalidCpuAffinityRequest { .. }
+    ));
+}
+
 /// The expected `OrchestratorMetrics` snapshot for a state in which a single
 /// `SandboxMetadata::default()`-shaped paused sandbox is the only entry in the
 /// store: no active running / starting contributions, and one Paused sandbox

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -876,9 +876,9 @@ async fn oversized_cpu_affinity_request_is_invalid() {
         .await
         .unwrap();
 
-    let handle: SandboxHandle = Arc::new(Mutex::new(Box::new(MockSandboxBackend::new(Arc::new(
-        MockBehavior::new(),
-    )))));
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.set_runtime_process_id(i32::MAX);
+    let handle: SandboxHandle = Arc::new(Mutex::new(Box::new(MockSandboxBackend::new(behavior))));
     orchestrator
         .sandboxes
         .write()
@@ -899,6 +899,49 @@ async fn oversized_cpu_affinity_request_is_invalid() {
         error,
         OrchestratorError::InvalidCpuAffinityRequest { .. }
     ));
+}
+
+#[tokio::test]
+async fn mock_cpu_affinity_does_not_target_the_test_process() {
+    let orchestrator = make_orchestrator_without_background_with_factory_and_persister(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::new(),
+        DisabledSandboxPersister,
+    );
+    let sandbox_id = SandboxId::new();
+
+    orchestrator
+        .set_metadata_state_for_test(sandbox_id, SandboxState::Running)
+        .await
+        .unwrap();
+
+    let handle: SandboxHandle = Arc::new(Mutex::new(Box::new(MockSandboxBackend::new(Arc::new(
+        MockBehavior::new(),
+    )))));
+    orchestrator
+        .sandboxes
+        .write()
+        .await
+        .insert(sandbox_id, handle);
+
+    let error = orchestrator
+        .bind_sandbox_cpu_affinity(
+            sandbox_id,
+            CpuAffinityRequest {
+                vcpu: "*".to_string(),
+                core: "0".to_string(),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        &error,
+        OrchestratorError::SandboxOperationFailed {
+            operation: SandboxOperation::BindCpuAffinity,
+            ..
+        }
+    ));
+    assert!(format!("{error:#}").contains("mock sandbox backend has no runtime process"));
 }
 
 /// The expected `OrchestratorMetrics` snapshot for a state in which a single

--- a/src/sandbox/backend.rs
+++ b/src/sandbox/backend.rs
@@ -262,6 +262,9 @@ pub trait SandboxBackend: Send + 'static {
     /// Return runtime facts that are only known after the backend has started.
     fn runtime_info(&self) -> SandboxRuntimeInfo;
 
+    /// Return the host PID of the process implementing this running sandbox.
+    fn runtime_process_id(&self) -> Result<i32>;
+
     /// Local runtime artifacts this sandbox opens on start.
     fn startup_artifacts(&self) -> RuntimeArtifactSet;
 

--- a/src/sandbox/backend.rs
+++ b/src/sandbox/backend.rs
@@ -263,7 +263,10 @@ pub trait SandboxBackend: Send + 'static {
     fn runtime_info(&self) -> SandboxRuntimeInfo;
 
     /// Return the host PID of the process implementing this running sandbox.
-    fn runtime_process_id(&self) -> Result<i32>;
+    ///
+    /// Implementations may poll the owned child process while resolving the
+    /// PID, so callers must hold the sandbox handle exclusively.
+    fn runtime_process_id(&mut self) -> Result<i32>;
 
     /// Local runtime artifacts this sandbox opens on start.
     fn startup_artifacts(&self) -> RuntimeArtifactSet;

--- a/src/sandbox/cpu_affinity.rs
+++ b/src/sandbox/cpu_affinity.rs
@@ -1,0 +1,810 @@
+//! Runtime CPU-affinity control for a Firecracker process.
+//!
+//! This module scans procfs, validates bounded CPU lists with ranges and
+//! optional strides, applies affinity one thread at a time, verifies every
+//! write, and restores earlier changes when a later write fails.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::ErrorKind;
+
+use anyhow::{anyhow, bail, Context, Result};
+use nix::sched::{sched_getaffinity, sched_setaffinity, CpuSet};
+use nix::unistd::Pid;
+
+const MAX_CPU_LIST_BYTES: usize = 16 * 1024;
+const MAX_CPU_LIST_VALUES: usize = 4096;
+const MAX_CPU_LIST_EXPANSION: u64 = 65_536;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CpuAffinityRequest {
+    pub vcpu: String,
+    pub core: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CpuAffinityOutcome {
+    pub vcpu: String,
+    pub cores: String,
+    pub ignored_offline_cores: String,
+    pub bound_thread_count: u32,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CpuAffinityError {
+    #[error("{0}")]
+    InvalidRequest(String),
+    #[error("{0:#}")]
+    Operation(#[source] anyhow::Error),
+}
+
+impl CpuAffinityError {
+    fn invalid(error: anyhow::Error) -> Self {
+        Self::InvalidRequest(format!("{error:#}"))
+    }
+}
+
+#[derive(Debug)]
+struct ThreadInfo {
+    tid: i32,
+    comm: String,
+    starttime: u64,
+}
+
+impl ThreadInfo {
+    /// Parse `/proc/PID/task/TID/stat`. Linux thread names may contain spaces
+    /// and `)`, so the final `") "` is the only safe command delimiter.
+    fn from_stat(expected_tid: i32, stat: &str) -> Result<Self> {
+        let (identity, fields) = stat
+            .trim_end()
+            .rsplit_once(") ")
+            .context("thread stat has no closing command delimiter")?;
+        let (raw_tid, comm) = identity
+            .split_once(" (")
+            .context("thread stat has no opening command delimiter")?;
+        let tid: i32 = raw_tid
+            .parse()
+            .with_context(|| format!("invalid thread ID {raw_tid:?} in stat"))?;
+        if tid != expected_tid {
+            bail!("thread stat ID changed from {expected_tid} to {tid}");
+        }
+
+        // `fields` starts at field 3 (`state`); starttime is field 22.
+        let raw_starttime = fields
+            .split_whitespace()
+            .nth(19)
+            .context("thread stat has no starttime field")?;
+        let starttime = raw_starttime
+            .parse()
+            .with_context(|| format!("invalid thread starttime {raw_starttime:?}"))?;
+
+        Ok(Self {
+            tid,
+            comm: comm.to_owned(),
+            starttime,
+        })
+    }
+
+    /// Re-read starttime around numeric-TID syscalls to narrow the window in
+    /// which an exited TID could refer to a different thread.
+    fn verify_identity(&self, pid: i32) -> Result<()> {
+        let path = format!("/proc/{pid}/task/{}/stat", self.tid);
+        let stat = fs::read_to_string(&path)
+            .with_context(|| format!("failed to re-read {path}; thread may have exited"))?;
+        let current = Self::from_stat(self.tid, &stat)
+            .with_context(|| format!("failed to verify identity of tid={}", self.tid))?;
+        if current.starttime != self.starttime {
+            bail!(
+                "tid={} identity changed during CPU-affinity operation (start time {} -> {})",
+                self.tid,
+                self.starttime,
+                current.starttime
+            );
+        }
+        Ok(())
+    }
+
+    /// Read this thread's affinity while checking that its numeric TID still
+    /// identifies the thread discovered during the procfs scan.
+    fn read_affinity(&self, pid: i32) -> Result<CpuSet> {
+        self.verify_identity(pid)?;
+        let affinity = sched_getaffinity(Pid::from_raw(self.tid)).with_context(|| {
+            format!(
+                "failed to read affinity of tid={} ({:?})",
+                self.tid, self.comm
+            )
+        })?;
+        self.verify_identity(pid)?;
+        Ok(affinity)
+    }
+}
+
+pub(crate) fn bind_process(
+    pid: i32,
+    request: CpuAffinityRequest,
+) -> std::result::Result<CpuAffinityOutcome, CpuAffinityError> {
+    if pid <= 0 {
+        return Err(CpuAffinityError::Operation(anyhow!(
+            "invalid Firecracker pid {pid}"
+        )));
+    }
+
+    if request.vcpu.len() > MAX_CPU_LIST_BYTES {
+        return Err(CpuAffinityError::InvalidRequest(format!(
+            "vcpu list is too long (maximum: {MAX_CPU_LIST_BYTES} bytes)"
+        )));
+    }
+    if request.core.len() > MAX_CPU_LIST_BYTES {
+        return Err(CpuAffinityError::InvalidRequest(format!(
+            "core list is too long (maximum: {MAX_CPU_LIST_BYTES} bytes)"
+        )));
+    }
+
+    let vcpu = request.vcpu.trim().to_owned();
+    let core = request.core.trim().to_owned();
+    let threads = list_threads(pid)
+        .with_context(|| format!("failed to enumerate threads of Firecracker pid {pid}"))
+        .map_err(CpuAffinityError::Operation)?;
+    let targets = select_threads(pid, &vcpu, &threads)?;
+
+    // nix::CpuSet wraps libc's fixed-size cpu_set_t. On supported Linux
+    // targets, this limits CPU IDs to 0-1023.
+    let max_cpu = CpuSet::count()
+        .checked_sub(1)
+        .context("cpu_set_t cannot represent any CPUs")
+        .and_then(|value| {
+            u32::try_from(value).context("cpu_set_t exceeds supported CPU identifiers")
+        })
+        .map_err(CpuAffinityError::Operation)?;
+    let requested = parse_cpu_list(&core, max_cpu)
+        .with_context(|| format!("invalid core value {core:?}"))
+        .map_err(CpuAffinityError::invalid)?;
+
+    let online_raw = fs::read_to_string("/sys/devices/system/cpu/online")
+        .context("failed to read /sys/devices/system/cpu/online")
+        .map_err(CpuAffinityError::Operation)?;
+    // The host may expose CPU IDs beyond libc's fixed-size cpu_set_t. Parse
+    // the trusted sysfs value as ranges without expanding it, then consider
+    // only the already-bounded CPUs requested by the caller.
+    let online = parse_cpu_ranges(&online_raw)
+        .context("invalid /sys/devices/system/cpu/online value")
+        .map_err(CpuAffinityError::Operation)?;
+    let (cores, ignored) = partition_online_cpus(&requested, &online);
+    if cores.is_empty() {
+        return Err(CpuAffinityError::InvalidRequest(format!(
+            "requested cores {} do not intersect online cores {}",
+            format_cpu_list(&requested),
+            online_raw.trim()
+        )));
+    }
+
+    let mut desired = CpuSet::new();
+    for &cpu in &cores {
+        desired
+            .set(cpu as usize)
+            .with_context(|| format!("core {cpu} does not fit in cpu_set_t"))
+            .map_err(CpuAffinityError::Operation)?;
+    }
+
+    let cores = format_cpu_list(&cores);
+    bind_threads(pid, &targets, &desired, &cores).map_err(CpuAffinityError::Operation)?;
+    let bound_thread_count = u32::try_from(targets.len())
+        .context("bound thread count does not fit in u32")
+        .map_err(CpuAffinityError::Operation)?;
+
+    Ok(CpuAffinityOutcome {
+        vcpu,
+        cores,
+        ignored_offline_cores: format_cpu_list(&ignored),
+        bound_thread_count,
+    })
+}
+
+fn select_threads<'a>(
+    pid: i32,
+    spec: &str,
+    threads: &'a [ThreadInfo],
+) -> std::result::Result<Vec<&'a ThreadInfo>, CpuAffinityError> {
+    if spec == "*" {
+        return Ok(threads.iter().collect());
+    }
+
+    let mut indexed = BTreeMap::new();
+    for thread in threads {
+        let Some(index) = fc_vcpu_index(&thread.comm) else {
+            continue;
+        };
+        if indexed.insert(index, thread).is_some() {
+            return Err(CpuAffinityError::Operation(anyhow!(
+                "pid {pid} has duplicate fc_vcpu thread index {index}"
+            )));
+        }
+    }
+    if indexed.is_empty() {
+        return Err(CpuAffinityError::Operation(anyhow!(
+            "pid {pid} has no fc_vcpu threads"
+        )));
+    }
+
+    let max_vcpu = indexed
+        .last_key_value()
+        .map(|(&index, _)| index)
+        .ok_or_else(|| CpuAffinityError::Operation(anyhow!("vCPU index set unexpectedly empty")))?;
+    let requested = parse_cpu_list(spec, max_vcpu)
+        .with_context(|| format!("invalid vcpu value {spec:?}"))
+        .map_err(CpuAffinityError::invalid)?;
+    let missing: Vec<u32> = requested
+        .iter()
+        .copied()
+        .filter(|index| !indexed.contains_key(index))
+        .collect();
+    if !missing.is_empty() {
+        let available: Vec<u32> = indexed.keys().copied().collect();
+        return Err(CpuAffinityError::InvalidRequest(format!(
+            "vcpu(s) {} not found in pid {pid}; available vcpus: {}",
+            format_cpu_list(&missing),
+            format_cpu_list(&available)
+        )));
+    }
+
+    Ok(requested
+        .iter()
+        .filter_map(|index| indexed.get(index).copied())
+        .collect())
+}
+
+/// Parse a comma/range CPU list while bounding input length, expansion work,
+/// allocation size, and the largest accepted value before any range expands.
+fn parse_cpu_list(spec: &str, max_value: u32) -> Result<Vec<u32>> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        bail!("empty cpu list");
+    }
+    if spec.len() > MAX_CPU_LIST_BYTES {
+        bail!("cpu list is too long (maximum: {MAX_CPU_LIST_BYTES} bytes)");
+    }
+
+    let mut values = BTreeSet::new();
+    let mut expansion = 0u64;
+    for part in spec.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            bail!("empty element in cpu list {spec:?}");
+        }
+
+        if let Some((lo, range_end)) = part.split_once('-') {
+            let lo: u32 = lo
+                .trim()
+                .parse()
+                .with_context(|| format!("invalid range start in {part:?}"))?;
+            let (hi, stride) = match range_end.split_once(':') {
+                Some((hi, stride)) => {
+                    let stride: u32 = stride
+                        .trim()
+                        .parse()
+                        .with_context(|| format!("invalid range stride in {part:?}"))?;
+                    if stride == 0 {
+                        bail!("range stride must be greater than zero in {part:?}");
+                    }
+                    (hi, stride)
+                }
+                None => (range_end, 1),
+            };
+            let hi: u32 = hi
+                .trim()
+                .parse()
+                .with_context(|| format!("invalid range end in {part:?}"))?;
+            if lo > hi {
+                bail!("descending range {part:?}");
+            }
+            if hi > max_value {
+                bail!("cpu {hi} exceeds maximum allowed value {max_value}");
+            }
+
+            let width = (u64::from(hi) - u64::from(lo)) / u64::from(stride) + 1;
+            if width > MAX_CPU_LIST_VALUES as u64 {
+                bail!("range {part:?} contains more than {MAX_CPU_LIST_VALUES} values");
+            }
+            expansion = expansion
+                .checked_add(width)
+                .context("cpu list expansion size overflow")?;
+            if expansion > MAX_CPU_LIST_EXPANSION {
+                bail!("cpu list expands to more than {MAX_CPU_LIST_EXPANSION} values");
+            }
+            let stride = usize::try_from(stride).context("range stride does not fit usize")?;
+            values.extend((lo..=hi).step_by(stride));
+        } else {
+            let value: u32 = part
+                .parse()
+                .with_context(|| format!("invalid cpu number {part:?}"))?;
+            if value > max_value {
+                bail!("cpu {value} exceeds maximum allowed value {max_value}");
+            }
+            expansion = expansion
+                .checked_add(1)
+                .context("cpu list expansion size overflow")?;
+            if expansion > MAX_CPU_LIST_EXPANSION {
+                bail!("cpu list expands to more than {MAX_CPU_LIST_EXPANSION} values");
+            }
+            values.insert(value);
+        }
+
+        if values.len() > MAX_CPU_LIST_VALUES {
+            bail!("cpu list contains more than {MAX_CPU_LIST_VALUES} unique values");
+        }
+    }
+    Ok(values.into_iter().collect())
+}
+
+/// Parse a trusted kernel CPU-list as non-expanded inclusive ranges. This
+/// keeps hosts with CPU IDs beyond cpu_set_t usable for lower representable
+/// CPUs and avoids allocating once per online CPU.
+fn parse_cpu_ranges(spec: &str) -> Result<Vec<(u32, u32)>> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        bail!("empty cpu list");
+    }
+    if spec.len() > MAX_CPU_LIST_BYTES {
+        bail!("cpu list is too long (maximum: {MAX_CPU_LIST_BYTES} bytes)");
+    }
+
+    let mut ranges = Vec::new();
+    for part in spec.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            bail!("empty element in cpu list {spec:?}");
+        }
+        let (lo, hi) = match part.split_once('-') {
+            Some((lo, hi)) => {
+                let lo = lo
+                    .trim()
+                    .parse::<u32>()
+                    .with_context(|| format!("invalid range start in {part:?}"))?;
+                let hi = hi
+                    .trim()
+                    .parse::<u32>()
+                    .with_context(|| format!("invalid range end in {part:?}"))?;
+                if lo > hi {
+                    bail!("descending range {part:?}");
+                }
+                (lo, hi)
+            }
+            None => {
+                let value = part
+                    .parse::<u32>()
+                    .with_context(|| format!("invalid cpu number {part:?}"))?;
+                (value, value)
+            }
+        };
+        ranges.push((lo, hi));
+        if ranges.len() > MAX_CPU_LIST_VALUES {
+            bail!("cpu list contains more than {MAX_CPU_LIST_VALUES} ranges");
+        }
+    }
+    Ok(ranges)
+}
+
+fn partition_online_cpus(requested: &[u32], online: &[(u32, u32)]) -> (Vec<u32>, Vec<u32>) {
+    requested
+        .iter()
+        .copied()
+        .partition(|cpu| online.iter().any(|&(lo, hi)| lo <= *cpu && *cpu <= hi))
+}
+
+fn format_cpu_list(cpus: &[u32]) -> String {
+    let mut parts = Vec::new();
+    let mut values = cpus.iter().copied().peekable();
+    while let Some(start) = values.next() {
+        let mut end = start;
+        while end < u32::MAX && values.peek() == Some(&(end + 1)) {
+            end = values.next().expect("peeked value must exist");
+        }
+        if start == end {
+            parts.push(start.to_string());
+        } else {
+            parts.push(format!("{start}-{end}"));
+        }
+    }
+    parts.join(",")
+}
+
+/// Collect a best-effort task snapshot. A task disappearing during the scan is
+/// normal; all other I/O and stat-format errors fail closed.
+fn list_threads(pid: i32) -> Result<Vec<ThreadInfo>> {
+    let directory = format!("/proc/{pid}/task");
+    let entries = fs::read_dir(&directory)
+        .with_context(|| format!("failed to open {directory} (process alive and permitted?)"))?;
+    let mut threads = Vec::new();
+
+    for entry in entries {
+        let entry = entry.with_context(|| format!("failed to enumerate {directory}"))?;
+        let tid: i32 = match entry.file_name().to_string_lossy().parse() {
+            Ok(tid) => tid,
+            Err(_) => continue,
+        };
+        let path = format!("/proc/{pid}/task/{tid}/stat");
+        let stat = match fs::read_to_string(&path) {
+            Ok(stat) => stat,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(error) => return Err(error).with_context(|| format!("failed to read {path}")),
+        };
+        threads.push(
+            ThreadInfo::from_stat(tid, &stat).with_context(|| format!("failed to parse {path}"))?,
+        );
+    }
+
+    if threads.is_empty() {
+        bail!("no threads found under {directory}");
+    }
+    threads.sort_by_key(|thread| (fc_vcpu_index(&thread.comm).unwrap_or(u32::MAX), thread.tid));
+    Ok(threads)
+}
+
+fn fc_vcpu_index(comm: &str) -> Option<u32> {
+    comm.strip_prefix("fc_vcpu")?.trim().parse().ok()
+}
+
+fn format_cpu_set(set: &CpuSet) -> String {
+    let cpus: Vec<u32> = (0..CpuSet::count())
+        .filter_map(|index| match set.is_set(index) {
+            Ok(true) => u32::try_from(index).ok(),
+            Ok(false) | Err(_) => None,
+        })
+        .collect();
+    format_cpu_list(&cpus)
+}
+
+/// Apply affinity as a best-effort transaction: preflight every target, update
+/// one by one, verify the result, and roll back earlier updates on failure.
+fn bind_threads(pid: i32, targets: &[&ThreadInfo], desired: &CpuSet, cores: &str) -> Result<()> {
+    let originals: Vec<(&ThreadInfo, CpuSet)> = targets
+        .iter()
+        .map(|&thread| thread.read_affinity(pid).map(|original| (thread, original)))
+        .collect::<Result<_>>()?;
+
+    for (index, (thread, _)) in originals.iter().enumerate() {
+        if let Err(error) = thread.verify_identity(pid) {
+            return Err(error_after_rollback(
+                pid,
+                format!("thread identity check failed: {error:#}"),
+                &originals[..index],
+            ));
+        }
+        if let Err(error) = sched_setaffinity(Pid::from_raw(thread.tid), desired) {
+            return Err(error_after_rollback(
+                pid,
+                format!(
+                    "failed to bind tid={} ({:?}) to cores {cores}: {error}",
+                    thread.tid, thread.comm
+                ),
+                &originals[..index],
+            ));
+        }
+        let applied = index + 1;
+
+        let actual = match thread.read_affinity(pid) {
+            Ok(actual) => actual,
+            Err(error) => {
+                return Err(error_after_rollback(
+                    pid,
+                    format!(
+                        "bound tid={} ({:?}) but failed to verify its affinity: {error:#}",
+                        thread.tid, thread.comm
+                    ),
+                    &originals[..applied],
+                ));
+            }
+        };
+        if actual != *desired {
+            return Err(error_after_rollback(
+                pid,
+                format!(
+                    "kernel restricted affinity of tid={} ({:?}): requested {cores}, actual {}",
+                    thread.tid,
+                    thread.comm,
+                    format_cpu_set(&actual)
+                ),
+                &originals[..applied],
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn error_after_rollback(
+    pid: i32,
+    reason: String,
+    applied: &[(&ThreadInfo, CpuSet)],
+) -> anyhow::Error {
+    if applied.is_empty() {
+        return anyhow!("{reason}; no affinity changes were applied");
+    }
+
+    let mut failures = Vec::new();
+    for (thread, original) in applied.iter().rev() {
+        if let Err(error) = thread.verify_identity(pid) {
+            failures.push(format!(
+                "tid={} (identity check failed: {error:#})",
+                thread.tid
+            ));
+            continue;
+        }
+        match sched_setaffinity(Pid::from_raw(thread.tid), original) {
+            Err(error) => failures.push(format!("tid={} (restore failed: {error})", thread.tid)),
+            Ok(()) => match thread.read_affinity(pid) {
+                Ok(actual) => {
+                    if actual != *original {
+                        failures.push(format!(
+                            "tid={} (restore verification mismatch: {})",
+                            thread.tid,
+                            format_cpu_set(&actual)
+                        ));
+                    }
+                }
+                Err(error) => failures.push(format!(
+                    "tid={} (restore verification failed: {error})",
+                    thread.tid
+                )),
+            },
+        }
+    }
+
+    if failures.is_empty() {
+        anyhow!("{reason}; rolled back {} thread(s)", applied.len())
+    } else {
+        anyhow!("{reason}; rollback incomplete for {}", failures.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::{Child, Command, Stdio};
+    use std::sync::{Arc, Barrier};
+    use std::time::{Duration, Instant};
+
+    struct ChildGuard(Child);
+
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    fn thread(tid: i32, comm: &str) -> ThreadInfo {
+        ThreadInfo {
+            tid,
+            comm: comm.to_string(),
+            starttime: 1,
+        }
+    }
+
+    #[test]
+    fn cpu_list_accepts_ranges_whitespace_and_duplicates() {
+        assert_eq!(parse_cpu_list("0", 4).unwrap(), vec![0]);
+        assert_eq!(parse_cpu_list("0,1-2,2,4", 4).unwrap(), vec![0, 1, 2, 4]);
+        assert_eq!(parse_cpu_list(" 3 , 1 ", 4).unwrap(), vec![1, 3]);
+        assert_eq!(
+            parse_cpu_list("0-10:2", 10).unwrap(),
+            vec![0, 2, 4, 6, 8, 10]
+        );
+        assert_eq!(parse_cpu_list("0-10:3", 10).unwrap(), vec![0, 3, 6, 9]);
+    }
+
+    #[test]
+    fn cpu_list_rejects_invalid_and_pathological_ranges() {
+        for value in [
+            "", "a", "1,", "2-1", "1-x", "1:2", "0-10:", "0-10:0", "0-10:x",
+        ] {
+            assert!(parse_cpu_list(value, 4).is_err(), "accepted {value:?}");
+        }
+        assert!(parse_cpu_list("0-4294967295", u32::MAX).is_err());
+        assert_eq!(
+            parse_cpu_list("0-4294967295:4294967295", u32::MAX).unwrap(),
+            vec![0, u32::MAX]
+        );
+        assert!(parse_cpu_list("1024", 1023).is_err());
+    }
+
+    #[test]
+    fn bind_request_rejects_oversized_fields_before_procfs_work() {
+        let oversized = "0".repeat(MAX_CPU_LIST_BYTES + 1);
+        let request = CpuAffinityRequest {
+            vcpu: oversized.clone(),
+            core: "0".to_string(),
+        };
+        assert!(matches!(
+            bind_process(i32::MAX, request),
+            Err(CpuAffinityError::InvalidRequest(_))
+        ));
+
+        let request = CpuAffinityRequest {
+            vcpu: "*".to_string(),
+            core: oversized,
+        };
+        assert!(matches!(
+            bind_process(i32::MAX, request),
+            Err(CpuAffinityError::InvalidRequest(_))
+        ));
+    }
+
+    #[test]
+    fn cpu_list_format_is_compact_and_overflow_safe() {
+        assert_eq!(format_cpu_list(&[0, 1, 2, 4]), "0-2,4");
+        assert_eq!(
+            format_cpu_list(&[u32::MAX - 1, u32::MAX]),
+            "4294967294-4294967295"
+        );
+    }
+
+    #[test]
+    fn kernel_cpu_ranges_do_not_expand_and_partition_requested_values() {
+        let online = parse_cpu_ranges("0-8191,10000").unwrap();
+        assert_eq!(online, vec![(0, 8191), (10000, 10000)]);
+        assert_eq!(
+            partition_online_cpus(&[0, 1023, 9000, 10000], &online),
+            (vec![0, 1023, 10000], vec![9000])
+        );
+        assert_eq!(
+            partition_online_cpus(&[9000], &online),
+            (Vec::new(), vec![9000])
+        );
+        assert!(parse_cpu_ranges("4-2").is_err());
+    }
+
+    #[test]
+    fn stat_parser_handles_spaces_and_parentheses_in_thread_name() {
+        let stat = "123 (worker ) name) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 987";
+        let thread = ThreadInfo::from_stat(123, stat).unwrap();
+        assert_eq!(thread.comm, "worker ) name");
+        assert_eq!(thread.starttime, 987);
+        assert!(ThreadInfo::from_stat(124, stat).is_err());
+    }
+
+    #[test]
+    fn firecracker_vcpu_names_are_recognized_without_matching_helpers() {
+        assert_eq!(fc_vcpu_index("fc_vcpu 0"), Some(0));
+        assert_eq!(fc_vcpu_index("fc_vcpu15"), Some(15));
+        assert_eq!(fc_vcpu_index("fc_vmm"), None);
+        assert_eq!(fc_vcpu_index("kvm-nx-lpage-re"), None);
+    }
+
+    #[test]
+    fn thread_selection_distinguishes_numeric_vcpus_from_wildcard() {
+        let threads = vec![
+            thread(10, "fc_vmm"),
+            thread(11, "fc_vcpu 0"),
+            thread(12, "fc_vcpu1"),
+            thread(13, "kvm-nx-lpage-re"),
+        ];
+
+        let selected = select_threads(99, "1,0,1", &threads).unwrap();
+        assert_eq!(
+            selected.iter().map(|thread| thread.tid).collect::<Vec<_>>(),
+            vec![11, 12]
+        );
+        assert_eq!(select_threads(99, "*", &threads).unwrap().len(), 4);
+        assert!(matches!(
+            select_threads(99, "2", &threads),
+            Err(CpuAffinityError::InvalidRequest(_))
+        ));
+
+        let duplicate = vec![thread(11, "fc_vcpu0"), thread(12, "fc_vcpu 0")];
+        assert!(matches!(
+            select_threads(99, "0", &duplicate),
+            Err(CpuAffinityError::Operation(_))
+        ));
+        assert!(matches!(
+            select_threads(99, "0", &[thread(10, "fc_vmm")]),
+            Err(CpuAffinityError::Operation(_))
+        ));
+    }
+
+    #[test]
+    fn current_process_threads_can_be_scanned_and_revalidated() {
+        let pid = i32::try_from(std::process::id()).unwrap();
+        let threads = list_threads(pid).unwrap();
+        let main = threads.iter().find(|thread| thread.tid == pid).unwrap();
+        main.verify_identity(pid).unwrap();
+        main.read_affinity(pid).unwrap();
+    }
+
+    #[test]
+    fn incomplete_rollback_reports_the_affected_tid() {
+        let pid = i32::try_from(std::process::id()).unwrap();
+        let missing = thread(i32::MAX, "exited-thread");
+        let original = CpuSet::new();
+        let error = error_after_rollback(pid, "apply failed".to_string(), &[(&missing, original)]);
+        let message = error.to_string();
+        assert!(message.contains("rollback incomplete"));
+        assert!(message.contains(&format!("tid={}", missing.tid)));
+    }
+
+    #[test]
+    fn wildcard_binding_and_rollback_work_on_disposable_process() {
+        let executable = std::env::current_exe().unwrap();
+        let child = Command::new(executable)
+            .args([
+                "--exact",
+                "sandbox::cpu_affinity::tests::affinity_test_child",
+                "--ignored",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut child = ChildGuard(child);
+        let pid = i32::try_from(child.0.id()).unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let threads = loop {
+            if let Some(status) = child.0.try_wait().unwrap() {
+                panic!("affinity test child exited before it was ready: {status}");
+            }
+            if let Ok(threads) = list_threads(pid) {
+                if threads.len() >= 3 {
+                    break threads;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "affinity test child was not ready"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        };
+
+        let originals: Vec<(&ThreadInfo, CpuSet)> = threads
+            .iter()
+            .map(|thread| {
+                (
+                    thread,
+                    sched_getaffinity(Pid::from_raw(thread.tid)).unwrap(),
+                )
+            })
+            .collect();
+        let cpu = (0..CpuSet::count())
+            .find(|&cpu| originals.iter().all(|(_, set)| set.is_set(cpu) == Ok(true)))
+            .expect("child threads should share at least one allowed CPU");
+
+        let outcome = bind_process(
+            pid,
+            CpuAffinityRequest {
+                vcpu: "*".to_string(),
+                core: cpu.to_string(),
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.bound_thread_count as usize, originals.len());
+
+        let rollback = error_after_rollback(pid, "test rollback".to_string(), &originals);
+        assert!(rollback.to_string().contains("rolled back"));
+        for (thread, original) in originals {
+            assert_eq!(
+                sched_getaffinity(Pid::from_raw(thread.tid)).unwrap(),
+                original
+            );
+            thread.verify_identity(pid).unwrap();
+        }
+    }
+
+    #[test]
+    #[ignore = "helper process for wildcard_binding_and_rollback_work_on_disposable_process"]
+    fn affinity_test_child() {
+        let ready = Arc::new(Barrier::new(3));
+        let workers: Vec<_> = (0..2)
+            .map(|_| {
+                let ready = Arc::clone(&ready);
+                std::thread::spawn(move || {
+                    ready.wait();
+                    std::thread::sleep(Duration::from_secs(30));
+                })
+            })
+            .collect();
+        ready.wait();
+        for worker in workers {
+            worker.join().unwrap();
+        }
+    }
+}

--- a/src/sandbox/cpu_affinity.rs
+++ b/src/sandbox/cpu_affinity.rs
@@ -145,6 +145,18 @@ pub(crate) fn bind_process(
     let threads = list_threads(pid)
         .with_context(|| format!("failed to enumerate threads of Firecracker pid {pid}"))
         .map_err(CpuAffinityError::Operation)?;
+    let process = threads
+        .iter()
+        .find(|thread| thread.tid == pid)
+        .ok_or_else(|| {
+            CpuAffinityError::Operation(anyhow!(
+                "Firecracker pid {pid} has no process-leader thread"
+            ))
+        })?;
+    process
+        .verify_identity(pid)
+        .context("failed to verify Firecracker process identity")
+        .map_err(CpuAffinityError::Operation)?;
     let targets = select_threads(pid, &vcpu, &threads)?;
 
     // nix::CpuSet wraps libc's fixed-size cpu_set_t. On supported Linux
@@ -187,7 +199,7 @@ pub(crate) fn bind_process(
     }
 
     let cores = format_cpu_list(&cores);
-    bind_threads(pid, &targets, &desired, &cores).map_err(CpuAffinityError::Operation)?;
+    bind_threads(pid, process, &targets, &desired, &cores).map_err(CpuAffinityError::Operation)?;
     let bound_thread_count = u32::try_from(targets.len())
         .context("bound thread count does not fit in u32")
         .map_err(CpuAffinityError::Operation)?;
@@ -456,16 +468,37 @@ fn format_cpu_set(set: &CpuSet) -> String {
 
 /// Apply affinity as a best-effort transaction: preflight every target, update
 /// one by one, verify the result, and roll back earlier updates on failure.
-fn bind_threads(pid: i32, targets: &[&ThreadInfo], desired: &CpuSet, cores: &str) -> Result<()> {
-    let originals: Vec<(&ThreadInfo, CpuSet)> = targets
-        .iter()
-        .map(|&thread| thread.read_affinity(pid).map(|original| (thread, original)))
-        .collect::<Result<_>>()?;
+fn bind_threads(
+    pid: i32,
+    process: &ThreadInfo,
+    targets: &[&ThreadInfo],
+    desired: &CpuSet,
+    cores: &str,
+) -> Result<()> {
+    let mut originals = Vec::with_capacity(targets.len());
+    for &thread in targets {
+        process
+            .verify_identity(pid)
+            .context("Firecracker process identity changed during affinity preflight")?;
+        originals.push((thread, thread.read_affinity(pid)?));
+        process
+            .verify_identity(pid)
+            .context("Firecracker process identity changed during affinity preflight")?;
+    }
 
     for (index, (thread, _)) in originals.iter().enumerate() {
+        if let Err(error) = process.verify_identity(pid) {
+            return Err(error_after_rollback(
+                pid,
+                process,
+                format!("Firecracker process identity check failed: {error:#}"),
+                &originals[..index],
+            ));
+        }
         if let Err(error) = thread.verify_identity(pid) {
             return Err(error_after_rollback(
                 pid,
+                process,
                 format!("thread identity check failed: {error:#}"),
                 &originals[..index],
             ));
@@ -473,6 +506,7 @@ fn bind_threads(pid: i32, targets: &[&ThreadInfo], desired: &CpuSet, cores: &str
         if let Err(error) = sched_setaffinity(Pid::from_raw(thread.tid), desired) {
             return Err(error_after_rollback(
                 pid,
+                process,
                 format!(
                     "failed to bind tid={} ({:?}) to cores {cores}: {error}",
                     thread.tid, thread.comm
@@ -487,6 +521,7 @@ fn bind_threads(pid: i32, targets: &[&ThreadInfo], desired: &CpuSet, cores: &str
             Err(error) => {
                 return Err(error_after_rollback(
                     pid,
+                    process,
                     format!(
                         "bound tid={} ({:?}) but failed to verify its affinity: {error:#}",
                         thread.tid, thread.comm
@@ -498,6 +533,7 @@ fn bind_threads(pid: i32, targets: &[&ThreadInfo], desired: &CpuSet, cores: &str
         if actual != *desired {
             return Err(error_after_rollback(
                 pid,
+                process,
                 format!(
                     "kernel restricted affinity of tid={} ({:?}): requested {cores}, actual {}",
                     thread.tid,
@@ -507,12 +543,21 @@ fn bind_threads(pid: i32, targets: &[&ThreadInfo], desired: &CpuSet, cores: &str
                 &originals[..applied],
             ));
         }
+        if let Err(error) = process.verify_identity(pid) {
+            return Err(error_after_rollback(
+                pid,
+                process,
+                format!("Firecracker process identity check failed: {error:#}"),
+                &originals[..applied],
+            ));
+        }
     }
     Ok(())
 }
 
 fn error_after_rollback(
     pid: i32,
+    process: &ThreadInfo,
     reason: String,
     applied: &[(&ThreadInfo, CpuSet)],
 ) -> anyhow::Error {
@@ -520,8 +565,18 @@ fn error_after_rollback(
         return anyhow!("{reason}; no affinity changes were applied");
     }
 
+    if let Err(error) = process.verify_identity(pid) {
+        return anyhow!(
+            "{reason}; rollback skipped because Firecracker process identity check failed: {error:#}"
+        );
+    }
+
     let mut failures = Vec::new();
     for (thread, original) in applied.iter().rev() {
+        if let Err(error) = process.verify_identity(pid) {
+            failures.push(format!("process identity check failed: {error:#}"));
+            break;
+        }
         if let Err(error) = thread.verify_identity(pid) {
             failures.push(format!(
                 "tid={} (identity check failed: {error:#})",
@@ -713,9 +768,16 @@ mod tests {
     #[test]
     fn incomplete_rollback_reports_the_affected_tid() {
         let pid = i32::try_from(std::process::id()).unwrap();
+        let threads = list_threads(pid).unwrap();
+        let process = threads.iter().find(|thread| thread.tid == pid).unwrap();
         let missing = thread(i32::MAX, "exited-thread");
         let original = CpuSet::new();
-        let error = error_after_rollback(pid, "apply failed".to_string(), &[(&missing, original)]);
+        let error = error_after_rollback(
+            pid,
+            process,
+            "apply failed".to_string(),
+            &[(&missing, original)],
+        );
         let message = error.to_string();
         assert!(message.contains("rollback incomplete"));
         assert!(message.contains(&format!("tid={}", missing.tid)));
@@ -764,6 +826,7 @@ mod tests {
                 )
             })
             .collect();
+        let process = threads.iter().find(|thread| thread.tid == pid).unwrap();
         let cpu = (0..CpuSet::count())
             .find(|&cpu| originals.iter().all(|(_, set)| set.is_set(cpu) == Ok(true)))
             .expect("child threads should share at least one allowed CPU");
@@ -778,7 +841,7 @@ mod tests {
         .unwrap();
         assert_eq!(outcome.bound_thread_count as usize, originals.len());
 
-        let rollback = error_after_rollback(pid, "test rollback".to_string(), &originals);
+        let rollback = error_after_rollback(pid, process, "test rollback".to_string(), &originals);
         assert!(rollback.to_string().contains("rolled back"));
         for (thread, original) in originals {
             assert_eq!(

--- a/src/sandbox/cpu_affinity.rs
+++ b/src/sandbox/cpu_affinity.rs
@@ -145,6 +145,11 @@ struct StoppedThreadGroup {
 
 impl StoppedThreadGroup {
     fn stop(pid: i32) -> Result<Self> {
+        let threads = list_threads(pid)?;
+        if threads.iter().any(ThreadInfo::is_stopped) {
+            bail!("Firecracker pid {pid} is already stopped");
+        }
+
         let pid = Pid::from_raw(pid);
         kill(pid, Signal::SIGSTOP)
             .with_context(|| format!("failed to send SIGSTOP to Firecracker pid {pid}"))?;

--- a/src/sandbox/cpu_affinity.rs
+++ b/src/sandbox/cpu_affinity.rs
@@ -1,20 +1,25 @@
 //! Runtime CPU-affinity control for a Firecracker process.
 //!
 //! This module scans procfs, validates bounded CPU lists with ranges and
-//! optional strides, applies affinity one thread at a time, verifies every
-//! write, and restores earlier changes when a later write fails.
+//! optional strides, stops the complete Firecracker thread group while numeric
+//! TIDs are used, applies affinity one thread at a time, verifies every write,
+//! and restores earlier changes when a later write fails.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::ErrorKind;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use nix::sched::{sched_getaffinity, sched_setaffinity, CpuSet};
+use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
 
 const MAX_CPU_LIST_BYTES: usize = 16 * 1024;
 const MAX_CPU_LIST_VALUES: usize = 4096;
 const MAX_CPU_LIST_EXPANSION: u64 = 65_536;
+const THREAD_GROUP_STOP_TIMEOUT: Duration = Duration::from_secs(1);
+const THREAD_GROUP_STOP_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CpuAffinityRequest {
@@ -48,6 +53,7 @@ impl CpuAffinityError {
 struct ThreadInfo {
     tid: i32,
     comm: String,
+    state: char,
     starttime: u64,
 }
 
@@ -70,9 +76,14 @@ impl ThreadInfo {
         }
 
         // `fields` starts at field 3 (`state`); starttime is field 22.
+        let mut fields = fields.split_whitespace();
+        let raw_state = fields.next().context("thread stat has no state field")?;
+        let state = match raw_state.as_bytes() {
+            [state] => char::from(*state),
+            _ => bail!("invalid thread state {raw_state:?}"),
+        };
         let raw_starttime = fields
-            .split_whitespace()
-            .nth(19)
+            .nth(18)
             .context("thread stat has no starttime field")?;
         let starttime = raw_starttime
             .parse()
@@ -81,8 +92,13 @@ impl ThreadInfo {
         Ok(Self {
             tid,
             comm: comm.to_owned(),
+            state,
             starttime,
         })
+    }
+
+    fn is_stopped(&self) -> bool {
+        matches!(self.state, 'T' | 't')
     }
 
     /// Re-read starttime around numeric-TID syscalls to narrow the window in
@@ -119,6 +135,66 @@ impl ThreadInfo {
     }
 }
 
+/// Keeps a process-wide SIGSTOP paired with SIGCONT on every normal unwind
+/// path. The explicit `resume` call reports delivery failures; `Drop` is a
+/// final best-effort safeguard for early returns and panics.
+struct StoppedThreadGroup {
+    pid: Pid,
+    resumed: bool,
+}
+
+impl StoppedThreadGroup {
+    fn stop(pid: i32) -> Result<Self> {
+        let pid = Pid::from_raw(pid);
+        kill(pid, Signal::SIGSTOP)
+            .with_context(|| format!("failed to send SIGSTOP to Firecracker pid {pid}"))?;
+
+        let guard = Self {
+            pid,
+            resumed: false,
+        };
+        let started = Instant::now();
+        loop {
+            let threads = list_threads(pid.as_raw())
+                .with_context(|| format!("failed to confirm that Firecracker pid {pid} stopped"))?;
+            if threads.iter().all(ThreadInfo::is_stopped) {
+                return Ok(guard);
+            }
+
+            let elapsed = started.elapsed();
+            if elapsed >= THREAD_GROUP_STOP_TIMEOUT {
+                let active = threads
+                    .iter()
+                    .filter(|thread| !thread.is_stopped())
+                    .map(|thread| format!("{}:{:?}:{}", thread.tid, thread.comm, thread.state))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                bail!(
+                    "Firecracker pid {pid} did not fully stop within {} ms; active threads: {active}",
+                    THREAD_GROUP_STOP_TIMEOUT.as_millis()
+                );
+            }
+
+            std::thread::sleep(THREAD_GROUP_STOP_POLL_INTERVAL);
+        }
+    }
+
+    fn resume(mut self) -> Result<()> {
+        kill(self.pid, Signal::SIGCONT)
+            .with_context(|| format!("failed to send SIGCONT to Firecracker pid {}", self.pid))?;
+        self.resumed = true;
+        Ok(())
+    }
+}
+
+impl Drop for StoppedThreadGroup {
+    fn drop(&mut self) {
+        if !self.resumed {
+            let _ = kill(self.pid, Signal::SIGCONT);
+        }
+    }
+}
+
 pub(crate) fn bind_process(
     pid: i32,
     request: CpuAffinityRequest,
@@ -141,24 +217,7 @@ pub(crate) fn bind_process(
     }
 
     let vcpu = request.vcpu.trim().to_owned();
-    let core = request.core.trim().to_owned();
-    let threads = list_threads(pid)
-        .with_context(|| format!("failed to enumerate threads of Firecracker pid {pid}"))
-        .map_err(CpuAffinityError::Operation)?;
-    let process = threads
-        .iter()
-        .find(|thread| thread.tid == pid)
-        .ok_or_else(|| {
-            CpuAffinityError::Operation(anyhow!(
-                "Firecracker pid {pid} has no process-leader thread"
-            ))
-        })?;
-    process
-        .verify_identity(pid)
-        .context("failed to verify Firecracker process identity")
-        .map_err(CpuAffinityError::Operation)?;
-    let targets = select_threads(pid, &vcpu, &threads)?;
-
+    let core = request.core.trim();
     // nix::CpuSet wraps libc's fixed-size cpu_set_t. On supported Linux
     // targets, this limits CPU IDs to 0-1023.
     let max_cpu = CpuSet::count()
@@ -168,7 +227,7 @@ pub(crate) fn bind_process(
             u32::try_from(value).context("cpu_set_t exceeds supported CPU identifiers")
         })
         .map_err(CpuAffinityError::Operation)?;
-    let requested = parse_cpu_list(&core, max_cpu)
+    let requested = parse_cpu_list(core, max_cpu)
         .with_context(|| format!("invalid core value {core:?}"))
         .map_err(CpuAffinityError::invalid)?;
 
@@ -199,7 +258,52 @@ pub(crate) fn bind_process(
     }
 
     let cores = format_cpu_list(&cores);
-    bind_threads(pid, process, &targets, &desired, &cores).map_err(CpuAffinityError::Operation)?;
+    let stopped = StoppedThreadGroup::stop(pid)
+        .context("failed to stop Firecracker for CPU-affinity update")
+        .map_err(CpuAffinityError::Operation)?;
+    let outcome = bind_stopped_process(pid, vcpu, cores, ignored, &desired);
+
+    if let Err(error) = stopped.resume() {
+        let context = match &outcome {
+            Ok(_) => "CPU affinity was applied, but Firecracker could not be resumed".to_string(),
+            Err(bind_error) => format!(
+                "CPU-affinity operation failed ({bind_error:#}); Firecracker also could not be resumed"
+            ),
+        };
+        return Err(CpuAffinityError::Operation(error.context(context)));
+    }
+
+    outcome
+}
+
+/// Enumerate and update tasks only after the complete thread group has entered
+/// a stopped state. This prevents normal Firecracker execution from exiting a
+/// worker and reusing its numeric TID during the affinity syscalls.
+fn bind_stopped_process(
+    pid: i32,
+    vcpu: String,
+    cores: String,
+    ignored: Vec<u32>,
+    desired: &CpuSet,
+) -> std::result::Result<CpuAffinityOutcome, CpuAffinityError> {
+    let threads = list_threads(pid)
+        .with_context(|| format!("failed to enumerate threads of Firecracker pid {pid}"))
+        .map_err(CpuAffinityError::Operation)?;
+    let process = threads
+        .iter()
+        .find(|thread| thread.tid == pid)
+        .ok_or_else(|| {
+            CpuAffinityError::Operation(anyhow!(
+                "Firecracker pid {pid} has no process-leader thread"
+            ))
+        })?;
+    process
+        .verify_identity(pid)
+        .context("failed to verify Firecracker process identity")
+        .map_err(CpuAffinityError::Operation)?;
+    let targets = select_threads(pid, &vcpu, &threads)?;
+
+    bind_threads(pid, process, &targets, desired, &cores).map_err(CpuAffinityError::Operation)?;
     let bound_thread_count = u32::try_from(targets.len())
         .context("bound thread count does not fit in u32")
         .map_err(CpuAffinityError::Operation)?;
@@ -466,8 +570,8 @@ fn format_cpu_set(set: &CpuSet) -> String {
     format_cpu_list(&cpus)
 }
 
-/// Apply affinity as a best-effort transaction: preflight every target, update
-/// one by one, verify the result, and roll back earlier updates on failure.
+/// While the caller keeps the complete thread group stopped, apply affinity as
+/// a best-effort transaction and roll back earlier updates on failure.
 fn bind_threads(
     pid: i32,
     process: &ThreadInfo,
@@ -618,6 +722,8 @@ mod tests {
     use std::sync::{Arc, Barrier};
     use std::time::{Duration, Instant};
 
+    const AFFINITY_TEST_WORKERS: [&str; 2] = ["aenv-affinity-0", "aenv-affinity-1"];
+
     struct ChildGuard(Child);
 
     impl Drop for ChildGuard {
@@ -631,7 +737,23 @@ mod tests {
         ThreadInfo {
             tid,
             comm: comm.to_string(),
+            state: 'S',
             starttime: 1,
+        }
+    }
+
+    fn wait_until_running(pid: i32) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let threads = list_threads(pid).unwrap();
+            if threads.iter().all(|thread| !thread.is_stopped()) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "test process remained stopped after SIGCONT"
+            );
+            std::thread::sleep(Duration::from_millis(1));
         }
     }
 
@@ -713,6 +835,7 @@ mod tests {
         let stat = "123 (worker ) name) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 987";
         let thread = ThreadInfo::from_stat(123, stat).unwrap();
         assert_eq!(thread.comm, "worker ) name");
+        assert_eq!(thread.state, 'S');
         assert_eq!(thread.starttime, 987);
         assert!(ThreadInfo::from_stat(124, stat).is_err());
     }
@@ -806,7 +929,10 @@ mod tests {
                 panic!("affinity test child exited before it was ready: {status}");
             }
             if let Ok(threads) = list_threads(pid) {
-                if threads.len() >= 3 {
+                let workers_ready = AFFINITY_TEST_WORKERS
+                    .iter()
+                    .all(|name| threads.iter().any(|thread| thread.comm == *name));
+                if workers_ready {
                     break threads;
                 }
             }
@@ -831,6 +957,25 @@ mod tests {
             .find(|&cpu| originals.iter().all(|(_, set)| set.is_set(cpu) == Ok(true)))
             .expect("child threads should share at least one allowed CPU");
 
+        let stopped = StoppedThreadGroup::stop(pid).unwrap();
+        assert!(list_threads(pid)
+            .unwrap()
+            .iter()
+            .all(ThreadInfo::is_stopped));
+        stopped.resume().unwrap();
+        wait_until_running(pid);
+
+        let error = bind_process(
+            pid,
+            CpuAffinityRequest {
+                vcpu: "0".to_string(),
+                core: cpu.to_string(),
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, CpuAffinityError::Operation(_)));
+        wait_until_running(pid);
+
         let outcome = bind_process(
             pid,
             CpuAffinityRequest {
@@ -840,6 +985,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(outcome.bound_thread_count as usize, originals.len());
+        wait_until_running(pid);
 
         let rollback = error_after_rollback(pid, process, "test rollback".to_string(), &originals);
         assert!(rollback.to_string().contains("rolled back"));
@@ -856,13 +1002,17 @@ mod tests {
     #[ignore = "helper process for wildcard_binding_and_rollback_work_on_disposable_process"]
     fn affinity_test_child() {
         let ready = Arc::new(Barrier::new(3));
-        let workers: Vec<_> = (0..2)
-            .map(|_| {
+        let workers: Vec<_> = AFFINITY_TEST_WORKERS
+            .into_iter()
+            .map(|name| {
                 let ready = Arc::clone(&ready);
-                std::thread::spawn(move || {
-                    ready.wait();
-                    std::thread::sleep(Duration::from_secs(30));
-                })
+                std::thread::Builder::new()
+                    .name(name.to_string())
+                    .spawn(move || {
+                        ready.wait();
+                        std::thread::sleep(Duration::from_secs(30));
+                    })
+                    .unwrap()
             })
             .collect();
         ready.wait();

--- a/src/sandbox/firecracker/instance.rs
+++ b/src/sandbox/firecracker/instance.rs
@@ -61,6 +61,21 @@ impl FirecrackerInstance {
         Ok(Pid::from_raw(raw_pid))
     }
 
+    /// Return the PID only if the owned Firecracker child has not exited.
+    pub fn running_pid(&mut self) -> Result<Pid> {
+        let child = self
+            .process
+            .as_mut()
+            .context("firecracker process is not running")?;
+        if let Some(status) = child
+            .try_wait()
+            .context("failed to check Firecracker process status")?
+        {
+            bail!("firecracker process exited with status {status}");
+        }
+        self.pid()
+    }
+
     pub async fn spawn_with_netns(
         &mut self,
         firecracker_binary: &Path,
@@ -683,6 +698,27 @@ mod tests {
 
         assert!(err.to_string().contains("already started"));
         instance.stop(Duration::from_millis(10)).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pid_rejects_an_exited_process() -> Result<()> {
+        let temp = tempdir()?;
+        let mut instance = FirecrackerInstance::new(temp.path().to_path_buf());
+        instance.process = Some(Command::new("/bin/true").spawn()?);
+
+        let error = time::timeout(Duration::from_secs(2), async {
+            loop {
+                match instance.running_pid() {
+                    Ok(_) => time::sleep(Duration::from_millis(10)).await,
+                    Err(error) => break error,
+                }
+            }
+        })
+        .await
+        .context("Firecracker test process did not exit")?;
+
+        assert!(error.to_string().contains("exited with status"));
         Ok(())
     }
 

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -479,6 +479,10 @@ impl SandboxBackend for FirecrackerSandbox {
         }
     }
 
+    fn runtime_process_id(&self) -> Result<i32> {
+        Ok(self.fc_instance.pid()?.as_raw())
+    }
+
     fn startup_artifacts(&self) -> RuntimeArtifactSet {
         let common = match &self.launch {
             LaunchMode::Fresh(config) => &config.common,

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -479,8 +479,8 @@ impl SandboxBackend for FirecrackerSandbox {
         }
     }
 
-    fn runtime_process_id(&self) -> Result<i32> {
-        Ok(self.fc_instance.pid()?.as_raw())
+    fn runtime_process_id(&mut self) -> Result<i32> {
+        Ok(self.fc_instance.running_pid()?.as_raw())
     }
 
     fn startup_artifacts(&self) -> RuntimeArtifactSet {

--- a/src/sandbox/mock.rs
+++ b/src/sandbox/mock.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{sync::Mutex, thread};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use tokio::time::sleep;
 
@@ -345,6 +345,10 @@ impl SandboxBackend for MockSandboxBackend {
 
     fn runtime_info(&self) -> SandboxRuntimeInfo {
         self.behavior.runtime_info()
+    }
+
+    fn runtime_process_id(&self) -> Result<i32> {
+        i32::try_from(std::process::id()).context("mock runtime pid does not fit in i32")
     }
 
     fn startup_artifacts(&self) -> RuntimeArtifactSet {

--- a/src/sandbox/mock.rs
+++ b/src/sandbox/mock.rs
@@ -72,6 +72,7 @@ pub struct MockBehavior {
     actions: Mutex<HashMap<MockOperation, VecDeque<MockAction>>>,
     on_operation: Mutex<HashMap<MockOperation, Arc<dyn Fn() + Send + Sync>>>,
     runtime_info: Mutex<SandboxRuntimeInfo>,
+    runtime_process_id: Mutex<Option<i32>>,
     source_config_paths: Mutex<Vec<std::path::PathBuf>>,
     stop_calls: AtomicUsize,
     update_network_calls: AtomicUsize,
@@ -106,6 +107,20 @@ impl MockBehavior {
             .lock()
             .expect("runtime_info mutex poisoned")
             .clone()
+    }
+
+    pub fn set_runtime_process_id(&self, pid: i32) {
+        *self
+            .runtime_process_id
+            .lock()
+            .expect("runtime_process_id mutex poisoned") = Some(pid);
+    }
+
+    fn runtime_process_id(&self) -> Option<i32> {
+        *self
+            .runtime_process_id
+            .lock()
+            .expect("runtime_process_id mutex poisoned")
     }
 
     pub fn set_source_config_paths(&self, paths: Vec<std::path::PathBuf>) {
@@ -347,8 +362,10 @@ impl SandboxBackend for MockSandboxBackend {
         self.behavior.runtime_info()
     }
 
-    fn runtime_process_id(&self) -> Result<i32> {
-        i32::try_from(std::process::id()).context("mock runtime pid does not fit in i32")
+    fn runtime_process_id(&mut self) -> Result<i32> {
+        self.behavior
+            .runtime_process_id()
+            .context("mock sandbox backend has no runtime process")
     }
 
     fn startup_artifacts(&self) -> RuntimeArtifactSet {

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,5 +1,6 @@
 mod access;
 mod backend;
+mod cpu_affinity;
 pub(crate) mod custom_extension;
 mod envd;
 mod extra_drive;
@@ -25,6 +26,8 @@ pub use backend::{
     SandboxBackendFactory, SandboxCaptureError, SandboxCaptureResult, SandboxExecutor,
     SandboxForkResult, SandboxForkSpec, SandboxRuntimeInfo,
 };
+pub(crate) use cpu_affinity::{bind_process as bind_process_cpu_affinity, CpuAffinityError};
+pub use cpu_affinity::{CpuAffinityOutcome, CpuAffinityRequest};
 pub use extra_drive::{
     normalize_mount_path, normalize_mount_path_for_drive, validate_drive_id, validate_mount_path,
     validate_sub_path, ExtraDrive,


### PR DESCRIPTION
<!-- Suggested PR title: feat(sandbox): bind running Firecracker threads to host CPUs -->

## What

Add runtime CPU-affinity control for running Firecracker sandboxes.

- Add the admin-only `POST /sandboxes/{sandboxID}/cpu-affinity` API.
- Add `aenv cpu-bind <sandbox-id> --vcpu <list|*> --core <list>`.
- Support CPU lists with ranges, duplicates, and optional strides such as
  `0-10:2`.
- Bind selected vCPU threads, or every current Firecracker thread with `*`, to
  online host logical CPUs.
- Verify every affinity update and roll back earlier updates when a later one
  fails.

## Why

Hardware architects use AgentENV sandboxes for processor benchmarking and
workload characterization. Runtime CPU affinity supports three main use cases:

1. **Topology-aware performance optimization.** Select logical CPUs according
   to LLC, NUMA, and SMT topology to improve long-running workload performance.
2. **Stable measurements.** Prevent vCPU threads from migrating across many
   host CPUs, reducing run-to-run noise in PMU counters, IPC, cache-miss rates,
   and latency measurements.
3. **Controlled oversubscription.** Place multiple vCPU threads on one logical
   CPU, or on SMT siblings of one physical core, to evaluate oversubscription
   behavior.

## Related issue

Closes #228

## Scope and non-goals

Included:

- Runtime affinity changes for running Firecracker sandboxes.
- Internal Firecracker PID resolution without exposing the PID through the
  public API.
- CLI/client, gateway routing, admin API, orchestrator, backend, tests, and
  user documentation.

Non-goals:

- Exclusive CPU reservation or automatic topology selection.
- Persisting affinity across pause/resume or runtime replacement.
- Querying current per-thread affinity; this can reuse the process and thread
  abstractions introduced here in a follow-up.
- Supporting host logical CPU IDs above 1023.

## Design and behavior changes

```text
aenv -> gateway -> admin API -> orchestrator -> Firecracker PID
                                               -> /proc thread scan
                                               -> sched_get/setaffinity
```

The orchestrator accepts only running sandboxes, locks the backend while the
blocking affinity operation runs, and keeps the operation cancellation-safe so
pause, snapshot, or delete cannot replace the Firecracker process midway.

The sandbox layer scans `/proc/<pid>/task`, identifies vCPU threads by their
`fc_vcpu N` names, and checks thread start times around numeric-TID syscalls to
narrow the TID-reuse window. Input length, expansion, value count, and CPU IDs
are bounded before allocation. Requested offline CPUs are ignored; an empty
online intersection is rejected before any affinity change.

Before applying changes, the implementation records every target's original
affinity. It then updates and reads back each thread one at a time. A failure or
kernel mismatch triggers best-effort rollback of all threads already changed.

## Compatibility and operations

- Public API or generated protocol: Adds one admin-only POST endpoint and its
  OpenAPI-generated server types. Existing endpoints are unchanged.
- Configuration or defaults: No new configuration. The endpoint is registered
  by default and protected by the deployment API key; there is no separate
  feature flag.
- Snapshot manifest, artifact layout, or storage format: N/A; affinity is live
  kernel state and is not persisted.
- Upgrade and rollback: No data migration is required. Rolling back removes the
  API, but an already-applied affinity remains until changed or the Firecracker
  process exits.
- Host requirements, permissions, ports, or dependencies: Linux `/proc` and
  permission to call `sched_setaffinity` on Firecracker threads. No new port or
  runtime dependency is introduced. Supported logical CPU IDs are 0-1023.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [x] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
make fmt
  passed

make clippy
  passed: workspace, all targets, all features, warnings denied

make test-unit
  passed

cargo test -p agentenv cpu_affinity --lib
  passed: 14 passed, 0 failed, 1 ignored helper process

AENV_UBLK_DAEMON_METRICS_LISTEN_ADDR="" make test-agent-integration
  passed: AgentENV integration suites and snapshot OSS tests
  snapshot OSS result: 4 passed, 0 failed

make -C services test
  passed: gateway and scheduler tests
```

Skipped checks and reasons:

- `make agentenv-server`: generated server changes and their OpenAPI source are
  committed, but final regeneration could not be rerun because Java is not
  installed in the validation environment.
- Benchmarks: not run; this adds an explicit administrative control path rather
  than changing a request-processing hot path.
- End-to-end tests: not run because they require a privileged KVM/ublk runtime
  environment.

## Risks and reviewer notes

- Incorrect placement can reduce performance for other workloads on the node;
  the endpoint is therefore admin-only.
- Affinity limits scheduler eligibility but does not reserve CPUs or provide
  exclusive access. All selected threads receive the same host CPU set.
- `*` selects threads present when the request is handled; it is not a policy
  for threads created later.
- Affinity is not restored after pause/resume, because resume creates a new
  Firecracker process.
- Numeric PID/TID syscalls cannot eliminate reuse races completely. Start-time
  checks before and after affinity reads narrow that window.
- Rollback is best-effort and reports any thread that could not be restored.

Suggested review order:

1. `src/sandbox/cpu_affinity.rs` for parsing, thread selection, verification,
   and rollback.
2. `src/orchestrator/service.rs` for lifecycle locking and PID handling.
3. `src/api/openapi.yml` and `src/api/impls/admin.rs` for the admin API.
4. `services/gateway/internal/server.go` and the `aenv` client/command for
   routing and user-facing behavior.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
