### PR TITLE
chore(release): bump version to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aenv"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "agentenv"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "agentenv-observability",
  "agentenv_http_server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
## What

- Bump the shared workspace package version from `0.1.3` to `0.2.0`.
- Update the `aenv` and `agentenv` package entries in `Cargo.lock`.

## Why

Prepare the workspace for the `v0.2.0` release.

## Related issue

N/A. This is release maintenance.

## Scope and non-goals

This PR changes release metadata only. It does not alter runtime behavior, APIs, dependencies, documentation, or generated code.

## Design and behavior changes

N/A. Package behavior is unchanged.

## Compatibility and operations

- Public API or generated protocol: N/A; no API or protocol changes.
- Configuration or defaults: N/A; no configuration changes.
- Snapshot manifest, artifact layout, or storage format: N/A; no format changes.
- Upgrade and rollback: N/A; metadata-only release preparation.
- Host requirements, permissions, ports, or dependencies: N/A; no operational changes.

After merge, pushing the `v0.2.0` tag will trigger the release workflow.

## Validation

- [x] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
make fmt
# passed

cargo metadata --locked --format-version 1 --no-deps
# passed; agentenv and aenv resolve as 0.2.0

cargo check -p agentenv -p aenv --all-targets --locked
# passed
```

Skipped checks and reasons:

The broader lint, test, integration, generation, documentation, and benchmark checks were not run because this PR changes package version metadata only.

## Risks and reviewer notes

Low risk. Confirm this PR is merged before creating the `v0.2.0` tag.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.