### PR TITLE
template: report failed build steps by number, not instruction text

### DIFF
--- a/src/api/impls/template_helpers.rs
+++ b/src/api/impls/template_helpers.rs
@@ -72,8 +72,10 @@ pub(super) fn template_build_spec_from_start_request(
         spec = spec.ready_cmd(ready_cmd.clone());
     }
 
-    for step in body.steps.as_deref().unwrap_or_default() {
+    for (index, step) in body.steps.as_deref().unwrap_or_default().iter().enumerate() {
+        let appended_from = spec.step_count();
         spec = apply_e2b_template_step(spec, step)?;
+        spec = spec.stamp_source_steps(appended_from, index + 1);
     }
 
     Ok(spec)
@@ -223,8 +225,43 @@ fn apply_e2b_template_step(
 
 #[cfg(test)]
 mod tests {
-    use super::{template_build_start_base_source, TemplateBuildStartBaseSource};
+    use super::{
+        template_build_spec_from_start_request, template_build_start_base_source,
+        TemplateBuildStartBaseSource,
+    };
+    use crate::types::SandboxResources;
     use agentenv_http_server::models;
+
+    #[test]
+    fn expanded_env_pairs_share_their_client_step_number() {
+        let mut body = models::TemplateBuildStartV2::new();
+        body.steps = Some(vec![
+            models::TemplateStep {
+                r_type: "ENV".to_string(),
+                args: Some(vec![
+                    "A".to_string(),
+                    "1".to_string(),
+                    "B".to_string(),
+                    "2".to_string(),
+                ]),
+                files_hash: None,
+                force: None,
+            },
+            models::TemplateStep {
+                r_type: "RUN".to_string(),
+                args: Some(vec!["false".to_string()]),
+                files_hash: None,
+                force: None,
+            },
+        ]);
+        let spec = template_build_spec_from_start_request(&body, None, SandboxResources::default())
+            .expect("spec should parse");
+        let sources: Vec<Option<usize>> =
+            spec.steps().iter().map(|step| step.source_step).collect();
+        // One ENV request with two pairs expands to two internal steps; both
+        // must report as client step 1, and the RUN as client step 2.
+        assert_eq!(sources, vec![Some(1), Some(1), Some(2)]);
+    }
 
     #[test]
     fn start_base_source_defaults_when_not_specified() {

--- a/src/template/build_spec.rs
+++ b/src/template/build_spec.rs
@@ -21,6 +21,12 @@ pub(crate) enum TemplateBuildRootfsBase {
 #[derive(Clone, Debug)]
 pub(crate) struct TemplateBuildStep {
     pub(crate) kind: TemplateBuildStepKind,
+    /// 1-based position of the client-visible step this came from. The e2b
+    /// front-end expands one request step (a multi-pair ENV/LABEL) into
+    /// several internal steps, so failed-step reporting must not count
+    /// internal positions. None: the step maps 1:1 to its position, which
+    /// holds for every other front-end.
+    pub(crate) source_step: Option<usize>,
 }
 
 #[derive(Clone, Debug)]
@@ -37,12 +43,14 @@ pub(crate) enum TemplateBuildStepKind {
 impl TemplateBuildStep {
     pub(crate) fn run(cmd: impl Into<String>) -> Self {
         Self {
+            source_step: None,
             kind: TemplateBuildStepKind::Run { cmd: cmd.into() },
         }
     }
 
     pub(crate) fn env(key: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
+            source_step: None,
             kind: TemplateBuildStepKind::Env {
                 key: key.into(),
                 value: value.into(),
@@ -52,12 +60,14 @@ impl TemplateBuildStep {
 
     pub(crate) fn workdir(path: impl Into<PathBuf>) -> Self {
         Self {
+            source_step: None,
             kind: TemplateBuildStepKind::Workdir { path: path.into() },
         }
     }
 
     pub(crate) fn user(value: impl Into<String>) -> Self {
         Self {
+            source_step: None,
             kind: TemplateBuildStepKind::User {
                 value: value.into(),
             },
@@ -66,18 +76,21 @@ impl TemplateBuildStep {
 
     pub(crate) fn exposed_port(port: impl Into<String>) -> Self {
         Self {
+            source_step: None,
             kind: TemplateBuildStepKind::ExposedPort { port: port.into() },
         }
     }
 
     pub(crate) fn volume(path: impl Into<String>) -> Self {
         Self {
+            source_step: None,
             kind: TemplateBuildStepKind::Volume { path: path.into() },
         }
     }
 
     pub(crate) fn label(key: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
+            source_step: None,
             kind: TemplateBuildStepKind::Label {
                 key: key.into(),
                 value: value.into(),
@@ -232,6 +245,19 @@ impl TemplateBuildSpec {
 
     pub(crate) fn rootfs_base_ref(&self) -> Option<&TemplateBuildRootfsBase> {
         self.rootfs_base.as_ref()
+    }
+
+    pub(crate) fn step_count(&self) -> usize {
+        self.steps.len()
+    }
+
+    /// Stamps the steps appended since `from` with the client step number
+    /// they came from — see `TemplateBuildStep::source_step`.
+    pub(crate) fn stamp_source_steps(mut self, from: usize, source_step: usize) -> Self {
+        for step in &mut self.steps[from..] {
+            step.source_step = Some(source_step);
+        }
+        self
     }
 
     pub(crate) fn steps(&self) -> &[TemplateBuildStep] {

--- a/src/template/step_executor.rs
+++ b/src/template/step_executor.rs
@@ -34,9 +34,12 @@ impl TemplateStepExecutor {
         // into their locally recorded stack traces ("base" / "finalize" /
         // int(step)), and anything non-numeric crashes the Python SDK's error
         // path before it can raise the real build error. The instruction text
-        // belongs in the message.
+        // belongs in the message. The number must be the client-visible one:
+        // source_step carries it when a front-end expanded one request step
+        // into several internal steps, and the positional fallback covers the
+        // front-ends that map 1:1.
         for (index, step) in steps.iter().enumerate() {
-            let step_no = index + 1;
+            let step_no = step.source_step.unwrap_or(index + 1);
             match &step.kind {
                 TemplateBuildStepKind::Env { key, value } => {
                     context = context.with_env_var(key.clone(), value.clone());
@@ -464,5 +467,28 @@ mod tests {
         assert_eq!(failure.reason.step.as_deref(), Some("2"));
         assert!(failure.reason.message.contains("RUN false"));
         assert!(failure.reason.message.contains("status 1"));
+    }
+
+    #[tokio::test]
+    async fn run_step_failure_reports_the_source_step_over_its_position() {
+        let sandbox = RecordingSandbox::failing();
+        // One client ENV step with two pairs arrives as two internal steps;
+        // the failing RUN sits at internal position 3 but is client step 2.
+        let mut steps = vec![
+            TemplateBuildStep::env("A", "1"),
+            TemplateBuildStep::env("B", "2"),
+            TemplateBuildStep::run("false"),
+        ];
+        steps[0].source_step = Some(1);
+        steps[1].source_step = Some(1);
+        steps[2].source_step = Some(2);
+        let error = TemplateStepExecutor::new()
+            .execute(&sandbox, &steps, CommandContext::default())
+            .await
+            .expect_err("a non-zero exit should fail the build");
+        let failure = error
+            .downcast_ref::<TemplateBuildFailure>()
+            .expect("the error should be a TemplateBuildFailure");
+        assert_eq!(failure.reason.step.as_deref(), Some("2"));
     }
 }

--- a/src/template/step_executor.rs
+++ b/src/template/step_executor.rs
@@ -29,14 +29,21 @@ impl TemplateStepExecutor {
         let mut context = initial_context;
 
         debug!("executing template build steps");
-        for step in steps {
+        // On failure, reason.step must carry the 1-based step number, the way
+        // e2b Cloud reports it: the official SDKs parse the field as an index
+        // into their locally recorded stack traces ("base" / "finalize" /
+        // int(step)), and anything non-numeric crashes the Python SDK's error
+        // path before it can raise the real build error. The instruction text
+        // belongs in the message.
+        for (index, step) in steps.iter().enumerate() {
+            let step_no = index + 1;
             match &step.kind {
                 TemplateBuildStepKind::Env { key, value } => {
                     context = context.with_env_var(key.clone(), value.clone());
                 }
                 TemplateBuildStepKind::Workdir { path } => {
                     let resolved = resolve_workdir(&context.workdir, &path.to_string_lossy());
-                    self.ensure_workdir(sandbox, &resolved).await?;
+                    self.ensure_workdir(sandbox, &resolved, step_no).await?;
                     context = context.with_workdir(resolved);
                 }
                 TemplateBuildStepKind::User { value } => {
@@ -62,7 +69,7 @@ impl TemplateStepExecutor {
                     context = context.with_labels(labels);
                 }
                 TemplateBuildStepKind::Run { cmd } => {
-                    self.run_step(sandbox, &context.workdir, &context.env_vars, cmd)
+                    self.run_step(sandbox, &context.workdir, &context.env_vars, cmd, step_no)
                         .await?;
                 }
             }
@@ -80,9 +87,17 @@ impl TemplateStepExecutor {
     /// `mkdir`: minimal images (scratch, distroless, Nix-style) may ship no
     /// userland at all, and Docker itself creates WORKDIR without consulting
     /// the image.
-    async fn ensure_workdir(&self, sandbox: &impl SandboxExecutor, path: &str) -> Result<()> {
+    async fn ensure_workdir(
+        &self,
+        sandbox: &impl SandboxExecutor,
+        path: &str,
+        step_no: usize,
+    ) -> Result<()> {
         sandbox.create_dir_all(path).await.with_context(|| {
-            TemplateBuildFailure::with_step("build step failed", format!("WORKDIR {path}"))
+            TemplateBuildFailure::with_step(
+                format!("build step failed: WORKDIR {path}"),
+                step_no.to_string(),
+            )
         })
     }
 
@@ -92,6 +107,7 @@ impl TemplateStepExecutor {
         workdir: &str,
         env: &HashMap<String, String>,
         cmd: &str,
+        step_no: usize,
     ) -> Result<()> {
         let opts = ProcessOpts {
             envs: env.clone(),
@@ -103,15 +119,18 @@ impl TemplateStepExecutor {
             .run_command_with_opts("/bin/bash", &["-lc", cmd], &opts)
             .await
             .with_context(|| {
-                TemplateBuildFailure::with_step("build step failed", format!("RUN {cmd}"))
+                TemplateBuildFailure::with_step(
+                    format!("build step failed: RUN {cmd}"),
+                    step_no.to_string(),
+                )
             })?;
         if output.exit_code != 0 {
             let message = format!(
-                "build step failed: command exited with status {}{}",
+                "build step failed: RUN {cmd}: command exited with status {}{}",
                 output.exit_code,
                 command_output_suffix(&output.stdout, &output.stderr)
             );
-            return Err(TemplateBuildFailure::with_step(message, format!("RUN {cmd}")).into());
+            return Err(TemplateBuildFailure::with_step(message, step_no.to_string()).into());
         }
         Ok(())
     }
@@ -419,6 +438,31 @@ mod tests {
         let failure = error
             .downcast_ref::<TemplateBuildFailure>()
             .expect("the error should be a TemplateBuildFailure");
-        assert_eq!(failure.reason.step.as_deref(), Some("WORKDIR /app"));
+        // The e2b SDKs parse reason.step as a number; the instruction text is
+        // in the message.
+        assert_eq!(failure.reason.step.as_deref(), Some("1"));
+        assert!(failure.reason.message.contains("WORKDIR /app"));
+    }
+
+    #[tokio::test]
+    async fn run_step_failure_reports_its_one_based_position() {
+        let sandbox = RecordingSandbox::failing();
+        let error = TemplateStepExecutor::new()
+            .execute(
+                &sandbox,
+                &[
+                    TemplateBuildStep::env("A", "1"),
+                    TemplateBuildStep::run("false"),
+                ],
+                CommandContext::default(),
+            )
+            .await
+            .expect_err("a non-zero exit should fail the build");
+        let failure = error
+            .downcast_ref::<TemplateBuildFailure>()
+            .expect("the error should be a TemplateBuildFailure");
+        assert_eq!(failure.reason.step.as_deref(), Some("2"));
+        assert!(failure.reason.message.contains("RUN false"));
+        assert!(failure.reason.message.contains("status 1"));
     }
 }


### PR DESCRIPTION
## What happens today

When a template build step fails, AgentENV fills `BuildStatusReason.step` with the instruction text (`"RUN apt-get update && …"`, `src/template/step_executor.rs`). The official e2b Python SDK resolves that field as an index into its locally recorded stack traces — `get_build_step_index` maps `"base"` → 0, `"finalize"` → last, and otherwise calls `int(step)` with no fallback (`packages/python-sdk/e2b/template/utils.py`). So any failed build crashes the SDK's error path:

```
ValueError: invalid literal for int() with base 10: 'RUN apt-get update && …'
```

…and the real build error (already carried in `message`) is never raised. The JS SDK doesn't crash but silently loses the traceback (`Number(step)` → `NaN`).

## The contract

The OpenAPI spec leaves `step` an unconstrained string ("Step that failed"), but e2b Cloud fills it with the **1-based step number** (`e2b-dev/infra`, `packages/orchestrator/pkg/template/build/phases/utils.go`: `strconv.Itoa(*StepNumber)`, numbered from 1 in `phases/steps/factory.go`), with `"base"`/`"finalize"` for those phases — and both official SDKs hard-code exactly that mapping. De-facto, numeric-or-sentinel is the contract.

## Change

- `reason.step` now carries the 1-based step number as a string.
- The instruction text moves into `message`, next to the exit status and stderr it already reports:
  ```
  message: "build step failed: RUN apt-get update …: command exited with status 100; stderr: …"
  step:    "3"
  ```
- Failures outside the step executor (base image, pipeline) keep `step: None`, which both SDKs skip safely.
- Existing test updated; new test pins the 1-based position of a failing RUN.
