### PR TITLE
feat: add funded execution policy and independent process watchdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,16 @@ on:
       - ".github/workflows/ci.yml"
 
 jobs:
+  runtime-policy:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/rust-ci-setup
+        with:
+          install_ci_deps: "false"
+      - name: Funded lease, reservation and independent watchdog contracts
+        run: cargo test --locked -p runtime-policy
+
   fmt:
     runs-on: ubuntu-22.04
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6527,6 +6527,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "runtime-policy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/benchmarks",
     "crates/e2e-tests",
     "crates/linux-cap",
+    "crates/runtime-policy",
     "crates/observability",
     "crates/object-store-operator",
     "crates/test-support",

--- a/crates/runtime-policy/Cargo.toml
+++ b/crates/runtime-policy/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "runtime-policy"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+libc = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+uuid = { version = "1", features = ["serde", "v7"] }
+
+
+[[bin]]
+name = "runtime-policy-probe"
+path = "tests/support/probe.rs"

--- a/crates/runtime-policy/src/lease.rs
+++ b/crates/runtime-policy/src/lease.rs
@@ -1,0 +1,179 @@
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+/// One funded authorization for an exact physical activation. A sequence is
+/// monotonic within that activation; an equal sequence is an identical replay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ExecutionLease {
+    pub activation_id: Uuid,
+    pub operation_id: Uuid,
+    pub sequence: u64,
+    pub expires_at_unix_ms: u64,
+}
+
+pub fn unix_millis(now: SystemTime) -> Result<u64> {
+    Ok(u64::try_from(now.duration_since(UNIX_EPOCH)?.as_millis())?)
+}
+
+impl ExecutionLease {
+    pub fn remaining(&self, now: SystemTime) -> Result<Duration> {
+        let remaining = self.expires_at_unix_ms.saturating_sub(unix_millis(now)?);
+        if remaining == 0 || self.activation_id.is_nil() || self.operation_id.is_nil() {
+            bail!("execution lease is expired or has no identity");
+        }
+        Ok(Duration::from_millis(remaining))
+    }
+}
+
+/// Wall-clock rollback cannot buy runtime: every accepted absolute deadline
+/// also has a monotonic cutoff fixed when that authorization was accepted.
+pub struct LeaseState {
+    lease: ExecutionLease,
+    monotonic_deadline: Instant,
+}
+
+impl LeaseState {
+    pub fn new(lease: ExecutionLease, wall: SystemTime, mono: Instant) -> Result<Self> {
+        let monotonic_deadline = mono
+            .checked_add(lease.remaining(wall)?)
+            .ok_or_else(|| anyhow::anyhow!("execution deadline overflows monotonic time"))?;
+        Ok(Self {
+            lease,
+            monotonic_deadline,
+        })
+    }
+
+    pub fn lease(&self) -> ExecutionLease {
+        self.lease
+    }
+
+    pub fn expired(&self, wall: SystemTime, mono: Instant) -> bool {
+        mono >= self.monotonic_deadline || self.lease.remaining(wall).is_err()
+    }
+
+    pub fn renew(&mut self, lease: ExecutionLease, wall: SystemTime, mono: Instant) -> Result<()> {
+        if self.expired(wall, mono) {
+            bail!("expired execution cannot be renewed");
+        }
+        if lease.activation_id != self.lease.activation_id || lease.sequence < self.lease.sequence {
+            bail!("execution lease lost its activation fence");
+        }
+        if lease.sequence == self.lease.sequence {
+            if lease != self.lease {
+                bail!("execution lease replay changed its payload");
+            }
+            return Ok(());
+        }
+        let mut next = Self::new(lease, wall, mono)?;
+        // A later sequence may add only the newly funded absolute time.
+        // Recomputing solely from a rolled-back wall clock would extend it.
+        let previous = self.lease.expires_at_unix_ms;
+        let bounded = if lease.expires_at_unix_ms >= previous {
+            self.monotonic_deadline
+                .checked_add(Duration::from_millis(lease.expires_at_unix_ms - previous))
+        } else {
+            self.monotonic_deadline
+                .checked_sub(Duration::from_millis(previous - lease.expires_at_unix_ms))
+        }
+        .ok_or_else(|| anyhow::anyhow!("renewal deadline overflows monotonic time"))?;
+        next.monotonic_deadline = next.monotonic_deadline.min(bounded);
+        *self = next;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn lease() -> ExecutionLease {
+        ExecutionLease {
+            activation_id: Uuid::now_v7(),
+            operation_id: Uuid::now_v7(),
+            sequence: 0,
+            expires_at_unix_ms: 10_000,
+        }
+    }
+    #[test]
+    fn delayed_expired_and_mutated_replays_never_extend_execution() {
+        let first = lease();
+        let mono = Instant::now();
+        let mut state = LeaseState::new(first, UNIX_EPOCH + Duration::from_secs(5), mono).unwrap();
+        state
+            .renew(
+                first,
+                UNIX_EPOCH + Duration::from_secs(8),
+                mono + Duration::from_secs(3),
+            )
+            .unwrap();
+        assert!(state.expired(UNIX_EPOCH, mono + Duration::from_secs(5)));
+        assert!(state
+            .renew(
+                ExecutionLease {
+                    expires_at_unix_ms: 20_000,
+                    ..first
+                },
+                UNIX_EPOCH + Duration::from_secs(9),
+                mono
+            )
+            .is_err());
+        assert!(state
+            .renew(
+                ExecutionLease {
+                    sequence: 1,
+                    expires_at_unix_ms: 20_000,
+                    ..first
+                },
+                UNIX_EPOCH + Duration::from_secs(10),
+                mono
+            )
+            .is_err());
+    }
+    #[test]
+    fn renewal_is_bound_to_one_activation_and_a_monotonic_sequence() {
+        let first = lease();
+        let mono = Instant::now();
+        let wall = UNIX_EPOCH + Duration::from_secs(5);
+        let mut state = LeaseState::new(first, wall, mono).unwrap();
+        assert!(state
+            .renew(
+                ExecutionLease {
+                    activation_id: Uuid::now_v7(),
+                    sequence: 1,
+                    ..first
+                },
+                wall,
+                mono
+            )
+            .is_err());
+        let next = ExecutionLease {
+            sequence: 1,
+            expires_at_unix_ms: 12_000,
+            ..first
+        };
+        state.renew(next, wall, mono).unwrap();
+        assert!(state.renew(first, wall, mono).is_err());
+        assert_eq!(state.lease(), next);
+    }
+    #[test]
+    fn a_new_sequence_cannot_rebase_a_rolled_back_clock() {
+        let first = lease();
+        let mono = Instant::now();
+        let mut state = LeaseState::new(first, UNIX_EPOCH + Duration::from_secs(5), mono).unwrap();
+        state
+            .renew(
+                ExecutionLease {
+                    sequence: 1,
+                    expires_at_unix_ms: 12_000,
+                    ..first
+                },
+                UNIX_EPOCH,
+                mono + Duration::from_secs(2),
+            )
+            .unwrap();
+        assert!(!state.expired(UNIX_EPOCH, mono + Duration::from_secs(6)));
+        assert!(state.expired(UNIX_EPOCH, mono + Duration::from_secs(7)));
+    }
+}

--- a/crates/runtime-policy/src/lib.rs
+++ b/crates/runtime-policy/src/lib.rs
@@ -1,0 +1,132 @@
+//! Shared execution authorization and node admission arithmetic.
+//! Scheduling reports are hints; this policy is enforced at the target node.
+
+mod lease;
+pub mod watchdog;
+
+pub use lease::{unix_millis, ExecutionLease, LeaseState};
+
+use anyhow::{bail, Result};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Reservation {
+    pub memory_bytes: u64,
+    pub maximum_memory_bytes: u64,
+    pub disk_bytes: u64,
+    pub starting: bool,
+}
+
+/// All operations run under the node owner's mutex. Kernel limit writes must
+/// succeed before releasing a reservation or transferring its memory budget.
+#[derive(Debug)]
+pub struct Budget {
+    pub memory_bytes: u64,
+    pub starting_limit: usize,
+    pub reservations: HashMap<Uuid, Reservation>,
+}
+
+impl Budget {
+    pub fn new(memory_bytes: u64, starting_limit: usize) -> Result<Self> {
+        if memory_bytes == 0 || starting_limit == 0 {
+            bail!("node admission needs positive memory and startup capacity");
+        }
+        Ok(Self {
+            memory_bytes,
+            starting_limit,
+            reservations: HashMap::new(),
+        })
+    }
+
+    pub fn available_memory(&self) -> u64 {
+        self.memory_bytes.saturating_sub(
+            self.reservations
+                .values()
+                .fold(0u64, |total, item| total.saturating_add(item.memory_bytes)),
+        )
+    }
+
+    pub fn admit(
+        &mut self,
+        id: Uuid,
+        reservation: Reservation,
+        memory_available: u64,
+        disk_available: u64,
+    ) -> Result<()> {
+        if self.reservations.contains_key(&id) {
+            bail!("runtime already holds node capacity");
+        }
+        if self
+            .reservations
+            .values()
+            .filter(|item| item.starting)
+            .count()
+            >= self.starting_limit
+        {
+            bail!("node startup capacity is exhausted");
+        }
+        if reservation.memory_bytes == 0
+            || reservation.memory_bytes > reservation.maximum_memory_bytes
+            || reservation.memory_bytes > self.available_memory()
+            || reservation.memory_bytes > memory_available
+        {
+            bail!("node resident memory capacity is exhausted");
+        }
+        let reserved_disk = self
+            .reservations
+            .values()
+            .fold(0u64, |total, item| total.saturating_add(item.disk_bytes));
+        if reservation.disk_bytes > disk_available.saturating_sub(reserved_disk) {
+            bail!("node disk capacity is exhausted");
+        }
+        self.reservations.insert(id, reservation);
+        Ok(())
+    }
+
+    pub fn growth(
+        &self,
+        id: Uuid,
+        desired: u64,
+        memory_available: u64,
+        disk_available: u64,
+    ) -> Option<u64> {
+        let item = self.reservations.get(&id)?;
+        let reserved_disk = self
+            .reservations
+            .values()
+            .fold(0u64, |total, item| total.saturating_add(item.disk_bytes));
+        let added = desired
+            .min(item.maximum_memory_bytes)
+            .saturating_sub(item.memory_bytes)
+            .min(self.available_memory())
+            .min(memory_available)
+            .min(disk_available.saturating_sub(reserved_disk));
+        (added > 0).then_some(item.memory_bytes + added)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_admissions_share_pending_memory_disk_and_startup_capacity() {
+        let mut budget = Budget::new(10, 2).unwrap();
+        let a = Uuid::now_v7();
+        let request = Reservation {
+            memory_bytes: 4,
+            maximum_memory_bytes: 9,
+            disk_bytes: 5,
+            starting: true,
+        };
+        budget.admit(a, request, 10, 10).unwrap();
+        assert!(budget.admit(Uuid::now_v7(), request, 10, 9).is_err());
+        budget.admit(Uuid::now_v7(), request, 10, 10).unwrap();
+        assert!(budget.admit(Uuid::now_v7(), request, 10, 100).is_err());
+        assert_eq!(budget.growth(a, 9, 100, 100), Some(6));
+        assert_eq!(budget.growth(a, 9, 1, 100), Some(5));
+        assert_eq!(budget.growth(a, 9, 100, 10), None);
+        assert!(budget.admit(a, request, 100, 100).is_err());
+    }
+}

--- a/crates/runtime-policy/src/lib.rs
+++ b/crates/runtime-policy/src/lib.rs
@@ -104,6 +104,25 @@ impl Budget {
             .min(disk_available.saturating_sub(reserved_disk));
         (added > 0).then_some(item.memory_bytes + added)
     }
+
+    /// Increase an existing reservation before writing a checkpoint. Dirty
+    /// history may exceed current RSS, so memory admission is not a disk bound.
+    pub fn reserve_disk(&mut self, id: Uuid, desired: u64, available: u64) -> Result<()> {
+        let previous = self
+            .reservations
+            .get(&id)
+            .ok_or_else(|| anyhow::anyhow!("runtime has no disk reservation"))?
+            .disk_bytes;
+        let reserved = self
+            .reservations
+            .values()
+            .fold(0u64, |total, item| total.saturating_add(item.disk_bytes));
+        if desired.saturating_sub(previous) > available.saturating_sub(reserved) {
+            bail!("node checkpoint disk capacity is exhausted");
+        }
+        self.reservations.get_mut(&id).unwrap().disk_bytes = desired.max(previous);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -128,5 +147,11 @@ mod tests {
         assert_eq!(budget.growth(a, 9, 1, 100), Some(5));
         assert_eq!(budget.growth(a, 9, 100, 10), None);
         assert!(budget.admit(a, request, 100, 100).is_err());
+        budget.reserve_disk(a, 7, 12).unwrap();
+        assert_eq!(budget.reservations[&a].disk_bytes, 7);
+        assert!(budget.reserve_disk(a, 8, 12).is_err());
+        assert_eq!(budget.reservations[&a].disk_bytes, 7);
+        budget.reserve_disk(a, 5, 12).unwrap();
+        assert_eq!(budget.reservations[&a].disk_bytes, 7);
     }
 }

--- a/crates/runtime-policy/src/watchdog.rs
+++ b/crates/runtime-policy/src/watchdog.rs
@@ -1,0 +1,247 @@
+//! A separate process enforces each funded runtime's deadline. It owns a
+//! pidfd, so PID reuse cannot redirect a kill. Loss of the owning server's
+//! socket also stops execution. This mode starts before the server's Tokio
+//! runtime, config, cgroups or network subsystems are initialized.
+
+use crate::{ExecutionLease, LeaseState};
+use anyhow::{bail, Context, Result};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
+
+pub const MODE: &str = "--execution-watchdog";
+const MAX_FRAME: usize = 4096;
+
+#[derive(Serialize, Deserialize)]
+struct Reply {
+    error: Option<String>,
+}
+
+pub struct Watchdog {
+    channel: UnixStream,
+    child: Option<Child>,
+}
+
+impl Watchdog {
+    pub fn start(executable: &Path, pid: i32, lease: ExecutionLease) -> Result<Self> {
+        lease.remaining(SystemTime::now())?;
+        let (channel, child_channel) = UnixStream::pair()?;
+        channel.set_read_timeout(Some(Duration::from_secs(2)))?;
+        channel.set_write_timeout(Some(Duration::from_secs(2)))?;
+        let child_fd: OwnedFd = child_channel.into();
+        let child = Command::new(executable)
+            .arg(MODE)
+            .arg(pid.to_string())
+            .stdin(Stdio::from(child_fd))
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .context("start independent execution watchdog")?;
+        let mut result = Self {
+            channel,
+            child: Some(child),
+        };
+        result.renew(lease)?;
+        Ok(result)
+    }
+
+    pub fn renew(&mut self, lease: ExecutionLease) -> Result<()> {
+        send(&mut self.channel, &lease)?;
+        let reply: Reply = receive(&mut self.channel)?;
+        if let Some(error) = reply.error {
+            bail!("watchdog refused execution lease: {error}");
+        }
+        Ok(())
+    }
+
+    pub fn exited(&mut self) -> bool {
+        self.child
+            .as_mut()
+            .is_none_or(|child| !matches!(child.try_wait(), Ok(None)))
+    }
+}
+
+impl Drop for Watchdog {
+    fn drop(&mut self) {
+        let _ = self.channel.shutdown(std::net::Shutdown::Both);
+        if let Some(mut child) = self.child.take() {
+            // Reap without blocking a runtime worker on process exit.
+            std::thread::spawn(move || {
+                let _ = child.wait();
+            });
+        }
+    }
+}
+
+fn send<T: Serialize>(stream: &mut UnixStream, value: &T) -> Result<()> {
+    let bytes = serde_json::to_vec(value)?;
+    if bytes.len() > MAX_FRAME {
+        bail!("watchdog frame is too large");
+    }
+    stream.write_all(&(bytes.len() as u32).to_be_bytes())?;
+    stream.write_all(&bytes)?;
+    Ok(())
+}
+
+fn receive<T: DeserializeOwned>(stream: &mut UnixStream) -> Result<T> {
+    let mut size = [0; 4];
+    stream.read_exact(&mut size)?;
+    let size = u32::from_be_bytes(size) as usize;
+    if size == 0 || size > MAX_FRAME {
+        bail!("invalid watchdog frame size");
+    }
+    let mut bytes = vec![0; size];
+    stream.read_exact(&mut bytes)?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+/// Linux pidfds name the actual process rather than a recyclable PID.
+pub struct ProcessHandle(OwnedFd);
+
+impl ProcessHandle {
+    #[cfg(target_os = "linux")]
+    pub fn open(pid: i32) -> Result<Self> {
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error()).context("open runtime pidfd");
+        }
+        Ok(Self(unsafe { OwnedFd::from_raw_fd(fd as i32) }))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn open(_pid: i32) -> Result<Self> {
+        bail!("runtime enforcement requires Linux pidfds");
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn kill(&self) -> Result<()> {
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.0.as_raw_fd(),
+                libc::SIGKILL,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        if result < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error.into());
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn kill(&self) -> Result<()> {
+        bail!("runtime enforcement requires Linux pidfds");
+    }
+
+    pub fn exited(&self) -> bool {
+        let mut fd = libc::pollfd {
+            fd: self.0.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        unsafe { libc::poll(&mut fd, 1, 0) > 0 && fd.revents != 0 }
+    }
+}
+
+struct StopOnExit(Arc<ProcessHandle>);
+impl Drop for StopOnExit {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+    }
+}
+
+/// The parent passes the private duplex control socket as stdin. No listener
+/// or public endpoint can grant execution time to this process.
+pub fn run(pid: i32) -> Result<()> {
+    let target = StopOnExit(Arc::new(ProcessHandle::open(pid)?));
+    let fd = unsafe { libc::dup(libc::STDIN_FILENO) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let mut channel = unsafe { UnixStream::from_raw_fd(fd) };
+    channel.set_read_timeout(Some(Duration::from_secs(1)))?;
+    channel.set_write_timeout(Some(Duration::from_secs(1)))?;
+    let first: ExecutionLease = receive(&mut channel)?;
+    let state = Arc::new(Mutex::new(LeaseState::new(
+        first,
+        SystemTime::now(),
+        Instant::now(),
+    )?));
+    // Deadline enforcement never waits for control-channel I/O. A partial
+    // renewal frame or a wedged parent cannot stall the cutoff.
+    let timer_target = Arc::clone(&target.0);
+    let timer_state = Arc::clone(&state);
+    std::thread::spawn(move || loop {
+        if timer_target.exited() {
+            std::process::exit(0);
+        }
+        let expired = timer_state
+            .lock()
+            .map(|lease| lease.expired(SystemTime::now(), Instant::now()))
+            .unwrap_or(true);
+        if expired {
+            let _ = timer_target.kill();
+            std::process::exit(0);
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    });
+    send(&mut channel, &Reply { error: None })?;
+    loop {
+        if target.0.exited()
+            || state
+                .lock()
+                .unwrap()
+                .expired(SystemTime::now(), Instant::now())
+        {
+            return Ok(());
+        }
+        let mut fds = [
+            libc::pollfd {
+                fd: channel.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: target.0 .0.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+        let remaining = state.lock().unwrap().lease().remaining(SystemTime::now())?;
+        let timeout = remaining.as_millis().clamp(1, 100) as i32;
+        let polled = unsafe { libc::poll(fds.as_mut_ptr(), 2, timeout) };
+        if polled < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error.into());
+        }
+        if fds[1].revents != 0 {
+            return Ok(());
+        }
+        if fds[0].revents != 0 {
+            let next = receive(&mut channel)?;
+            let result = state
+                .lock()
+                .unwrap()
+                .renew(next, SystemTime::now(), Instant::now());
+            send(
+                &mut channel,
+                &Reply {
+                    error: result.err().map(|error| error.to_string()),
+                },
+            )?;
+        }
+    }
+}

--- a/crates/runtime-policy/tests/support/probe.rs
+++ b/crates/runtime-policy/tests/support/probe.rs
@@ -1,0 +1,29 @@
+use runtime_policy::{
+    unix_millis,
+    watchdog::{self, Watchdog},
+    ExecutionLease,
+};
+use std::{
+    io::{self, Write},
+    process::Command,
+    time::SystemTime,
+};
+use uuid::Uuid;
+fn main() -> anyhow::Result<()> {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.get(1).map(String::as_str) == Some(watchdog::MODE) {
+        return watchdog::run(args[2].parse()?);
+    }
+    let mut target = Command::new("sleep").arg("60").spawn()?;
+    let lease = ExecutionLease {
+        activation_id: Uuid::now_v7(),
+        operation_id: Uuid::now_v7(),
+        sequence: 0,
+        expires_at_unix_ms: unix_millis(SystemTime::now())? + 700,
+    };
+    let _watchdog = Watchdog::start(&std::env::current_exe()?, target.id() as i32, lease)?;
+    println!("{}", target.id());
+    io::stdout().flush()?;
+    target.wait()?;
+    Ok(())
+}

--- a/crates/runtime-policy/tests/watchdog.rs
+++ b/crates/runtime-policy/tests/watchdog.rs
@@ -1,0 +1,98 @@
+#![cfg(target_os = "linux")]
+use runtime_policy::{
+    unix_millis,
+    watchdog::{ProcessHandle, Watchdog, MODE},
+    ExecutionLease,
+};
+use std::{
+    io::{BufRead, BufReader, Read, Write},
+    os::{fd::OwnedFd, unix::net::UnixStream},
+    path::Path,
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant, SystemTime},
+};
+use uuid::Uuid;
+const PROBE: &str = env!("CARGO_BIN_EXE_runtime-policy-probe");
+struct Cleanup(Child);
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+fn lease(ms: u64) -> ExecutionLease {
+    ExecutionLease {
+        activation_id: Uuid::now_v7(),
+        operation_id: Uuid::now_v7(),
+        sequence: 0,
+        expires_at_unix_ms: unix_millis(SystemTime::now()).unwrap() + ms,
+    }
+}
+fn await_exit(process: &ProcessHandle, deadline: Instant) {
+    while !process.exited() {
+        assert!(
+            Instant::now() < deadline,
+            "runtime continued beyond its funded cutoff"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+#[test]
+fn expiry_and_lost_control_channel_stop_the_exact_process() {
+    for close in [false, true] {
+        let target = Cleanup(Command::new("sleep").arg("60").spawn().unwrap());
+        let process = ProcessHandle::open(target.0.id() as i32).unwrap();
+        let watchdog = Watchdog::start(
+            Path::new(PROBE),
+            target.0.id() as i32,
+            lease(if close { 10_000 } else { 500 }),
+        )
+        .unwrap();
+        let mut watchdog = Some(watchdog);
+        if close {
+            watchdog.take();
+        }
+        await_exit(&process, Instant::now() + Duration::from_secs(2));
+    }
+}
+#[test]
+fn stalled_api_owner_cannot_stall_execution_deadline() {
+    let mut owner = Cleanup(Command::new(PROBE).stdout(Stdio::piped()).spawn().unwrap());
+    let mut line = String::new();
+    BufReader::new(owner.0.stdout.take().unwrap())
+        .read_line(&mut line)
+        .unwrap();
+    let process = ProcessHandle::open(line.trim().parse().unwrap()).unwrap();
+    assert_eq!(unsafe { libc::kill(owner.0.id() as i32, libc::SIGSTOP) }, 0);
+    await_exit(&process, Instant::now() + Duration::from_secs(2));
+}
+#[test]
+fn partial_renewal_frame_cannot_hold_the_deadline_thread() {
+    let target = Cleanup(Command::new("sleep").arg("60").spawn().unwrap());
+    let process = ProcessHandle::open(target.0.id() as i32).unwrap();
+    let (mut parent, child) = UnixStream::pair().unwrap();
+    parent
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    let child: OwnedFd = child.into();
+    let _watchdog = Cleanup(
+        Command::new(PROBE)
+            .arg(MODE)
+            .arg(target.0.id().to_string())
+            .stdin(Stdio::from(child))
+            .spawn()
+            .unwrap(),
+    );
+    let payload = serde_json::to_vec(&lease(500)).unwrap();
+    parent
+        .write_all(&(payload.len() as u32).to_be_bytes())
+        .unwrap();
+    parent.write_all(&payload).unwrap();
+    let mut size = [0; 4];
+    parent.read_exact(&mut size).unwrap();
+    let mut reply = vec![0; u32::from_be_bytes(size) as usize];
+    parent.read_exact(&mut reply).unwrap();
+    parent.write_all(&100u32.to_be_bytes()).unwrap();
+    parent.write_all(b"{").unwrap();
+    await_exit(&process, Instant::now() + Duration::from_secs(2));
+}


### PR DESCRIPTION
Add a small `runtime-policy` crate for resource reservations and externally funded execution. It provides a single budget owner for startup, resident-memory growth and disk reservations, plus fenced absolute leases that cannot gain runtime from a delayed command or wall-clock rollback.

The Linux watchdog owns a pidfd and its own deadline thread. It terminates the runtime on funding expiry or control-channel closure even if the API process is stopped or an incomplete frame is received. Linux process tests cover those failure paths; portable unit tests cover admission and lease transitions.

This PR is a standalone building block based directly on upstream main. It contains no fork deployment configuration or private integration history. Runtime/API adoption is intentionally a separate integration: this crate does not silently enable admission in existing deployments.

Validation: `cargo test -p runtime-policy` and `cargo fmt -p runtime-policy -- --check` pass locally. A focused Linux CI job runs the process tests without KVM or privileged host setup.
