### PR TITLE
fix(volume): avoid VM snapshots during sandbox deletion

### DIFF
--- a/docs/src/concepts/volumes.md
+++ b/docs/src/concepts/volumes.md
@@ -10,6 +10,16 @@ A volume has a stable ID, a unique name, a fixed size, and an access mode. You
 can mount it at an absolute guest path when creating a sandbox, then reuse its
 contents after that sandbox is deleted.
 
+Deleting a running sandbox freezes its writable volume filesystems, seals and
+publishes their layers, and stops the VM without saving memory or rootfs state.
+This checkpoints the filesystem journal so the next mount avoids journal replay.
+Recoverable capture or publication failures thaw the filesystems and retain the
+running sandbox and its volume reservations. A terminal capture failure stops the
+VM and marks writable volumes `failed`, preventing mounts of incomplete data.
+Stop or catalog failures retain the deletion state for retry; reservations are
+released only after stop succeeds. Pausing still saves the full sandbox state
+for later resume.
+
 The default volume size is 65536 MiB (64 GiB). By default, one sandbox may
 mount up to four volumes and each volume may be at most 262144 MiB (256 GiB).
 Administrators can change these limits in the [`[volume]` configuration](../configuration/reference.md#volume).

--- a/scripts/tests/e2e/suites/15_volume.sh
+++ b/scripts/tests/e2e/suites/15_volume.sh
@@ -113,6 +113,22 @@ track_sandbox "${source_sandbox_id}"
 write_volume_files "${source_sandbox_id}"
 verify_volume_files "${source_sandbox_id}"
 
+api_delete "/sandboxes/${source_sandbox_id}"
+assert_status "${HTTP_STATUS}" "204" "delete running sandbox and publish its volume"
+api_get "/volumes/${source_volume_id}"
+assert_status "${HTTP_STATUS}" "200" "get volume after sandbox deletion"
+assert_json_field "${HTTP_BODY}" '.status' "ready" "deleted sandbox volume is reusable"
+api_post "/sandboxes-cold" "${cold_payload}"
+assert_status "${HTTP_STATUS}" "201" "mount deleted sandbox volume in a new sandbox"
+if [[ "${HTTP_STATUS}" != "201" ]]; then
+    error "replacement sandbox create response: ${HTTP_BODY}"
+    exit 1
+fi
+source_sandbox_id="$(echo "${HTTP_BODY}" | jq -r '.sandboxID // empty')"
+assert_not_empty "${source_sandbox_id}" "replacement sandbox ID is present"
+track_sandbox "${source_sandbox_id}"
+verify_volume_files "${source_sandbox_id}"
+
 api_post "/sandboxes/${source_sandbox_id}/snapshots" "$(jq -nc \
   --arg name "${run_name}-snapshot" \
   '{name: $name}')"

--- a/src/orchestrator/service.rs
+++ b/src/orchestrator/service.rs
@@ -39,6 +39,19 @@ use super::{OrchestratorError, Result, SandboxForkOutcome, SandboxOperation};
 
 type SandboxHandle = Arc<Mutex<Box<dyn SandboxBackend>>>;
 
+#[derive(Default)]
+enum DeleteProgress {
+    #[default]
+    Capture,
+    Stop {
+        capture_failed: bool,
+    },
+    Release {
+        capture_failed: bool,
+    },
+    Done,
+}
+
 /// Maximum time to wait for a sandbox to leave a transitional state.
 /// Guards against indefinite blocking when a sandbox's in-progress operation
 /// never completes (e.g. the task holding the state panics without rolling back).
@@ -98,6 +111,7 @@ pub struct Orchestrator<
     factory: F,
     persister: P,
     sandboxes: RwLock<HashMap<SandboxId, SandboxHandle>>,
+    deletions: Mutex<HashMap<SandboxId, Arc<Mutex<DeleteProgress>>>>,
     proxy_routes: RwLock<ProxyRouteTable>,
     next_proxy_route_version: AtomicU64,
     counters: OrchestratorCounters,
@@ -214,6 +228,7 @@ where
             factory,
             persister,
             sandboxes: RwLock::new(HashMap::new()),
+            deletions: Mutex::new(HashMap::new()),
             proxy_routes: RwLock::new(ProxyRouteTable::default()),
             next_proxy_route_version: AtomicU64::new(1),
             counters: OrchestratorCounters::default(),
@@ -1005,27 +1020,18 @@ where
     pub async fn delete_sandbox(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         let this = Arc::clone(self);
         self.run_cancellation_safe("delete", sandbox_id, async move {
-            this.snapshot_volume_mounts_before_delete(sandbox_id)
-                .await?;
             this.delete_sandbox_inner(sandbox_id).await
         })
         .await
     }
 
-    async fn snapshot_volume_mounts_before_delete(
-        self: &Arc<Self>,
-        sandbox_id: SandboxId,
-    ) -> Result<()> {
-        // A running volume mount may contain writes that only exist in the VM's
-        // current upper layer. Pause first to seal those writes locally before
-        // the final volume state is published during deletion.
-        let should_snapshot = self.store.get(&sandbox_id).await?.is_some_and(|metadata| {
-            metadata.state == SandboxState::Running && !metadata.volume_mounts.is_empty()
-        });
-        if should_snapshot {
-            self.pause_sandbox_inner(sandbox_id).await?;
-        }
-        Ok(())
+    async fn deletion_progress(&self, sandbox_id: SandboxId) -> Arc<Mutex<DeleteProgress>> {
+        self.deletions
+            .lock()
+            .await
+            .entry(sandbox_id)
+            .or_default()
+            .clone()
     }
 
     #[tracing::instrument(
@@ -1035,6 +1041,17 @@ where
     )]
     async fn delete_sandbox_inner(self: &Arc<Self>, sandbox_id: SandboxId) -> Result<()> {
         info!("deleting sandbox");
+        let deletion = self.deletion_progress(sandbox_id).await;
+        let mut progress = deletion.lock().await;
+        match *progress {
+            DeleteProgress::Done => return Ok(()),
+            DeleteProgress::Capture => {}
+            _ => {
+                return self
+                    .delete_sandbox_impl(sandbox_id, SandboxState::Killing, &mut progress)
+                    .await
+            }
+        }
 
         // Attempt to transition to Killing, retrying after waiting whenever we
         // find the sandbox in a transitional state.
@@ -1103,11 +1120,17 @@ where
                         }));
                     }
                 },
-                Err(err) => return Err(OrchestratorError::from(err)),
+                Err(err) => {
+                    if matches!(err, StoreError::SandboxNotFound { .. }) {
+                        self.deletions.lock().await.remove(&sandbox_id);
+                    }
+                    return Err(OrchestratorError::from(err));
+                }
             }
         };
 
