### PR TITLE
fix: reuse published layers when cloning volumes

### DIFF
--- a/src/volume.rs
+++ b/src/volume.rs
@@ -324,6 +324,7 @@ impl VolumeManager {
         }
 
         let id = format!("vol_{}", Uuid::now_v7().simple());
+        let mut backing_layers = Vec::new();
         let backing_image_config = if let Some((reference, source_owner)) = from_volume {
             let mut parent = match self.get(&reference).await {
                 Ok(parent) => parent,
@@ -345,12 +346,21 @@ impl VolumeManager {
             if parent.size_mb != size_mb {
                 return Err(VolumeError::SizeMismatch);
             }
-            if parent.backing_image_config.is_none() && !parent.backing_layers.is_empty() {
-                parent = self.materialize_backing(&parent.id).await?;
-            }
-            match parent.backing_image_config.as_ref() {
-                Some(path) => Some(self.create_child_backing(&id, path).await?),
-                None => None,
+            if parent.reserved_by_sandbox_id.is_none() && !parent.backing_layers.is_empty() {
+                // Committed layers are immutable and repository-owned. Materializing
+                // the child on mount preserves their descriptors without copying or
+                // republishing the parent's local files. Reserved parents may have
+                // newer local writes, so they still need the local clone below.
+                backing_layers = parent.backing_layers;
+                None
+            } else {
+                if parent.backing_image_config.is_none() && !parent.backing_layers.is_empty() {
+                    parent = self.materialize_backing(&parent.id).await?;
+                }
+                match parent.backing_image_config.as_ref() {
+                    Some(path) => Some(self.create_child_backing(&id, path).await?),
+                    None => None,
+                }
             }
         } else if let Some(source_config) = source_config {
             Some(self.create_child_backing(&id, &source_config).await?)
@@ -366,7 +376,7 @@ impl VolumeManager {
             status: VolumeStatus::Ready,
             reserved_by_sandbox_id: reserved_owner.map(str::to_owned),
             backing_image_config,
-            backing_layers: Vec::new(),
+            backing_layers,
             read_only_mounts: Vec::new(),
             deleting: false,
         };
@@ -817,25 +827,308 @@ fn validate_volume_id(id: &str) -> Result<(), VolumeError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{VolumeManager, VolumeMode};
+    use std::path::Path;
+
+    use overlaybd::config::{ImageConfig, LayerConfig};
+
+    use super::{VolumeError, VolumeManager, VolumeMode, VolumeRecord, VolumeStatus};
+    use crate::digest::sha256_digest;
     use crate::snapshot::repository::backends::{PosixFsBackend, PosixFsBackendConfig};
     use crate::snapshot::{ManagedLayer, OverlaybdLayerRef};
+
+    async fn manager_at(root: &Path) -> VolumeManager {
+        let backend = PosixFsBackend::new(PosixFsBackendConfig {
+            root: root.join("repository"),
+            cache_root: Some(root.join("cache")),
+            runtime_cache_root: Some(root.join("runtime")),
+        })
+        .expect("POSIX snapshot backend");
+        VolumeManager::open_with_repository(root.join("volumes/catalog"), backend.repository())
+            .await
+            .expect("volume manager")
+    }
+
+    async fn published_volume(root: &Path, manager: &VolumeManager) -> VolumeRecord {
+        let layer = root.join("base.commit");
+        std::fs::write(&layer, b"published volume layer").unwrap();
+        let config = ImageConfig {
+            lowers: vec![
+                LayerConfig {
+                    file: layer.to_string_lossy().into_owned(),
+                    ..LayerConfig::default()
+                },
+                LayerConfig {
+                    repo_blob_url: "https://registry.example.test/v2/cache/blobs".to_owned(),
+                    digest: sha256_digest(b"external volume layer"),
+                    size: 21,
+                    ..LayerConfig::default()
+                },
+            ],
+            ..ImageConfig::default()
+        };
+        let path = root.join("source.json");
+        std::fs::write(&path, serde_json::to_vec(&config).unwrap()).unwrap();
+        manager
+            .create(
+                "parent".to_owned(),
+                VolumeMode::Exclusive,
+                None,
+                Some(path),
+                1024,
+            )
+            .await
+            .expect("publish initial volume")
+    }
+
+    fn append_local_layer(record: &VolumeRecord) {
+        let path = record.backing_image_config.as_ref().unwrap();
+        let layer = path.parent().unwrap().join("unpublished.commit");
+        std::fs::write(&layer, b"new volume writes").unwrap();
+        let mut config = overlaybd::config::load_image_config(path).unwrap();
+        config.lowers.push(LayerConfig {
+            file: layer.to_string_lossy().into_owned(),
+            ..LayerConfig::default()
+        });
+        std::fs::write(path, serde_json::to_vec(&config).unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn published_volume_clones_survive_parent_deletion_without_local_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = manager_at(temp.path()).await;
+        let parent = published_volume(temp.path(), &manager).await;
+        // A stale local config must not override the committed backing, even
+        // when the manager still has the config path in its in-memory cache.
+        std::fs::write(
+            parent.backing_image_config.as_ref().unwrap(),
+            b"stale config",
+        )
+        .unwrap();
+        let cold_manager = manager_at(temp.path()).await;
+        let mut children = Vec::new();
+        for (index, (manager, mode)) in [
+            (&manager, VolumeMode::ReadOnly),
+            (&cold_manager, VolumeMode::Exclusive),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let child = manager
+                .create(
+                    format!("child-{index}"),
+                    mode,
+                    Some(parent.id.clone()),
+                    None,
+                    1024,
+                )
+                .await
+                .expect("clone committed volume without reading local files");
+            assert_eq!(child.backing_layers, parent.backing_layers);
+            assert_eq!(child.mode, mode);
+            assert!(child.backing_image_config.is_none());
+            assert!(!manager.data_dir(&child.id).exists());
+            children.push(child);
+        }
+        manager.delete(&parent.id).await.unwrap();
+        let restarted = manager_at(temp.path()).await;
+        for child in children {
+            let child = restarted.materialize_backing(&child.id).await.unwrap();
+            let config =
+                overlaybd::config::load_image_config(child.backing_image_config.unwrap()).unwrap();
+            assert_eq!(
+                std::fs::read(&config.lowers[0].file).unwrap(),
+                b"published volume layer"
+            );
+            assert_eq!(
+                config.lowers[0].digest,
+                sha256_digest(b"published volume layer")
+            );
+            assert_eq!(config.lowers[0].size, 22);
+            assert!(config.lowers[1].file.is_empty());
+            assert_eq!(
+                config.lowers[1].repo_blob_url,
+                "https://registry.example.test/v2/cache/blobs"
+            );
+            assert_eq!(
+                config.lowers[1].digest,
+                sha256_digest(b"external volume layer")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn volume_generations_preserve_inherited_descriptors_and_new_writes() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = manager_at(temp.path()).await;
+        let parent = published_volume(temp.path(), &manager).await;
+        let seed = manager
+            .create(
+                "seed".to_owned(),
+                VolumeMode::ReadOnly,
+                Some(parent.id.clone()),
+                None,
+                1024,
+            )
+            .await
+            .unwrap();
+        manager.reserve(&seed.id, "builder").await.unwrap();
+        let child = manager
+            .create_child_for_owner(
+                &seed.id,
+                "work".to_owned(),
+                VolumeMode::Exclusive,
+                1024,
+                "builder",
+                "builder",
+            )
+            .await
+            .unwrap();
+        assert_eq!(child.backing_layers, parent.backing_layers);
+        let child = manager.materialize_backing(&child.id).await.unwrap();
+        let config =
+            overlaybd::config::load_image_config(child.backing_image_config.as_ref().unwrap())
+                .unwrap();
+        assert_eq!(
+            config.lowers[0].digest,
+            sha256_digest(b"published volume layer")
+        );
+        assert_eq!(config.lowers[0].size, 22);
+        append_local_layer(&child);
+        manager
+            .recover_and_publish_backings("builder", std::slice::from_ref(&child.id))
+            .await
+            .unwrap();
+        manager
+            .replace_owner_for("builder", None, &[seed.id, child.id.clone()])
+            .await
+            .unwrap();
+        let published = manager.get(&child.id).await.unwrap();
+        assert_eq!(
+            &published.backing_layers[..2],
+            parent.backing_layers.as_slice()
+        );
+        assert_eq!(
+            published.backing_layers[2],
+            OverlaybdLayerRef::Managed(ManagedLayer {
+                digest: sha256_digest(b"new volume writes"),
+                size: 17,
+                uuid: None,
+            })
+        );
+        let next_seed = manager
+            .create(
+                "next-seed".to_owned(),
+                VolumeMode::ReadOnly,
+                Some(child.id),
+                None,
+                1024,
+            )
+            .await
+            .unwrap();
+        assert_eq!(next_seed.backing_layers, published.backing_layers);
+        assert!(next_seed.backing_image_config.is_none());
+    }
+
+    #[tokio::test]
+    async fn reserved_volume_clone_retains_unpublished_local_layers() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = manager_at(temp.path()).await;
+        let parent = published_volume(temp.path(), &manager).await;
+        manager.reserve(&parent.id, "source").await.unwrap();
+        append_local_layer(&parent);
+        let child = manager
+            .create_child_for_owner(
+                &parent.id,
+                "fork".to_owned(),
+                VolumeMode::Exclusive,
+                1024,
+                "source",
+                "child",
+            )
+            .await
+            .unwrap();
+        assert!(child.backing_layers.is_empty());
+        manager
+            .replace_owner_for("source", None, std::slice::from_ref(&parent.id))
+            .await
+            .unwrap();
+        manager.delete(&parent.id).await.unwrap();
+        manager
+            .recover_and_publish_backings("child", std::slice::from_ref(&child.id))
+            .await
+            .unwrap();
+        let child = manager.get(&child.id).await.unwrap();
+        assert_eq!(child.backing_layers.len(), 3);
+        assert_eq!(
+            child.backing_layers[2],
+            OverlaybdLayerRef::Managed(ManagedLayer {
+                digest: sha256_digest(b"new volume writes"),
+                size: 17,
+                uuid: None,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn published_volume_clone_validates_source_state_and_size() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = manager_at(temp.path()).await;
+        let mut parent = published_volume(temp.path(), &manager).await;
+        assert_eq!(
+            manager
+                .create(
+                    "wrong-size".to_owned(),
+                    VolumeMode::ReadOnly,
+                    Some(parent.id.clone()),
+                    None,
+                    2048
+                )
+                .await
+                .unwrap_err(),
+            VolumeError::SizeMismatch
+        );
+        manager.reserve(&parent.id, "owner").await.unwrap();
+        assert_eq!(
+            manager
+                .create(
+                    "reserved".to_owned(),
+                    VolumeMode::ReadOnly,
+                    Some(parent.id.clone()),
+                    None,
+                    1024
+                )
+                .await
+                .unwrap_err(),
+            VolumeError::Reserved("owner".to_owned())
+        );
+        for status in [VolumeStatus::Uploading, VolumeStatus::Failed] {
+            parent.status = status;
+            manager.persist_catalog(&parent).await.unwrap();
+            let error = manager
+                .create(
+                    "unready".to_owned(),
+                    VolumeMode::ReadOnly,
+                    Some(parent.id.clone()),
+                    None,
+                    1024,
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(
+                error,
+                match status {
+                    VolumeStatus::Uploading => VolumeError::Uploading(parent.id.clone()),
+                    VolumeStatus::Failed => VolumeError::Failed(parent.id.clone()),
+                    VolumeStatus::Ready => unreachable!(),
+                }
+            );
+        }
+    }
 
     #[tokio::test]
     async fn create_from_snapshot_preserves_read_only_mode() {
         let temp = tempfile::tempdir().expect("temporary volume repository");
-        let backend = PosixFsBackend::new(PosixFsBackendConfig {
-            root: temp.path().join("repository"),
-            cache_root: Some(temp.path().join("cache")),
-            runtime_cache_root: Some(temp.path().join("runtime")),
-        })
-        .expect("POSIX snapshot backend");
-        let manager = VolumeManager::open_with_repository(
-            temp.path().join("volumes/catalog"),
-            backend.repository(),
-        )
-        .await
-        .expect("volume manager");
+        let manager = manager_at(temp.path()).await;
 
         let restored = manager
             .create_from_snapshot(


### PR DESCRIPTION
## What

Reuse committed repository layer references when cloning an unreserved, published volume. Cloning now creates a volume record and materializes its image config on mount, preserving each inherited layer's digest and size. Reserved source volumes continue cloning their local files so unpublished writes are retained.

## Why

A template build investigated in #247 spent 33.556 seconds deleting its builder and another 33.375 seconds publishing the next cache seed. Both operations hashed the same inherited 7.43 GB BuildKit cache layer. The local cache config lacked descriptors even though its volume record already contained the published layer references; reproducing the Rust hash loop against that layer took 33.98 seconds.

Reusing published references eliminates seed republication and supplies descriptor-bearing configs to subsequent writable clones, so unchanged inherited layers bypass full-file hashing during publication. Existing cache generations benefit without rewriting their old local configs.

## Related issue

Diagnosed while testing #247. This PR is based directly on `main` and does not depend on or modify #247.

## Scope and non-goals

The change is confined to volume cloning and its regression tests. It applies to both POSIX and OSS repositories through the existing repository interfaces. New local data still follows normal publication and integrity checks.

## Design and behavior changes

- After validating source status, reservation, and size, an unreserved source with committed layers supplies those references directly to the child.
- The existing materializer resolves managed and external layers when the child is mounted. Local cache files from the source are unnecessary, and deleting the parent does not invalidate the child's committed backing.
- Reserved sources and sources without committed backing retain the existing local clone path.

## Compatibility and operations

- Public API or generated protocol: unchanged.
- Configuration or defaults: unchanged.
- Snapshot manifest, artifact layout, or storage format: unchanged; uses existing volume layer references and lazy materialization.
- Upgrade and rollback: no migration. Existing published volumes use the new path immediately.
- Host requirements, permissions, ports, or dependencies: unchanged.

## Validation

- [x] `make fmt`
- [x] `make clippy` (workspace, all targets and features, warnings denied).
- [x] `make test-unit`: 812 ordinary AgentENV tests, 4 capability tests, 3 Linux capability tests, 8 ublk tests, 46 daemon tests, and both shell verification scripts passed.
- [x] `cargo test -p agentenv --lib volume::tests`: 5 passed.
- [x] `git merge-tree --write-tree HEAD fork/feat/template-buildkit`: clean merge with #247 at `c53bc78`.

Regression coverage includes stale and absent local configs, cold managers, managed and external layers, parent deletion, successive read-only/writable generations, unpublished writes from reserved sources, and source state/size validation.

Live BuildKit/VM integration and a post-fix wall-clock benchmark have not been run. BuildKit remains in the separate, unmerged #247. Services and generated code are untouched.

## Risks and reviewer notes

The optimization requires an unreserved source because a reserved volume can contain local changes newer than its committed backing. Tests exercise that distinction. Content addressing and repository ownership remain authoritative for published layers.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] Generated code is untouched.
