### PR TITLE
fix(sandbox): pass seal output to persistent volume restack

### DIFF
--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -2333,6 +2333,8 @@ impl FirecrackerSandbox {
                 output_dir,
                 &snapshot_layer_file_name,
                 "volume",
+                // Persistent volume seals always stay raw.
+                OverlaybdCompactOutput::Raw,
             )
             .await
             .with_context(|| format!("snapshot persistent volume '{}'", drive.drive_id()))?;


### PR DESCRIPTION
## What

Adds the missing `seal_output` argument (`OverlaybdCompactOutput::Raw`) to the persistent-volume `restack_snapshot_overlaybd_device` call site, fixing the build on `main`.

## Why

Two recently merged PRs conflict semantically: the template-build compression switch added a `seal_output` parameter to `restack_snapshot_overlaybd_device`, while the volumes feature added a new call site that doesn't pass it — so `main` fails to compile (`E0061`, clippy and unit-tests jobs red).

## Related issue

N/A — build fix for the main CI failure.

## Scope and non-goals

One-argument call-site fix. Persistent volume seals always stay raw, same as attached drives; no behavior change.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`

```text
cargo clippy -p agentenv --all-targets -- -D warnings   # clean
cargo test -p agentenv --lib overlaybd_snapshot         # 12/12 pass
```

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