-        self.delete_sandbox_impl(sandbox_id, previous_state).await
+        self.delete_sandbox_impl(sandbox_id, previous_state, &mut progress)
+            .await
     }
 
     async fn claim_expired_running_sandbox(
@@ -1153,64 +1176,115 @@ where
         self: &Arc<Self>,
         sandbox_id: SandboxId,
         previous_state: SandboxState,
+        progress: &mut DeleteProgress,
     ) -> Result<()> {
-        let volume_ids = self
-            .store
-            .get(&sandbox_id)
-            .await?
+        let metadata = self.store.get(&sandbox_id).await?;
+        let volume_ids = metadata
             .map(|metadata| metadata.volume_mounts.into_values().collect::<Vec<_>>())
             .unwrap_or_default();
         let (handle, removed_route) = self.detach_sandbox_handle_and_route(&sandbox_id).await;
+        let mut capture_error = None;
 
-        // If the sandbox is still in memory, attempt to stop it.
-        if let Some(handle) = handle {
-            let stop_result = {
-                let mut sandbox = handle.lock().await;
-                sandbox.stop().await
+        if matches!(progress, DeleteProgress::Capture) {
+            let mut volumes_frozen = false;
+            let capture_result: std::result::Result<(), SandboxCaptureError> = async {
+                if let Some(handle) = handle.as_ref() {
+                    if previous_state == SandboxState::Running && !volume_ids.is_empty() {
+                        handle.lock().await.freeze_and_snapshot_volumes().await?;
+                        volumes_frozen = true;
+                    }
+                }
+                self.publish_sandbox_volume_backings(sandbox_id, &volume_ids)
+                    .await
+                    .map_err(|error| SandboxCaptureError::recoverable(error.into()))
+            }
+            .await;
+            if let Err(mut error) = capture_result {
+                if volumes_frozen && !error.is_terminal() {
+                    if let Some(handle) = handle.as_ref() {
+                        if let Err(thaw_error) = handle.lock().await.thaw_volumes().await {
+                            error = SandboxCaptureError::terminal(anyhow::anyhow!(
+                                "delete failed: {error}; thaw failed: {thaw_error:#}"
+                            ));
+                        }
+                    }
+                }
+                if !error.is_terminal() {
+                    if let Some(handle) = handle {
+                        self.sandboxes.write().await.insert(sandbox_id, handle);
+                    }
+                    self.restore_proxy_route(sandbox_id, removed_route).await;
+                    self.store
+                        .update_state_if_state(
+                            &sandbox_id,
+                            previous_state,
+                            &[SandboxState::Killing],
+                        )
+                        .await?;
+                    return Err(OrchestratorError::SandboxOperationFailed {
+                        sandbox_id,
+                        operation: SandboxOperation::Stop,
+                        source: error.into(),
+                    });
+                }
+                warn!(
+                    ?error,
+                    "volume capture failed; stopping sandbox and failing its volumes"
+                );
+                capture_error = Some(error);
+            }
+            *progress = DeleteProgress::Stop {
+                capture_failed: capture_error.is_some(),
             };
-
-            if let Err(err) = stop_result {
-                warn!(error = ?err, "failed to stop sandbox during delete");
-                self.sandboxes.write().await.insert(sandbox_id, handle);
-                self.restore_proxy_route(sandbox_id, removed_route).await;
-                self.store
-                    .update_state_if_state(&sandbox_id, previous_state, &[SandboxState::Killing])
-                    .await?;
-
-                return Err(OrchestratorError::SandboxOperationFailed {
-                    sandbox_id,
-                    operation: SandboxOperation::Stop,
-                    source: err,
-                });
-            }
         }
 
-        if let Some(manager) = self.volume_manager.as_ref() {
-            if let Err(err) = self
-                .publish_sandbox_volume_backings(sandbox_id, &volume_ids)
-                .await
-            {
-                self.store
-                    .update_state_if_state(&sandbox_id, previous_state, &[SandboxState::Killing])
-                    .await?;
-                return Err(err);
+        let cleanup: anyhow::Result<()> = async {
+            if let DeleteProgress::Stop { capture_failed } = *progress {
+                if let Some(handle) = handle.as_ref() {
+                    handle.lock().await.stop().await?;
+                }
+                *progress = DeleteProgress::Release { capture_failed };
             }
-            if let Err(err) = manager
-                .replace_owner_for(&sandbox_id.to_string(), None, &volume_ids)
-                .await
-            {
-                self.store
-                    .update_state_if_state(&sandbox_id, previous_state, &[SandboxState::Killing])
-                    .await?;
-                return Err(OrchestratorError::SandboxOperationFailed {
-                    sandbox_id,
-                    operation: SandboxOperation::Stop,
-                    source: err.into(),
-                });
+            if let DeleteProgress::Release { capture_failed } = *progress {
+                if let Some(manager) = self.volume_manager.as_ref() {
+                    let owner = sandbox_id.to_string();
+                    // An incomplete restack may leave image.json pointing at old
+                    // layers. Never publish that backing as a successful capture.
+                    if capture_failed {
+                        manager.fail_backings(&owner, &volume_ids).await?;
+                    }
+                    manager.replace_owner_for(&owner, None, &volume_ids).await?;
+                }
+                self.remove_deleted_sandbox(sandbox_id).await?;
+                *progress = DeleteProgress::Done;
             }
+            Ok(())
         }
+        .await;
+        if let Err(error) = cleanup {
+            if matches!(progress, DeleteProgress::Stop { .. }) {
+                if let Some(handle) = handle {
+                    self.sandboxes.write().await.insert(sandbox_id, handle);
+                }
+            }
+            warn!(?error, "sandbox deletion needs a cleanup retry");
+            return Err(OrchestratorError::SandboxOperationFailed {
+                sandbox_id,
+                operation: SandboxOperation::Stop,
+                source: error,
+            });
+        }
+        if let Some(error) = capture_error {
+            return Err(OrchestratorError::SandboxOperationFailed {
+                sandbox_id,
+                operation: SandboxOperation::Stop,
+                source: error.into(),
+            });
+        }
+        Ok(())
+    }
 
-        // Now the sandbox is successfully stopped, remove its metadata.
+    async fn remove_deleted_sandbox(&self, sandbox_id: SandboxId) -> Result<()> {
         let metadata = self.store.remove(&sandbox_id).await?;
         if let Some(metadata) = metadata {
             self.publish_sandbox_event(
@@ -1228,6 +1302,7 @@ where
         }
         self.release_image_refs(RuntimeImageOwner::PausedSandbox(sandbox_id))
             .await;
+        self.deletions.lock().await.remove(&sandbox_id);
         info!("sandbox deleted");
 
         Ok(())
@@ -2151,29 +2226,21 @@ where
             if metadata.state != SandboxState::Running {
                 continue;
             }
-            let flush_volumes_before_delete =
-                matches!(metadata.timeout_action, SandboxTimeoutAction::Delete)
-                    && !metadata.volume_mounts.is_empty();
-            let claimed_state = match (metadata.timeout_action, flush_volumes_before_delete) {
-                (SandboxTimeoutAction::Pause, _) => SandboxState::Pausing,
-                (SandboxTimeoutAction::Delete, true) => SandboxState::Pausing,
-                (SandboxTimeoutAction::Delete, false) => SandboxState::Killing,
+            let claimed_state = match metadata.timeout_action {
+                SandboxTimeoutAction::Pause => SandboxState::Pausing,
+                SandboxTimeoutAction::Delete => SandboxState::Killing,
             };
+            // Use the same operation lock as explicit deletion before claiming Killing.
+            let deletion = self.deletion_progress(metadata.id).await;
+            let mut progress = deletion.lock().await;
             let result = match self
                 .claim_expired_running_sandbox(metadata.id, eviction_cutoff, claimed_state)
                 .await
             {
                 Ok(true) => match metadata.timeout_action {
                     SandboxTimeoutAction::Pause => self.pause_sandbox_impl(metadata.id).await,
-                    SandboxTimeoutAction::Delete if flush_volumes_before_delete => {
-                        async {
-                            self.pause_sandbox_impl(metadata.id).await?;
-                            self.delete_sandbox_inner(metadata.id).await
-                        }
-                        .await
-                    }
                     SandboxTimeoutAction::Delete => {
-                        self.delete_sandbox_impl(metadata.id, SandboxState::Running)
+                        self.delete_sandbox_impl(metadata.id, SandboxState::Running, &mut progress)
                             .await
                     }
                 }

--- a/src/orchestrator/tests.rs
+++ b/src/orchestrator/tests.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use async_trait::async_trait;
@@ -108,6 +109,7 @@ fn make_orchestrator_without_background_with_factory_and_persister<
         factory,
         persister,
         sandboxes: RwLock::new(HashMap::new()),
+        deletions: tokio::sync::Mutex::new(HashMap::new()),
         proxy_routes: RwLock::new(ProxyRouteTable::default()),
         next_proxy_route_version: AtomicU64::new(1),
         counters: Default::default(),
@@ -2419,12 +2421,17 @@ async fn orchestrator_concurrent_delete_calls_are_idempotent() -> Result<()> {
         MockOperation::Stop,
         MockAction::SucceedAfter(Duration::from_millis(200)),
     );
+    let stopping = Arc::new(tokio::sync::Notify::new());
+    let notify = stopping.clone();
+    behavior.set_on_operation(MockOperation::Stop, Arc::new(move || notify.notify_one()));
     let orchestrator =
-        make_orchestrator_with_factory(MockBackendFactory::with_behavior(behavior)).await;
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(behavior.clone())).await;
     let case_id = Uuid::now_v7().to_string();
-    let created = orchestrator
-        .create_sandbox(create_request(Some(60), &[("case_id", case_id.as_str())]))
-        .await?;
+    let mut request = create_request(Some(60), &[("case_id", case_id.as_str())]);
+    request
+        .volume_mounts
+        .insert("/data".to_owned(), "volume".to_owned());
+    let created = orchestrator.create_sandbox(request).await?;
     let sandbox_id = created.id;
     assert_metrics_values(
         &orchestrator,
@@ -2437,6 +2444,17 @@ async fn orchestrator_concurrent_delete_calls_are_idempotent() -> Result<()> {
     )
     .await;
 
+    // Cancel the first request while stop is pending. Its owned cleanup must
+    // finish, and other deleters must not remove metadata in the meantime.
+    let first = {
+        let orchestrator = orchestrator.clone();
+        tokio::spawn(async move { orchestrator.delete_sandbox(sandbox_id).await })
+    };
+    tokio::time::timeout(Duration::from_secs(2), stopping.notified())
+        .await
+        .unwrap();
+    first.abort();
+
     // Spawn 3 concurrent delete calls.
     const N: usize = 3;
     let handles: Vec<_> = (0..N)
@@ -2447,6 +2465,11 @@ async fn orchestrator_concurrent_delete_calls_are_idempotent() -> Result<()> {
         })
         .collect();
 
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(
+        orchestrator.get_sandbox(&sandbox_id).await?.unwrap().state,
+        SandboxState::Killing
+    );
     for (i, handle) in handles.into_iter().enumerate() {
         let outcome = handle
             .await
@@ -2467,6 +2490,7 @@ async fn orchestrator_concurrent_delete_calls_are_idempotent() -> Result<()> {
     );
     assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;
     assert_proxy_not_found(&orchestrator, &sandbox_id).await?;
+    assert_eq!(behavior.stop_calls(), 1);
 
     Ok(())
 }
@@ -2712,6 +2736,220 @@ async fn orchestrator_list_empty_returns_empty() -> Result<()> {
         "empty store should return empty filtered sandbox list"
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn volume_deletion_stop_failure_preserves_runtime_for_retry() -> Result<()> {
+    let behavior = Arc::new(MockBehavior::new());
+    for _ in 0..2 {
+        behavior.push_action(
+            MockOperation::Stop,
+            MockAction::Fail {
+                message: "stop failed".to_owned(),
+            },
+        );
+    }
+    let thawed = Arc::new(AtomicBool::new(false));
+    let thawed_hook = thawed.clone();
+    behavior.set_on_operation(
+        MockOperation::ThawVolumes,
+        Arc::new(move || {
+            thawed_hook.store(true, Ordering::SeqCst);
+        }),
+    );
+    let orchestrator =
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(behavior)).await;
+    let mut request = create_request(Some(60), &[]);
+    request
+        .volume_mounts
+        .insert("/data".to_owned(), "volume".to_owned());
+    let id = orchestrator.create_sandbox(request).await?.id;
+    assert!(orchestrator.delete_sandbox(id).await.is_err());
+    assert!(!thawed.load(Ordering::SeqCst));
+    assert_eq!(
+        orchestrator
+            .get_sandbox(&id)
+            .await?
+            .expect("Killing record")
+            .state,
+        SandboxState::Killing
+    );
+    assert!(orchestrator.sandboxes.read().await.get(&id).is_some());
+    assert!(orchestrator.delete_sandbox(id).await.is_err());
+    assert_eq!(
+        orchestrator
+            .get_sandbox(&id)
+            .await?
+            .expect("Killing record")
+            .state,
+        SandboxState::Killing
+    );
+    orchestrator.delete_sandbox(id).await?;
+    assert!(orchestrator.get_sandbox(&id).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn volume_deletion_capture_failure_preserves_runtime() -> Result<()> {
+    let behavior = Arc::new(MockBehavior::new());
+    behavior.push_action(
+        MockOperation::SnapshotVolumes,
+        MockAction::Fail {
+            message: "freeze or seal failed".to_owned(),
+        },
+    );
+    let orchestrator =
+        make_orchestrator_with_factory(MockBackendFactory::with_behavior(behavior.clone())).await;
+    let mut request = create_request(Some(60), &[]);
+    request
+        .volume_mounts
+        .insert("/data".to_owned(), "volume".to_owned());
+    let sandbox = orchestrator.create_sandbox(request).await?;
+    let result = orchestrator.delete_sandbox(sandbox.id).await;
+    assert!(result.is_err());
+    assert_eq!(behavior.stop_calls(), 0);
+    assert_eq!(
+        orchestrator.get_sandbox(&sandbox.id).await?.unwrap().state,
+        SandboxState::Running
+    );
+    assert!(matches!(
+        orchestrator.proxy_lookup_for(&sandbox.id).await?,
+        ProxyLookupResult::Ready(_)
+    ));
+    orchestrator.delete_sandbox(sandbox.id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn volume_deletion_publication_and_terminal_cleanup_failures_are_retryable(
+) -> anyhow::Result<()> {
+    use crate::snapshot::repository::backends::{PosixFsBackend, PosixFsBackendConfig};
+    use crate::volume::{VolumeMode, VolumeRecord, VolumeStatus};
+
+    let temp = TempDir::new()?;
+    let backend = PosixFsBackend::new(PosixFsBackendConfig {
+        root: temp.path().join("repository"),
+        cache_root: Some(temp.path().join("cache")),
+        runtime_cache_root: Some(temp.path().join("runtime")),
+    })?;
+    let repository = backend.repository();
+    let volumes = Arc::new(
+        VolumeManager::open_with_repository(temp.path().join("volumes"), repository.clone())
+            .await?,
+    );
+    let behavior = Arc::new(MockBehavior::new());
+    let thawed = Arc::new(AtomicBool::new(false));
+    let thawed_hook = thawed.clone();
+    behavior.set_on_operation(
+        MockOperation::ThawVolumes,
+        Arc::new(move || {
+            thawed_hook.store(true, Ordering::SeqCst);
+        }),
+    );
+    let orchestrator = TestOrchestrator::new_inner_with_volumes(
+        InMemoryMetadataStore::new(),
+        MockBackendFactory::with_behavior(behavior.clone()),
+        DisabledSandboxPersister,
+        test_runtime_image_refs(),
+        Some(volumes.clone()),
+    )
+    .await?;
+    let sandbox = orchestrator
+        .create_sandbox(create_request(Some(60), &[]))
+        .await?;
+    let volume = VolumeRecord {
+        id: "vol_missing_backing".to_owned(),
+        name: "missing-backing".to_owned(),
+        mode: VolumeMode::Exclusive,
+        size_mb: 1024,
+        status: VolumeStatus::Ready,
+        reserved_by_sandbox_id: Some(sandbox.id.to_string()),
+        backing_image_config: None,
+        backing_layers: Vec::new(),
+        read_only_mounts: Vec::new(),
+        deleting: false,
+    };
+    repository.create_volume(volume.clone()).await?;
+    let record_path = temp
+        .path()
+        .join("repository/volumes/records")
+        .join(format!("{}.json", volume.id));
+    let owner = sandbox.id.to_string();
+    orchestrator
+        .store
+        .update_if_state(&sandbox.id, &[SandboxState::Running], |metadata| {
+            metadata
+                .volume_mounts
+                .insert("/cache".to_owned(), volume.id.clone());
+        })
+        .await?;
+    let deleted = orchestrator.delete_sandbox(sandbox.id).await;
+    let record = volumes.get(&volume.id).await?;
+    assert_eq!(record.status, VolumeStatus::Failed);
+    assert!(deleted.is_err());
+    assert!(thawed.load(Ordering::SeqCst));
+    assert_eq!(behavior.stop_calls(), 0);
+    assert_eq!(
+        orchestrator.get_sandbox(&sandbox.id).await?.unwrap().state,
+        SandboxState::Running
+    );
+    assert!(matches!(
+        orchestrator.proxy_lookup_for(&sandbox.id).await?,
+        ProxyLookupResult::Ready(_)
+    ));
+    assert!(orchestrator.store.get(&sandbox.id).await?.is_some());
+    assert_eq!(
+        record.reserved_by_sandbox_id.as_deref(),
+        Some(sandbox.id.to_string().as_str())
+    );
+    // A subsequent terminal capture must not publish the incomplete backing.
+    // Fail catalog access after stop to exercise cleanup retry without a runtime.
+    behavior.push_action(
+        MockOperation::SnapshotVolumes,
+        MockAction::FailTerminal {
+            message: "incomplete restack".to_owned(),
+        },
+    );
+    let saved_path = record_path.with_extension("saved");
+    let record_to_hide = record_path.clone();
+    let saved_record = saved_path.clone();
+    behavior.set_on_operation(
+        MockOperation::Stop,
+        Arc::new(move || {
+            let record: VolumeRecord =
+                serde_json::from_slice(&std::fs::read(&record_to_hide).unwrap()).unwrap();
+            assert_eq!(
+                record.reserved_by_sandbox_id.as_deref(),
+                Some(owner.as_str()),
+                "ownership must remain held until stop completes"
+            );
+            std::fs::rename(&record_to_hide, &saved_record).unwrap();
+        }),
+    );
+    assert!(orchestrator.delete_sandbox(sandbox.id).await.is_err());
+    assert_eq!(
+        orchestrator.get_sandbox(&sandbox.id).await?.unwrap().state,
+        SandboxState::Killing
+    );
+    assert!(orchestrator
+        .sandboxes
+        .read()
+        .await
+        .get(&sandbox.id)
+        .is_none());
+    assert_eq!(behavior.stop_calls(), 1);
+    std::fs::rename(saved_path, record_path)?;
+    assert_eq!(
+        volumes.get(&volume.id).await?.reserved_by_sandbox_id,
+        Some(sandbox.id.to_string())
+    );
+    orchestrator.delete_sandbox(sandbox.id).await?;
+    assert_eq!(behavior.stop_calls(), 1, "cleanup must not stop twice");
+    let record = volumes.get(&volume.id).await?;
+    assert_eq!(record.status, VolumeStatus::Failed);
+    assert!(record.reserved_by_sandbox_id.is_none());
+    assert!(orchestrator.get_sandbox(&sandbox.id).await?.is_none());
     Ok(())
 }
 
@@ -3129,7 +3367,7 @@ async fn auto_evict_claim_prevents_late_keep_alive_success() -> Result<()> {
     for (timeout_action, claimed_state, with_volume) in [
         (SandboxTimeoutAction::Pause, SandboxState::Pausing, false),
         (SandboxTimeoutAction::Delete, SandboxState::Killing, false),
-        (SandboxTimeoutAction::Delete, SandboxState::Pausing, true),
+        (SandboxTimeoutAction::Delete, SandboxState::Killing, true),
     ] {
         let control = Arc::new(ScriptedStoreControl::default());
         let orchestrator =
@@ -3847,7 +4085,6 @@ async fn delete_when_stop_fails_returns_error_and_allows_retry() -> Result<()> {
         .create_sandbox(create_request(Some(60), &[("team", "delete-stop-failure")]))
         .await?;
     let sandbox_id = created.id;
-    let running_metrics = current_metrics(&orchestrator).await;
     assert_metrics_values(
         &orchestrator,
         1,
@@ -3871,12 +4108,14 @@ async fn delete_when_stop_fails_returns_error_and_allows_retry() -> Result<()> {
         }
     ));
 
-    assert!(
-        orchestrator.get_sandbox(&sandbox_id).await?.is_some(),
-        "metadata should still exist after failed delete"
+    assert_eq!(
+        orchestrator
+            .get_sandbox(&sandbox_id)
+            .await?
+            .expect("Killing record")
+            .state,
+        SandboxState::Killing
     );
-    assert_metrics_snapshot(&orchestrator, &running_metrics).await;
-
     orchestrator.delete_sandbox(sandbox_id).await?;
     assert!(orchestrator.get_sandbox(&sandbox_id).await?.is_none());
     assert_metrics_values(&orchestrator, 1, 0, 0, 0, 0, 0).await;

--- a/src/sandbox/backend.rs
+++ b/src/sandbox/backend.rs
@@ -256,6 +256,18 @@ pub trait SandboxBackend: Send + 'static {
     /// Idempotent: calling `stop` more than once must not return an error.
     async fn stop(&mut self) -> Result<()>;
 
+    /// Freeze writable persistent filesystems and seal their volume layers,
+    /// without capturing memory, rootfs, or VM state. On success, writes remain
+    /// frozen until `stop` or `thaw_volumes`. Recoverable errors guarantee that
+    /// writes have resumed; terminal errors require runtime teardown.
+    /// Callers must keep ownership through completion and thaw/stop; dropping
+    /// this future does not cancel guest I/O. The orchestrator shields deletion
+    /// from request cancellation with an owned task.
+    async fn freeze_and_snapshot_volumes(&mut self) -> SandboxCaptureResult<()>;
+
+    /// Resume writes after abandoning a deletion that froze the volumes.
+    async fn thaw_volumes(&mut self) -> Result<()>;
+
     /// Obtain the IP address that the sandbox can use to interact with the host.
     fn host_interaction_ip(&self) -> Option<std::net::Ipv4Addr>;
 

--- a/src/sandbox/extra_drive.rs
+++ b/src/sandbox/extra_drive.rs
@@ -257,7 +257,9 @@ pub fn validate_mount_path(path: &Path) -> Result<()> {
     if path == Path::new("/") {
         anyhow::bail!("attached drive mountPath must not be /");
     }
-    let raw = path.to_string_lossy();
+    let raw = path
+        .to_str()
+        .context("attached drive mountPath must be valid UTF-8")?;
     if raw.chars().any(char::is_whitespace) || raw.contains(',') || raw.contains(':') {
         anyhow::bail!(
             "attached drive mountPath must not contain whitespace, commas, or colons: {}",
@@ -612,6 +614,13 @@ mod tests {
             PathBuf::from("/workspace/data")
         );
         assert!(normalize_mount_path(PathBuf::from("/workspace/data/../logs")).is_err());
+    }
+
+    #[test]
+    fn mount_path_rejects_non_utf8() {
+        use std::os::unix::ffi::OsStringExt;
+        let mount = PathBuf::from(std::ffi::OsString::from_vec(b"/data/\xff".to_vec()));
+        assert!(validate_mount_path(&mount).is_err());
     }
 
     #[test]

--- a/src/sandbox/firecracker/overlaybd_snapshot.rs
+++ b/src/sandbox/firecracker/overlaybd_snapshot.rs
@@ -563,16 +563,18 @@ async fn capture_live_overlaybd_snapshot(
                     "read restack snapshot layer metadata {}",
                     snapshot_layer_path.display()
                 )
-            })?
+            })
+            .map_err(into_terminal_snapshot_failure)?
             .len();
         if copied_size != descriptor.size {
-            let _ = fs::remove_file(&snapshot_layer_path);
-            anyhow::bail!(
+            // Keep the sealed layer: the live device may still reference it,
+            // and terminal deletion marks the volume failed for recovery.
+            return Err(into_terminal_snapshot_failure(anyhow::anyhow!(
                 "restack snapshot descriptor size mismatch for {}: descriptor says {}, file has {}",
                 snapshot_layer_path.display(),
                 descriptor.size,
                 copied_size
-            );
+            )));
         }
     }
 

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -192,6 +192,7 @@ pub struct FirecrackerSandbox {
     /// waits out the fallback with no notification.
     rootfs_image_config_path: Option<PathBuf>,
     extra_drive_runtimes: Vec<OverlaybdRuntimeHandle>,
+    frozen_volume_mounts: Vec<(PathBuf, String)>,
     /// Drives added to a committed snapshot at launch time are not represented
     /// in its guest mount namespace. Mount only those drives after envd is
     /// ready; paused-state resumes must preserve the captured mount state.
@@ -464,6 +465,74 @@ impl SandboxBackend for FirecrackerSandbox {
 
     async fn stop(&mut self) -> Result<()> {
         FirecrackerSandbox::stop(self).await
+    }
+
+    async fn freeze_and_snapshot_volumes(&mut self) -> SandboxCaptureResult<()> {
+        let started = std::time::Instant::now();
+        let result = async {
+            let mounts = self
+                .launch
+                .common()
+                .extra_drives
+                .iter()
+                .filter(|drive| !drive.read_only() && drive.snapshot_output_dir().is_some())
+                .map(|drive| drive.mount_path().to_path_buf())
+                .collect::<Vec<_>>();
+            for mount in mounts {
+                // An RPC failure leaves the ioctl's outcome unknown, so the VM
+                // cannot safely be returned to service in that case.
+                // Record the mount before awaiting so cancellation leaves a
+                // thaw obligation on the owned sandbox handle.
+                self.frozen_volume_mounts
+                    .push((mount.clone(), String::new()));
+                let output = self
+                    .set_volume_freeze(&mount, None)
+                    .await
+                    .map_err(SandboxCaptureError::terminal)?;
+                if output.exit_code != 0 {
+                    self.frozen_volume_mounts.pop();
+                    anyhow::bail!(
+                        "freeze volume {} failed: {}",
+                        mount.display(),
+                        output.stderr.trim()
+                    );
+                }
+                self.frozen_volume_mounts.last_mut().unwrap().1 = output.stdout.trim().to_owned();
+            }
+            self.snapshot_persistent_volume_drives().await?;
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+        if let Err(error) = result {
+            let error = SandboxCaptureError::from(error);
+            if !error.is_terminal() {
+                self.thaw_volumes().await.map_err(|thaw_error| {
+                    SandboxCaptureError::terminal(anyhow::anyhow!(
+                        "volume capture failed: {error}; thaw failed: {thaw_error:#}"
+                    ))
+                })?;
+            }
+            return Err(error);
+        }
+        debug!(
+            elapsed_ms = started.elapsed().as_millis(),
+            "volume filesystems frozen and sealed"
+        );
+        Ok(())
+    }
+
+    async fn thaw_volumes(&mut self) -> Result<()> {
+        while let Some((mount, device)) = self.frozen_volume_mounts.last().cloned() {
+            let output = self.set_volume_freeze(&mount, Some(&device)).await?;
+            anyhow::ensure!(
+                output.exit_code == 0,
+                "thaw volume {} failed: {}",
+                mount.display(),
+                output.stderr.trim()
+            );
+            self.frozen_volume_mounts.pop();
+        }
+        Ok(())
     }
 
     fn host_interaction_ip(&self) -> Option<std::net::Ipv4Addr> {
@@ -842,7 +911,10 @@ impl FirecrackerSandbox {
     }
 
     async fn create_guest_directory(envd: &EnvdInstance, path: &str) -> Result<()> {
-        Executor::new(envd.clone()).create_dir_all(path).await
+        Executor::new(envd.clone())
+            .with_root_user()
+            .create_dir_all(path)
+            .await
     }
 
     async fn run_guest_command(
@@ -851,7 +923,14 @@ impl FirecrackerSandbox {
         args: Vec<String>,
     ) -> Result<crate::sandbox::process::ProcessOutput> {
         let args = args.iter().map(String::as_str).collect::<Vec<_>>();
-        Executor::new(envd).run_command(&command, &args).await
+        Executor::new(envd)
+            .with_root_user()
+            .run_command_with_opts(
+                &command,
+                &args,
+                &crate::sandbox::ProcessOpts::default().with_cwd("/"),
+            )
+            .await
     }
 
     async fn sync_writable_volume_filesystems(envd: EnvdInstance) -> Result<()> {
@@ -871,6 +950,56 @@ impl FirecrackerSandbox {
             output.stderr.trim()
         );
         Ok(())
+    }
+
+    async fn set_volume_freeze(
+        &self,
+        mount: &Path,
+        frozen_device: Option<&str>,
+    ) -> Result<crate::sandbox::process::ProcessOutput> {
+        let envd = self.envd_instance.clone().context("envd is not running")?;
+        let mount = mount
+            .to_str()
+            .context("volume mount path is not valid UTF-8")?;
+        // Keep one opened filesystem across validation and the ioctl, so an
+        // unmount cannot redirect fsfreeze to the root filesystem hosting envd.
+        let script = r#"
+            set -eu
+            exec 3< "$1"
+            device=$(/agentenv/bin/busybox stat -Lc %d /proc/self/fd/3)
+            if [ "$2" = --freeze ]; then
+                test "$device" != "$(/agentenv/bin/busybox stat -c %d /)"
+            else
+                test "$device" = "$3"
+            fi
+            /agentenv/bin/busybox fsfreeze "$2" /proc/self/fd/3
+            printf '%s\n' "$device"
+        "#;
+        let operation = if frozen_device.is_some() {
+            "--unfreeze"
+        } else {
+            "--freeze"
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(30), async move {
+            Executor::new(envd)
+                .with_root_user()
+                .run_command_with_opts(
+                    "/agentenv/bin/busybox",
+                    &[
+                        "sh",
+                        "-c",
+                        script,
+                        "freeze-volume",
+                        mount,
+                        operation,
+                        frozen_device.unwrap_or_default(),
+                    ],
+                    &crate::sandbox::ProcessOpts::default().with_cwd("/"),
+                )
+                .await
+        })
+        .await
+        .context("volume filesystem freeze/thaw timed out")?
     }
 
     async fn mount_guest_path_with_options(
@@ -1192,6 +1321,7 @@ impl FirecrackerSandbox {
             envd.invalidate();
         }
         self.envd_instance = None;
+        self.frozen_volume_mounts.clear();
 
         // Cleanup ublk device (must happen after FC stop, before network cleanup)
         if let Some(runtime) = self.rootfs_runtime.take() {
@@ -1501,6 +1631,7 @@ impl FirecrackerSandbox {
             mem_snapshot_image_config_path: None,
             rootfs_image_config_path: None,
             extra_drive_runtimes: Vec::new(),
+            frozen_volume_mounts: Vec::new(),
             initial_guest_drive_mounts: Vec::new(),
             live_snapshot_root: None,
             snapshot_compression_override: None,

--- a/src/sandbox/mock.rs
+++ b/src/sandbox/mock.rs
@@ -52,6 +52,7 @@ pub enum MockOperation {
     Resume,
     Snapshot,
     SnapshotVolumes,
+    ThawVolumes,
     Fork,
     ForkChild,
     Stop,
@@ -245,6 +246,7 @@ impl MockBehavior {
 pub struct MockSandboxBackend {
     behavior: Arc<MockBehavior>,
     host_ip: Option<std::net::Ipv4Addr>,
+    volumes_frozen: bool,
 }
 
 impl MockSandboxBackend {
@@ -256,7 +258,11 @@ impl MockSandboxBackend {
         behavior: Arc<MockBehavior>,
         host_ip: Option<std::net::Ipv4Addr>,
     ) -> Self {
-        Self { behavior, host_ip }
+        Self {
+            behavior,
+            host_ip,
+            volumes_frozen: false,
+        }
     }
 }
 
@@ -336,7 +342,28 @@ impl SandboxBackend for MockSandboxBackend {
     }
 
     async fn stop(&mut self) -> Result<()> {
-        self.behavior.apply_async(MockOperation::Stop).await
+        self.behavior.apply_async(MockOperation::Stop).await?;
+        self.volumes_frozen = false;
+        Ok(())
+    }
+
+    async fn freeze_and_snapshot_volumes(&mut self) -> SandboxCaptureResult<()> {
+        assert!(!self.volumes_frozen, "volumes already frozen");
+        let result = self.snapshot_volumes().await;
+        self.volumes_frozen = result
+            .as_ref()
+            .err()
+            .is_none_or(|error| error.is_terminal());
+        result
+    }
+
+    async fn thaw_volumes(&mut self) -> Result<()> {
+        anyhow::ensure!(self.volumes_frozen, "volumes are not frozen");
+        self.behavior
+            .apply_async(MockOperation::ThawVolumes)
+            .await?;
+        self.volumes_frozen = false;
+        Ok(())
     }
 
     fn host_interaction_ip(&self) -> Option<std::net::Ipv4Addr> {

--- a/src/sandbox/process.rs
+++ b/src/sandbox/process.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::{bail, Context, Result};
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use tokio::time::Duration;
 use tonic::Request;
 
@@ -14,6 +14,18 @@ use envd::process::{
 use super::envd::EnvdInstance;
 
 const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
+
+fn guest_request<T>(message: T, root_user: bool) -> Request<T> {
+    let mut request = Request::new(message);
+    if root_user {
+        // envd uses HTTP Basic's username to select the guest account.
+        request.metadata_mut().insert(
+            "authorization",
+            tonic::metadata::MetadataValue::from_static("Basic cm9vdDo="),
+        );
+    }
+    request
+}
 
 /// Options for starting a process inside the sandbox.
 #[derive(Clone, Debug, Default)]
@@ -70,6 +82,7 @@ pub struct ProcessHandle {
     client: ProcessClient,
     stream: tonic::Streaming<StartResponse>,
     timeout: Option<Duration>,
+    root_user: bool,
 }
 
 impl ProcessHandle {
@@ -128,12 +141,15 @@ impl ProcessHandle {
             selector: Some(process_selector::Selector::Pid(self.pid)),
         };
         self.client
-            .send_input(Request::new(SendInputRequest {
-                process: Some(selector),
-                input: Some(ProcessInput {
-                    input: Some(process_input::Input::Stdin(data.to_vec())),
-                }),
-            }))
+            .send_input(guest_request(
+                SendInputRequest {
+                    process: Some(selector),
+                    input: Some(ProcessInput {
+                        input: Some(process_input::Input::Stdin(data.to_vec())),
+                    }),
+                },
+                self.root_user,
+            ))
             .await
             .context("failed to send stdin")?;
         Ok(())
@@ -145,10 +161,14 @@ impl ProcessHandle {
             selector: Some(process_selector::Selector::Pid(self.pid)),
         };
         self.client
-            .send_signal(Request::new(SendSignalRequest {
-                process: Some(selector),
-                signal: signal as i32,
-            }))
+            .send_signal(guest_request(
+                SendSignalRequest {
+                    process: Some(selector),
+                    signal: signal as i32,
+                },
+                self.root_user,
+            ))
+            .boxed()
             .await
             .context("failed to send signal")?;
         Ok(())
@@ -185,11 +205,21 @@ impl ProcessHandle {
 /// Owns a lightweight clone of the sandbox's envd connection settings.
 pub struct Executor {
     envd_instance: EnvdInstance,
+    root_user: bool,
 }
 
 impl Executor {
     pub(super) fn new(envd_instance: EnvdInstance) -> Self {
-        Self { envd_instance }
+        Self {
+            envd_instance,
+            root_user: false,
+        }
+    }
+
+    /// Select root for internal filesystem maintenance, independently of USER.
+    pub(super) fn with_root_user(mut self) -> Self {
+        self.root_user = true;
+        self
     }
 
     /// Run a command and wait for it to complete.
@@ -205,8 +235,11 @@ impl Executor {
         args: &[&str],
         opts: &ProcessOpts,
     ) -> Result<ProcessOutput> {
-        let mut handle = self.start_process_inner(cmd, args, opts, false).await?;
-        handle.wait().await
+        let mut handle = self
+            .start_process_inner(cmd, args, opts, false)
+            .boxed()
+            .await?;
+        handle.wait().boxed().await
     }
 
     /// Start a long-running process and return a [`ProcessHandle`].
@@ -226,9 +259,12 @@ impl Executor {
     pub async fn create_dir_all(&self, path: &str) -> Result<()> {
         let mut client = self.envd_instance.filesystem_client().await?;
         match client
-            .make_dir(Request::new(MakeDirRequest {
-                path: path.to_string(),
-            }))
+            .make_dir(guest_request(
+                MakeDirRequest {
+                    path: path.to_string(),
+                },
+                self.root_user,
+            ))
             .await
         {
             Ok(_) => Ok(()),
@@ -247,33 +283,38 @@ impl Executor {
         opts: &ProcessOpts,
         stdin_enabled: bool,
     ) -> Result<ProcessHandle> {
-        let request = Request::new(StartRequest {
-            process: Some(ProcessConfig {
-                cmd: cmd.to_string(),
-                args: args.iter().map(|s| s.to_string()).collect(),
-                envs: opts.envs.clone(),
-                cwd: opts.cwd.clone(),
-            }),
-            pty: None,
-            tag: None,
-            stdin: Some(stdin_enabled),
-        });
+        let request = guest_request(
+            StartRequest {
+                process: Some(ProcessConfig {
+                    cmd: cmd.to_string(),
+                    args: args.iter().map(|s| s.to_string()).collect(),
+                    envs: opts.envs.clone(),
+                    cwd: opts.cwd.clone(),
+                }),
+                pty: None,
+                tag: None,
+                stdin: Some(stdin_enabled),
+            },
+            self.root_user,
+        );
 
-        let mut client = self.envd_instance.process_client().await?;
+        let mut client = self.envd_instance.process_client().boxed().await?;
         let mut stream = client
             .start(request)
+            .boxed()
             .await
             .context("failed to start process via envd")?
             .into_inner();
 
         // Wait for the StartEvent to learn the PID.
-        let pid = Self::wait_for_start_event(&mut stream).await?;
+        let pid = Self::wait_for_start_event(&mut stream).boxed().await?;
 
         Ok(ProcessHandle {
             pid,
             client,
             stream,
             timeout: opts.timeout,
+            root_user: self.root_user,
         })
     }
 

--- a/src/sandbox/ublk/device.rs
+++ b/src/sandbox/ublk/device.rs
@@ -430,7 +430,7 @@ impl UblkDeviceManager {
                     .is_some()
                 {
                     return Err(SandboxCaptureError::terminal(anyhow!(format!(
-                        "restack snapshot overlaybd device {} to {} failed after mutating live runtime: {err:#}",
+                        "restack snapshot overlaybd device {} to {} failed; live runtime may have been mutated: {err:#}",
                         device.dev_id,
                         output_layer_path.display()
                     )))

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -552,6 +552,23 @@ impl VolumeManager {
         Ok(())
     }
 
+    /// Keep an incomplete capture unavailable after its sandbox is stopped.
+    pub(crate) async fn fail_backings(
+        &self,
+        owner: &str,
+        volume_ids: &[String],
+    ) -> Result<(), VolumeError> {
+        for volume_id in volume_ids {
+            let mut record = self.get(volume_id).await?;
+            if record.reserved_by_sandbox_id.as_deref() == Some(owner) {
+                record.status = VolumeStatus::Failed;
+                self.persist_catalog(&record).await?;
+                self.cache_record(record).await;
+            }
+        }
+        Ok(())
+    }
+
     pub async fn publish_backings(
         &self,
         owner: &str,

--- a/storage/ublk-daemon/src/client.rs
+++ b/storage/ublk-daemon/src/client.rs
@@ -459,7 +459,14 @@ impl UblkDaemonClient {
             dev_id,
             output_layer_path: output_layer_path.to_path_buf(),
         };
-        match self.call(request, SNAPSHOT_TIMEOUT).await? {
+        // A lost reply can follow a successful seal. Only an explicit Error
+        // response establishes that the runtime is still safe to resume.
+        let response = self.call(request, SNAPSHOT_TIMEOUT).await.context(
+            RestackSnapshotTerminalFailure::new(format!(
+                "daemon: restack snapshot dev_id={dev_id} outcome unknown"
+            )),
+        )?;
+        match response {
             DaemonResponse::RestackSnapshotCreated {
                 descriptor,
                 data_stat,
@@ -478,7 +485,10 @@ impl UblkDaemonClient {
             DaemonResponse::Error { message } => {
                 bail!("daemon: restack snapshot dev_id={dev_id} failed: {message}")
             }
-            other => bail!("daemon: unexpected response for restack snapshot: {other:?}"),
+            other => Err(RestackSnapshotTerminalFailure::new(format!(
+                "daemon: unexpected response for restack snapshot: {other:?}"
+            ))
+            .into()),
         }
     }
 
@@ -706,6 +716,30 @@ mod tests {
             .create_overlaybd(Path::new("/img.json"), Path::new("/global.json"))
             .await;
         assert!(err.is_err(), "should fail when no server is listening");
+    }
+
+    #[tokio::test]
+    async fn restack_lost_reply_is_terminal() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("restack.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let client = UblkDaemonClient::new_for_test(socket, false);
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            assert!(matches!(
+                recv_message::<DaemonRequest>(&mut stream).await.unwrap(),
+                Some(DaemonRequest::RestackSnapshot { .. })
+            ));
+            // Consume the request, then close without replying: the client
+            // cannot know whether the live upper was already sealed.
+        });
+
+        let error = client
+            .restack_snapshot(0, Path::new("/snapshot.commit"))
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        assert!(error.is::<RestackSnapshotTerminalFailure>(), "{error:#}");
     }
 
     #[tokio::test]

--- a/storage/ublk-daemon/tests/ublk_daemon_test.rs
+++ b/storage/ublk-daemon/tests/ublk_daemon_test.rs
@@ -553,6 +553,7 @@ mod client_tests {
             .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("snapshot failed"), "error: {msg}");
+        assert!(!err.is::<RestackSnapshotTerminalFailure>(), "{err:#}");
     }
 
     #[tokio::test]
@@ -585,6 +586,7 @@ mod client_tests {
             .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("unexpected"), "error: {msg}");
+        assert!(err.is::<RestackSnapshotTerminalFailure>(), "{err:#}");
     }
 
     // ── shutdown ────────────────────────────────────────────────────────

--- a/tests/integration/snapshot_attached_drive.rs
+++ b/tests/integration/snapshot_attached_drive.rs
@@ -195,6 +195,176 @@ async fn publish_sandbox_snapshot_with_attached_drive(
 }
 
 #[tokio::test]
+async fn frozen_volumes_survive_deletion_without_vm_snapshot() -> Result<()> {
+    use agentenv::volume::{VolumeManager, VolumeMode};
+
+    common::setup().await;
+    let root = tempdir()?;
+    let (_, _, repository) = common::snapshot_test_parts(root.path());
+    let volumes =
+        VolumeManager::open_with_repository(root.path().join("volumes"), repository).await?;
+    let mut config = common::default_sandbox_config()?;
+    config.vcpu_count = 2;
+    config.mem_size_mib = 512;
+    for name in ["data", "archive"] {
+        let volume = volumes
+            .create(name.to_owned(), VolumeMode::Exclusive, None, None, 1024)
+            .await?;
+        let image_config = volume.backing_image_config.expect("local volume config");
+        config.common.extra_drives.push(ExtraDrive::Overlaybd {
+            drive_id: volume.id,
+            image_config_path: image_config.clone(),
+            read_only: false,
+            mount_path: PathBuf::from(format!("/{name}")),
+            virtual_size: Some(1024 * 1024 * 1024),
+            sub_path: None,
+            snapshot_output_dir: Some(image_config.parent().unwrap().to_path_buf()),
+            volume: true,
+        });
+    }
+    let mut worker = FirecrackerSandbox::new(config.clone())?;
+    worker.start().await?;
+    let worker_result: Result<()> = async {
+        let output = worker
+            .run_command(
+                "/agentenv/bin/busybox",
+                &[
+                    "sh",
+                    "-c",
+                    r#"
+        set -eu
+        mkdir /archive/nested
+        i=0
+        while [ "$i" -lt 2000 ]; do
+            printf 'marker-%s\n' "$i" > /data/file-$i
+            printf 'marker-%s\n' "$i" > /archive/nested/file-$i
+            i=$((i + 1))
+        done
+        /agentenv/bin/busybox umount /archive
+    "#,
+                ],
+            )
+            .await?;
+        anyhow::ensure!(output.exit_code == 0, "{}", output.stderr);
+        // Failure on the second mount must thaw the first mount, and must never
+        // freeze the root filesystem now visible beneath the unmounted path.
+        let error = worker
+            .freeze_and_snapshot_volumes()
+            .await
+            .err()
+            .ok_or_else(|| anyhow!("capture should reject the unmounted volume"))?;
+        anyhow::ensure!(!error.is_terminal(), "{error}");
+        let output = worker
+        .executor()?
+        .run_command_with_opts(
+            "/agentenv/bin/busybox",
+            &[
+                "sh",
+                "-c",
+                "echo recovered > /data/recovered && /agentenv/bin/busybox mount /dev/vdd /archive",
+            ],
+            &agentenv::sandbox::ProcessOpts::default()
+                .with_timeout(std::time::Duration::from_secs(10)),
+        )
+        .await?;
+        anyhow::ensure!(output.exit_code == 0, "{}", output.stderr);
+        worker.freeze_and_snapshot_volumes().await?;
+        let output = worker
+            .run_command(
+                "/agentenv/bin/busybox",
+                &["mount", "--bind", "/archive", "/data"],
+            )
+            .await?;
+        anyhow::ensure!(output.exit_code == 0, "{}", output.stderr);
+        anyhow::ensure!(
+            worker.thaw_volumes().await.is_err(),
+            "thaw must reject a replaced mount"
+        );
+        let output = worker
+            .run_command("/agentenv/bin/busybox", &["umount", "/data"])
+            .await?;
+        anyhow::ensure!(output.exit_code == 0, "{}", output.stderr);
+        worker.thaw_volumes().await?;
+        let output = worker
+            .run_command(
+                "/agentenv/bin/busybox",
+                &["sh", "-c", "echo thawed > /data/thawed"],
+            )
+            .await?;
+        anyhow::ensure!(output.exit_code == 0, "{}", output.stderr);
+        worker.freeze_and_snapshot_volumes().await?;
+        Ok(())
+    }
+    .await;
+    let worker_stop = worker.stop().await;
+    worker_result?;
+    worker_stop?;
+
+    let ExtraDrive::Overlaybd { sub_path, .. } = config
+        .common
+        .extra_drives
+        .iter_mut()
+        .find(|drive| drive.mount_path() == Path::new("/archive"))
+        .ok_or_else(|| anyhow!("archive drive missing"))?;
+    *sub_path = Some(PathBuf::from("nested"));
+    config.common.default_user = Some("nobody".to_owned());
+    config.common.default_workdir = Some("/".to_owned());
+
+    let mut replacement = FirecrackerSandbox::new(config)?;
+    replacement.start().await?;
+    let replacement_result: Result<()> = async {
+        let output = replacement
+            .run_command(
+                "/agentenv/bin/busybox",
+                &[
+                    "sh",
+                    "-c",
+                    r#"
+        set -eu
+        test "$(id -u)" != 0
+        test "$(cat /data/recovered)" = recovered
+        test "$(cat /data/thawed)" = thawed
+        i=0
+        while [ "$i" -lt 2000 ]; do
+            read -r value < /data/file-$i
+            test "$value" = "marker-$i"
+            read -r value < /archive/file-$i
+            test "$value" = "marker-$i"
+            i=$((i + 1))
+        done
+    "#,
+                ],
+            )
+            .await?;
+        anyhow::ensure!(output.exit_code == 0, "{}", output.stderr);
+        // Read kernel messages from the host so this check does not need a
+        // root executor in a sandbox whose default user is nobody.
+        let kernel_log = fs::read_to_string(replacement.firecracker_stdout_path())?;
+        for device in ["vdc", "vdd"] {
+            let prefix = format!("EXT4-fs ({device})");
+            anyhow::ensure!(
+                kernel_log.contains(&prefix),
+                "missing {prefix} messages: {kernel_log}"
+            );
+            anyhow::ensure!(
+                !kernel_log
+                    .lines()
+                    .any(|line| line.contains(&prefix) && line.contains("recovery complete")),
+                "unexpected journal recovery: {kernel_log}"
+            );
+        }
+        // Freeze and seal through a subPath bind mount as well.
+        replacement.freeze_and_snapshot_volumes().await?;
+        Ok(())
+    }
+    .await;
+    let replacement_stop = replacement.stop().await;
+    replacement_result?;
+    replacement_stop?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn attached_overlaybd_drive_is_visible_on_snapshot_based_build() -> Result<()> {
     common::setup().await;
     let store = tempdir()?;


### PR DESCRIPTION
## What

Delete sandboxes with mounted volumes by freezing the writable filesystems, sealing and publishing their layers, and stopping the VM. Deletion no longer captures disposable memory, rootfs, or VM state.

## Why

The existing deletion path pauses the entire sandbox to preserve volume writes. A volume-only checkpoint avoids that work and leaves a clean filesystem journal for the next mount.

## Related issue

Extracted from #247 alongside #253 (OCI UID/GID startup) and #254 (BuildKit). The layer-reuse optimization in #249 remains separate.

## Scope and non-goals

Mounted-volume deletion, timeout eviction, failure recovery, regression tests, and volume documentation. BuildKit integration and OCI UID/GID resolution are submitted separately.

## Design and behavior changes

- Keep volume reservations until publication succeeds and the VM stops.
- Thaw and restore the original runtime after recoverable capture or publication failures. Terminal failures tear down the runtime and its persisted state.
- Bound freeze/thaw RPCs and check mountpoints before freezing, so an unmounted path cannot freeze the guest root filesystem.
- Explicit pause and graceful shutdown continue to save resumable VM state.

## Compatibility and operations

- Public API or generated protocol: unchanged; the internal sandbox backend gains freeze/thaw operations.
- Configuration or defaults: unchanged.
- Snapshot manifest, artifact layout, or storage format: unchanged.
- Upgrade and rollback: no migration required.
- Host requirements, permissions, ports, or dependencies: existing Firecracker, ublk, and guest BusyBox requirements.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
make fmt clippy: passed
make test-unit: passed, including capability and ublk checks
cargo test -p agentenv --test integration frozen_volumes_survive_deletion_without_vm_snapshot -- --nocapture: passed
git diff --check: passed
```

The VM test passed with multiple volumes, recovery after a partial freeze failure, thaw/reseal, subPath mounts, a non-root default user, and dirty-file preservation in a replacement VM. It ran as a non-root user through the repository capability runner with isolated state and dependency copies. No timing benchmark was run; the regression tests verify that deletion does not invoke a full VM pause/snapshot. Go and generated API checks do not apply.

## Risks and reviewer notes

Review deletion ordering in `src/orchestrator/service.rs` and freeze recovery in `src/sandbox/firecracker/sandbox.rs`. Filesystem freezing flushes filesystem state; application buffers still require application-level coordination. Guest root-selection helpers overlap identically with the OCI startup fix and merge cleanly.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by focused regression tests.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] No generated code was manually edited.
