### PR TITLE
feat(cli): enable secure sandboxes by default

### DIFF
--- a/crates/aenv/src/client/sandboxes.rs
+++ b/crates/aenv/src/client/sandboxes.rs
@@ -11,8 +11,7 @@ pub struct NewSandbox<'a> {
     pub template_id: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub secure: Option<bool>,
+    pub secure: bool,
     #[serde(skip_serializing_if = "Option::is_none", rename = "volumeMounts")]
     pub volume_mounts: Option<HashMap<String, String>>,
 }
@@ -28,8 +27,7 @@ pub struct NewColdSandbox<'a> {
     pub memory_mb: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "diskSizeMB")]
     pub disk_size_mb: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub secure: Option<bool>,
+    pub secure: bool,
     #[serde(skip_serializing_if = "Option::is_none", rename = "volumeMounts")]
     pub volume_mounts: Option<HashMap<String, String>>,
 }
@@ -82,13 +80,12 @@ impl Client {
         &self,
         template_id: &str,
         timeout: Option<u32>,
-        secure: bool,
         volume_mounts: Option<HashMap<String, String>>,
     ) -> Result<Sandbox> {
         let body = NewSandbox {
             template_id,
             timeout,
-            secure: secure.then_some(true),
+            secure: true,
             volume_mounts,
         };
         let resp = handle_status(self.post("/sandboxes").send_json(&body))?;
@@ -104,7 +101,6 @@ impl Client {
         cpu_count: Option<u32>,
         memory_mb: Option<u32>,
         disk_size_mb: Option<u32>,
-        secure: bool,
         volume_mounts: Option<HashMap<String, String>>,
     ) -> Result<Sandbox> {
         let body = NewColdSandbox {
@@ -113,7 +109,7 @@ impl Client {
             cpu_count,
             memory_mb,
             disk_size_mb,
-            secure: secure.then_some(true),
+            secure: true,
             volume_mounts,
         };
         let resp = handle_status(self.post("/sandboxes-cold").send_json(&body))?;
@@ -195,7 +191,7 @@ mod tests {
         let body = NewSandbox {
             template_id: "base-template",
             timeout: Some(300),
-            secure: Some(true),
+            secure: true,
             volume_mounts: None,
         };
 
@@ -215,7 +211,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mb: Some(1024),
             disk_size_mb: Some(8192),
-            secure: Some(true),
+            secure: true,
             volume_mounts: None,
         };
 

--- a/crates/aenv/src/commands/start.rs
+++ b/crates/aenv/src/commands/start.rs
@@ -22,9 +22,6 @@ pub struct Args {
     /// Start directly from an external OCI image instead of a template/snapshot
     #[arg(long)]
     cold: bool,
-    /// Require an envd access token for sandbox control communication
-    #[arg(long)]
-    secure: bool,
     /// Sandbox TTL in seconds
     #[arg(long, default_value_t = super::DEFAULT_TIMEOUT_SECS)]
     timeout: u32,
@@ -61,14 +58,13 @@ pub fn run(args: Args) -> Result<()> {
             args.resources.cpu_count,
             args.resources.memory_mb,
             args.disk_size_mb,
-            args.secure,
             volume_mounts,
         )?
     } else {
         if args.resources.is_set() || args.disk_size_mb.is_some() {
             anyhow::bail!("--cpu-count, --memory-mb, and --disk-size-mb require --cold");
         }
-        client.create_sandbox(&args.target, Some(args.timeout), args.secure, volume_mounts)?
+        client.create_sandbox(&args.target, Some(args.timeout), volume_mounts)?
     };
     let sandbox_id = sandbox.sandbox_id;
 
@@ -189,7 +185,20 @@ async fn wait_for_envd(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_volume_mounts;
+    use super::{parse_volume_mounts, Args};
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: Args,
+    }
+
+    #[test]
+    fn secure_flag_is_not_accepted() {
+        assert!(TestCli::try_parse_from(["test", "my-template"]).is_ok());
+        assert!(TestCli::try_parse_from(["test", "--secure", "my-template"]).is_err());
+    }
 
     #[test]
     fn parses_volume_mounts() {

--- a/docs/src/concepts/authentication.md
+++ b/docs/src/concepts/authentication.md
@@ -165,10 +165,11 @@ curl http://127.0.0.1:8000/proxy/health \
   -H "X-Access-Token: $ENVD_ACCESS_TOKEN"
 ```
 
-The `aenv` CLI handles this automatically. Use `--secure` when starting a sandbox:
+The `aenv` CLI always requests secure sandbox authentication and handles the
+envd access token automatically:
 
 ```bash
-aenv start --secure <template-or-snapshot>
+aenv start <template-or-snapshot>
 ```
 
 For `connect`, `exec`, `upload`, and

--- a/docs/src/concepts/sandboxes.md
+++ b/docs/src/concepts/sandboxes.md
@@ -65,13 +65,14 @@ Warm-start options:
 | Argument or option | Default | Description |
 |---|---|---|
 | `<template-or-snapshot>` | Required | Template or snapshot ID or alias. |
-| `--secure` | Off | Require an envd access token for command and file operations. The CLI manages the token automatically; see [Authentication](./authentication.md#secure-sandbox-authentication). |
 | `--timeout <seconds>` | `300` | Set the sandbox TTL. The sandbox auto-pauses when it reaches the TTL; see [Auto-Eviction](#auto-eviction). |
 | `-d`, `--detach` | Off | Print the sandbox ID and exit instead of attaching an interactive shell. |
 
 Without `--detach`, `aenv start` waits for the sandbox to become ready and then
 attaches an interactive shell. CPU, memory, and disk settings are inherited
-from the template or snapshot and cannot be overridden on a warm start.
+from the template or snapshot and cannot be overridden on a warm start. The CLI
+always enables secure sandbox authentication and manages the envd access token
+automatically; see [Authentication](./authentication.md#secure-sandbox-authentication).
 
 To retrieve the current state and configuration of one sandbox, use the HTTP
 API:
@@ -105,12 +106,13 @@ Cold-start options:
 |---|---|---|
 | `<image>` | Required | External OCI image reference. |
 | `--cold` | Required for an OCI image | Cold start directly from `<image>`. |
-| `--secure` | Off | Require an envd access token for command and file operations. The CLI manages the token automatically; see [Authentication](./authentication.md#secure-sandbox-authentication). |
 | `--timeout <seconds>` | `300` | Set the sandbox TTL. The sandbox auto-pauses when it reaches the TTL; see [Auto-Eviction](#auto-eviction). |
 | `--cpu <count>` | `[machine].vcpu_count` from your AgentENV config file | Set the sandbox's vCPU count. Alias: `--cpu-count`. |
 | `--memory <MiB>` | `[machine].mem_size_mib` from your config file | Set sandbox memory. Aliases: `--memory-mb`, `--mem`. |
 | `--disk-size-mb <MiB>` | Source image virtual size | Set root filesystem size. The value must be greater than zero and divisible by 1024 MiB. Alias: `--disk-mb`. |
 | `-d`, `--detach` | Off | Print the sandbox ID and exit instead of attaching an interactive shell. |
+
+Cold-started sandboxes also use secure sandbox authentication by default.
 
 The AgentENV config file is `config/default.toml` by default, or the file
 specified by `AENV_CONFIG_PATH`.

--- a/docs/src/concepts/snapshots.md
+++ b/docs/src/concepts/snapshots.md
@@ -148,9 +148,11 @@ aenv start <snapshot-id-or-name>
 | Argument or option | Default | Description |
 | --- | --- | --- |
 | `<snapshot-id-or-name>` | Required | Snapshot ID or alias to start from. |
-| `--secure` | Disabled | Requires an envd access token for sandbox control communication. |
 | `--timeout <seconds>` | `300` | Sets the sandbox TTL; see [Auto-Eviction](sandboxes.md#auto-eviction). |
 | `-d`, `--detach` | Disabled | Prints the new sandbox ID without attaching an interactive shell. |
+
+The CLI always enables secure sandbox authentication and manages the envd
+access token automatically.
 
 ### Delete a Snapshot
 

--- a/docs/src/getting-started/aenv-cli.md
+++ b/docs/src/getting-started/aenv-cli.md
@@ -115,14 +115,15 @@ or snapshot ID or alias, or an OCI image reference with `--cold`.
 
 ```bash
 aenv start my-ubuntu
-aenv start --secure my-ubuntu               # require token-authenticated envd access
 aenv start --cold ubuntu:24.04              # start directly from an OCI image
 ```
+
+Sandboxes started by `aenv` always require token-authenticated envd access. The
+CLI obtains and manages the access token automatically.
 
 | Flag | Description |
 |------|-------------|
 | `--cold` | Start directly from an external OCI image instead of a template |
-| `--secure` | Require token authentication for envd control communication |
 | `--timeout <secs>` | Sandbox TTL in seconds (default: 300) |
 | `--cpu <count>` | CPU cores; only valid with `--cold`. Defaults to `[machine].vcpu_count` on the server. Alias: `--cpu-count`. |
 | `--memory <MiB>` | Memory in MiB; only valid with `--cold`. Defaults to `[machine].mem_size_mib` on the server. Aliases: `--memory-mb`, `--mem`. |


### PR DESCRIPTION
## Summary

- make warm and cold `aenv start` requests always enable secure sandbox authentication
- remove the redundant `--secure` option and reject it during argument parsing
- update CLI and concept documentation to describe automatic envd access-token management

## Compatibility

Existing scripts that pass `aenv start --secure` must remove the flag. The AgentENV HTTP API remains unchanged and continues to support explicit secure-mode selection for non-CLI clients.

## Testing

- `cargo fmt --package aenv -- --check`
- `cargo test -p aenv`
- `cargo clippy -p aenv --all-targets -- -D warnings`
- inspected `aenv start --help` to confirm `--secure` is absent