### PR TITLE
fix(docs): correct overview navigation

### DIFF
--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>AgentENV Documentation</title>
+  <meta http-equiv="refresh" content="0; url=./getting-started/overview.html">
+  <link rel="canonical" href="./getting-started/overview.html">
+  <script>
+    window.location.replace(
+      "./getting-started/overview.html" + window.location.search + window.location.hash
+    );
+  </script>
+</head>
+<body>
+  <p>
+    Redirecting to the
+    <a href="./getting-started/overview.html">AgentENV overview</a>&hellip;
+  </p>
+</body>
+</html>

--- a/docs/src/stoplight-elements.html
+++ b/docs/src/stoplight-elements.html
@@ -66,6 +66,7 @@
       ['sandboxes', 'Sandboxes'],
       ['templates', 'Templates'],
       ['snapshots', 'Snapshots'],
+      ['volumes', 'Volumes'],
       ['admin', 'Admin'],
     ]);
     const tagByName = new Map((spec.tags || []).map(tag => [tag.name, tag]));


### PR DESCRIPTION
## Summary

- replace mdBook's broken root-level first-chapter alias with a relative redirect to the canonical getting-started overview
- preserve query strings and fragments when redirecting from a version root
- display the `volumes` OpenAPI tag as `Volumes` in the Stoplight API reference

## Testing

- `make docs`
- verified the emitted `book/index.html` matches the redirect source
- verified the overview and its linked documentation pages exist in the built book
- parsed the inline Stoplight adapter script after adding the display-name substitution
