### PR TITLE
fix(sandbox): start OCI images with explicit UID or GID

### DIFF
--- a/src/sandbox/envd.rs
+++ b/src/sandbox/envd.rs
@@ -18,6 +18,8 @@ use envd::http_client::models::InitPostRequest;
 use envd::process::ProcessClient;
 use envd::reqwest::Client;
 
+mod user;
+
 const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 // Bootstrap addresses can be reused across sandbox runtime generations. Do not
@@ -156,6 +158,30 @@ impl EnvdInstance {
         default_workdir: Option<String>,
         default_user: Option<String>,
     ) -> Result<()> {
+        let default_user = match default_user {
+            Some(user) if user::needs_resolution(&user) => {
+                // Authenticate this runtime first, including after restore.
+                // Account setup runs before the sandbox becomes available.
+                self.post_init(None, Some("/".to_owned()), Some("root".to_owned()))
+                    .await?;
+                Some(
+                    tokio::time::timeout(Duration::from_secs(30), self.resolve_default_user(&user))
+                        .await
+                        .context("timed out resolving Dockerfile USER")??,
+                )
+            }
+            user => user,
+        };
+        self.post_init(env_vars, default_workdir, default_user)
+            .await
+    }
+
+    async fn post_init(
+        &self,
+        env_vars: Option<HashMap<String, String>>,
+        default_workdir: Option<String>,
+        default_user: Option<String>,
+    ) -> Result<()> {
         debug!(has_env_vars = env_vars.is_some(), "initializing envd");
         let now = chrono::Utc::now().fixed_offset();
         let init_post_request = InitPostRequest {
@@ -179,9 +205,9 @@ impl EnvdInstance {
 mod tests {
     use std::time::Instant;
 
-    use axum::extract::State;
+    use axum::extract::{Query, State};
     use axum::http::{HeaderMap, StatusCode};
-    use axum::routing::post;
+    use axum::routing::{get, post};
     use axum::{Json, Router};
     use serde_json::Value;
     use tokio::net::TcpListener;
@@ -216,6 +242,42 @@ mod tests {
         let (headers, body) = receiver.recv().await.expect("captured init request");
         assert_eq!(headers["x-access-token"], token.expose());
         assert_eq!(body["accessToken"], token.expose());
+        server.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn init_resolves_numeric_default_user_and_preserves_image_environment() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let (sender, mut receiver) = mpsc::channel(2);
+        let token = crate::sandbox::SandboxAccessTokenGenerator::new("numeric-user-test-seed")?
+            .generate(crate::types::SandboxId::new());
+        let file_token = token.clone();
+        let app = Router::new()
+            .route("/init", post(capture_init_request))
+            .route("/files", get(move |headers: HeaderMap, Query(query): Query<HashMap<String, String>>| async move {
+                assert_eq!(headers["x-access-token"], file_token.expose());
+                assert_eq!(query["path"], "/etc/passwd");
+                assert_eq!(query["username"], "root");
+                b"root:x:0:0:r\xffot:/root:/bin/sh\nother:x:1000:1000:\xff:/home/other:/bin/sh\n".to_vec()
+            }))
+            .with_state(sender);
+        let server = tokio::spawn(async move { axum::serve(listener, app).await });
+        let envd = EnvdInstance::new(format!("http://{address}"), Some(token.clone()));
+        envd.init(
+            Some(HashMap::from([("HOME".to_owned(), "/app".to_owned())])),
+            Some("/work".to_owned()),
+            Some("0".to_owned()),
+        )
+        .await?;
+        let (headers, bootstrap) = receiver.recv().await.unwrap();
+        assert_eq!(headers["x-access-token"], token.expose());
+        assert_eq!(bootstrap["accessToken"], token.expose());
+        let (_, body) = receiver.recv().await.unwrap();
+        assert_eq!(body["defaultUser"], "root");
+        assert_eq!(body["defaultWorkdir"], "/work");
+        assert_eq!(body["envVars"]["HOME"], "/app");
         server.abort();
         Ok(())
     }

--- a/src/sandbox/envd/user.rs
+++ b/src/sandbox/envd/user.rs
@@ -1,0 +1,326 @@
+use std::collections::HashMap;
+
+use anyhow::{bail, ensure, Context, Result};
+use envd::http_client::apis::files_api;
+use shell_util::shell_quote;
+
+use super::EnvdInstance;
+use crate::sandbox::{Executor, ProcessOpts};
+
+pub(super) fn needs_resolution(user: &str) -> bool {
+    user.contains(':') || is_numeric(user)
+}
+
+fn is_numeric(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|c| c.is_ascii_digit())
+}
+
+impl EnvdInstance {
+    pub(super) async fn resolve_default_user(&self, user: &str) -> Result<String> {
+        let passwd = self.read_account_file("/etc/passwd").await?;
+        let groups = if user
+            .split_once(':')
+            .is_some_and(|(_, group)| !is_numeric(group))
+        {
+            self.read_account_file("/etc/group").await?
+        } else {
+            Vec::new()
+        };
+        let resolved = resolve_user(user, &passwd, &groups)?;
+        if let Some(entry) = resolved.passwd_entry {
+            // envd requires a name even when Docker permits a UID without an
+            // account. Add an identity without changing existing accounts.
+            let script = format!("printf '\\n%s\\n' {} >> /etc/passwd", shell_quote(&entry));
+            let output = Executor::new(self.clone())
+                .with_root_user()
+                .run_command_with_opts(
+                    "/agentenv/bin/busybox",
+                    &["sh", "-c", &script],
+                    &ProcessOpts::default()
+                        .with_cwd("/")
+                        .with_timeout(std::time::Duration::from_secs(10)),
+                )
+                .await?;
+            if output.exit_code != 0 {
+                bail!(
+                    "failed to prepare Dockerfile USER {user}: {}",
+                    output.stderr
+                );
+            }
+        }
+        Ok(resolved.name)
+    }
+
+    async fn read_account_file(&self, path: &str) -> Result<Vec<u8>> {
+        match files_api::files_get(&self.config, Some(path), Some("root"), None, None).await {
+            Ok(mut response) => {
+                let mut bytes = Vec::new();
+                while let Some(chunk) = response.chunk().await? {
+                    ensure!(
+                        bytes.len() + chunk.len() <= 1024 * 1024,
+                        "guest {path} exceeds the 1 MiB account-file limit"
+                    );
+                    bytes.extend_from_slice(&chunk);
+                }
+                Ok(bytes)
+            }
+            Err(envd::http_client::apis::Error::ResponseError(response))
+                if response.status == envd::reqwest::StatusCode::NOT_FOUND =>
+            {
+                Ok(Vec::new())
+            }
+            Err(error) => {
+                Err(error).with_context(|| format!("read guest {path} to resolve Dockerfile USER"))
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ResolvedUser {
+    name: String,
+    passwd_entry: Option<String>,
+}
+
+fn parse_id(value: &[u8]) -> Result<u32> {
+    let value = std::str::from_utf8(value).context("invalid Dockerfile user/group ID")?;
+    let id = value
+        .parse::<u32>()
+        .context("invalid Dockerfile user/group ID")?;
+    if id == u32::MAX {
+        bail!("invalid Dockerfile user/group ID: {value}");
+    }
+    Ok(id)
+}
+
+fn resolve_user(user: &str, passwd: &[u8], groups: &[u8]) -> Result<ResolvedUser> {
+    let (account, group) = user
+        .split_once(':')
+        .map_or((user, None), |(u, g)| (u, Some(g)));
+    let numeric_uid = is_numeric(account)
+        .then(|| parse_id(account.as_bytes()))
+        .transpose()?;
+    // Parse delimiters and IDs as bytes; unrelated names, comments, and paths
+    // need not be UTF-8. Only convert the selected account's name/home below.
+    let accounts: Vec<Vec<&[u8]>> = passwd
+        .split(|&byte| byte == b'\n')
+        .enumerate()
+        .filter(|(_, line)| !line.is_empty() && !line.starts_with(b"#"))
+        .map(|(index, line)| {
+            let line_number = index + 1;
+            let fields: Vec<_> = line.split(|&byte| byte == b':').collect();
+            ensure!(
+                fields.len() == 7 && !fields[0].is_empty(),
+                "malformed /etc/passwd record at line {line_number}: expected a name and seven fields"
+            );
+            parse_id(fields[2])
+                .with_context(|| format!("invalid /etc/passwd UID at line {line_number}"))?;
+            parse_id(fields[3])
+                .with_context(|| format!("invalid /etc/passwd GID at line {line_number}"))?;
+            Ok(fields)
+        })
+        .collect::<Result<_>>()?;
+    let existing = accounts.iter().find(|fields| {
+        numeric_uid.map_or(fields[0] == account.as_bytes(), |uid| {
+            parse_id(fields[2]).ok() == Some(uid)
+        })
+    });
+    let uid = match numeric_uid {
+        Some(uid) => uid,
+        None => parse_id(
+            existing.context("Dockerfile USER names an account absent from /etc/passwd")?[2],
+        )?,
+    };
+    let gid = match group {
+        Some(group) if is_numeric(group) => parse_id(group.as_bytes())?,
+        Some(group) => {
+            let entry = groups
+                .split(|&byte| byte == b'\n')
+                .map(|line| line.split(|&byte| byte == b':').collect::<Vec<_>>())
+                .find(|fields| fields[0] == group.as_bytes())
+                .context("Dockerfile USER names a group absent from /etc/group")?;
+            ensure!(entry.len() == 4, "malformed /etc/group record for {group}");
+            parse_id(entry[2])?
+        }
+        None => existing
+            .map(|fields| parse_id(fields[3]))
+            .transpose()?
+            .unwrap_or(0),
+    };
+    if group.is_none() {
+        if let Some(fields) = existing {
+            if parse_id(fields[3])? == gid {
+                return Ok(ResolvedUser {
+                    name: std::str::from_utf8(fields[0])
+                        .context("selected /etc/passwd account name is not UTF-8")?
+                        .to_owned(),
+                    passwd_entry: None,
+                });
+            }
+        }
+    }
+    // A separate name preserves explicit UID:GID pairs without rewriting an
+    // existing user's primary group. Reuse it on subsequent snapshot restores.
+    let home = std::str::from_utf8(existing.map_or(b"/".as_slice(), |fields| fields[5]))
+        .context("selected /etc/passwd home is not UTF-8")?;
+    let mut names = HashMap::new();
+    for fields in &accounts {
+        names.entry(fields[0]).or_insert(fields);
+    }
+    let base_name = format!("aenv-{uid}-{gid}");
+    for suffix in 0..=accounts.len() {
+        let name = if suffix == 0 {
+            base_name.clone()
+        } else {
+            format!("{base_name}-{suffix}")
+        };
+        if let Some(fields) = names.get(name.as_bytes()) {
+            if fields.len() == 7
+                && fields[1] == b"x"
+                && parse_id(fields[2]).ok() == Some(uid)
+                && parse_id(fields[3]).ok() == Some(gid)
+                && fields[4].is_empty()
+                && fields[5] == home.as_bytes()
+                && fields[6] == b"/bin/sh"
+            {
+                return Ok(ResolvedUser {
+                    name,
+                    passwd_entry: None,
+                });
+            }
+            continue;
+        }
+        let passwd_entry = Some(format!("{name}:x:{uid}:{gid}::{home}:/bin/sh"));
+        return Ok(ResolvedUser { name, passwd_entry });
+    }
+    unreachable!("a free account name exists after inspecting every entry")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PASSWD: &str =
+        "root:x:0:0:root:/root:/bin/sh\nnonroot:x:65532:65532::/home/nonroot:/sbin/nologin\n";
+
+    #[test]
+    fn numeric_users_resolve_to_existing_guest_accounts() {
+        for (user, name) in [("0", "root"), ("00", "root"), ("65532", "nonroot")] {
+            assert_eq!(
+                resolve_user(user, PASSWD.as_bytes(), b"").unwrap(),
+                ResolvedUser {
+                    name: name.into(),
+                    passwd_entry: None
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn missing_numeric_user_keeps_requested_uid_and_gid() {
+        assert_eq!(
+            resolve_user("1234", PASSWD.as_bytes(), b"")
+                .unwrap()
+                .passwd_entry
+                .as_deref(),
+            Some("aenv-1234-0:x:1234:0::/:/bin/sh")
+        );
+        let resolved = resolve_user("1234:5678", PASSWD.as_bytes(), b"").unwrap();
+        let updated = format!("{PASSWD}{}\n", resolved.passwd_entry.unwrap());
+        assert_eq!(
+            resolve_user("1234:5678", updated.as_bytes(), b"")
+                .unwrap()
+                .passwd_entry,
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_group_preserves_existing_account_and_home() {
+        let resolved =
+            resolve_user("nonroot:staff", PASSWD.as_bytes(), b"staff:x:1000:\n").unwrap();
+        assert_eq!(
+            resolved.passwd_entry.as_deref(),
+            Some("aenv-65532-1000:x:65532:1000::/home/nonroot:/bin/sh")
+        );
+    }
+
+    #[test]
+    fn conflicting_generated_name_is_not_reused() {
+        let passwd = format!(
+            "{PASSWD}other:x:1234:0::/home/other:/bin/sh\naenv-1234-0:x:1234:0::/other:/bin/sh\n"
+        );
+        assert_eq!(
+            resolve_user("1234:0", passwd.as_bytes(), b"").unwrap().name,
+            "aenv-1234-0-1"
+        );
+    }
+
+    #[test]
+    fn explicit_group_does_not_reuse_existing_account() {
+        assert_eq!(
+            resolve_user("nonroot:65532", PASSWD.as_bytes(), b"")
+                .unwrap()
+                .name,
+            "aenv-65532-65532"
+        );
+    }
+
+    #[test]
+    fn non_utf8_account_fields_do_not_block_valid_identities() {
+        let passwd = b"root:x:0:0:r\xffot:/root:/bin/sh\n\xffuser:x:1000:1000::/\xffhome:/bin/sh\n";
+        assert_eq!(resolve_user("0", passwd, b"").unwrap().name, "root");
+        let groups = b"\xffgroup:x:1000:\xffuser\nstaff:x:1001:\xffuser\n";
+        assert_eq!(
+            resolve_user("0:staff", passwd, groups)
+                .unwrap()
+                .passwd_entry
+                .as_deref(),
+            Some("aenv-0-1001:x:0:1001::/root:/bin/sh")
+        );
+    }
+
+    #[test]
+    fn malformed_passwd_records_fail_with_line_context() {
+        for record in [
+            "nonroot:x:65532:65532::/home/nonroot", // Missing shell field.
+            "nonroot:x:bad:65532::/home/nonroot:/bin/sh",
+            "nonroot:x:65532:bad::/home/nonroot:/bin/sh",
+            ":x:65532:65532::/home/nonroot:/bin/sh",
+        ] {
+            let passwd = format!("root:x:0:0::/root:/bin/sh\n{record}\n");
+            for user in ["65532", "nonroot:0"] {
+                let error = resolve_user(user, passwd.as_bytes(), b"").unwrap_err();
+                assert!(error.to_string().contains("/etc/passwd"), "{error:#}");
+                assert!(error.to_string().contains("line 2"), "{error:#}");
+            }
+        }
+    }
+
+    #[test]
+    fn blank_lines_and_comments_do_not_hide_existing_accounts() {
+        let passwd = format!("\n# Accounts\n{PASSWD}\n");
+        assert_eq!(
+            resolve_user("0", passwd.as_bytes(), b"").unwrap().name,
+            "root"
+        );
+    }
+
+    #[test]
+    fn invalid_ids_and_missing_names_fail() {
+        for user in [
+            "4294967295",
+            "4294967296",
+            "0:",
+            "0:no-such-group",
+            "missing:0",
+            ":0",
+            "0:0:0",
+        ] {
+            assert!(
+                resolve_user(user, PASSWD.as_bytes(), b"").is_err(),
+                "{user}"
+            );
+        }
+    }
+}

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -275,8 +275,8 @@ impl TemplateBuildRunner {
 /// account at build time aligns template builds with what E2B-compatible
 /// clients assume.
 ///
-/// Numeric USER values are left alone (Docker allows a UID with no passwd
-/// entry). An image with no account-management tooling at all (neither
+/// Numeric USER values are resolved during envd initialization (Docker allows
+/// a UID with no passwd entry). An image without account-management tooling (neither
 /// useradd/groupadd nor adduser/addgroup) keeps building with a warning
 /// rather than failing: such an image worked before this provisioning
 /// existed, and only envd calls that resolve the default user will fail.

--- a/tests/integration/process.rs
+++ b/tests/integration/process.rs
@@ -18,6 +18,77 @@ async fn start_sandbox() -> Result<FirecrackerSandbox> {
 }
 
 #[tokio::test]
+async fn numeric_image_users_preserve_identity_after_start_and_resume() -> Result<()> {
+    common::setup().await;
+    // Discover named-account IDs from the fixture instead of coupling this
+    // regression test to a particular distro's nobody/nogroup assignments.
+    let mut probe = start_sandbox().await?;
+    let nobody_uid = probe
+        .run_command("id", &["-u", "nobody"])
+        .await?
+        .stdout
+        .trim()
+        .to_owned();
+    let nobody_gid = probe
+        .run_command("id", &["-g", "nobody"])
+        .await?
+        .stdout
+        .trim()
+        .to_owned();
+    let root_gid = probe
+        .run_command("id", &["-g", "root"])
+        .await?
+        .stdout
+        .trim()
+        .to_owned();
+    probe.stop().await?;
+
+    for (identity, uid, gid) in [
+        ("0", "0", root_gid.as_str()),
+        (
+            nobody_uid.as_str(),
+            nobody_uid.as_str(),
+            nobody_gid.as_str(),
+        ),
+        ("12345", "12345", "0"),
+        ("12345:23456", "12345", "23456"),
+        ("nobody:0", nobody_uid.as_str(), "0"),
+        ("12345:root", "12345", root_gid.as_str()),
+    ] {
+        let mut config = common::default_sandbox_config()?;
+        config.vcpu_count = 2;
+        config.mem_size_mib = 512;
+        config.common.default_user = Some(identity.to_owned());
+        config.common.default_workdir = Some("/tmp".to_owned());
+        let mut sandbox = FirecrackerSandbox::new(config)?;
+        sandbox.start().await?;
+
+        for restored in [false, true] {
+            if restored {
+                let snapshot = sandbox.pause().await?;
+                sandbox.stop().await?;
+                sandbox = FirecrackerSandbox::resume_from_snapshot_config(&snapshot).await?;
+            }
+            let output = sandbox
+                .run_command_with_opts(
+                    "/agentenv/bin/busybox",
+                    &["sh", "-c", "id -u; id -g; pwd"],
+                    &ProcessOpts::default().with_timeout(Duration::from_secs(10)),
+                )
+                .await?;
+            assert_eq!(output.exit_code, 0, "{identity}: {}", output.stderr);
+            assert_eq!(
+                output.stdout.trim(),
+                format!("{uid}\n{gid}\n/tmp"),
+                "{identity}"
+            );
+        }
+        sandbox.stop().await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn run_command_basic_contracts() -> Result<()> {
     common::setup().await;
     tokio::time::timeout(TEST_TIMEOUT, async {


### PR DESCRIPTION
## What

Start and resume OCI images whose `User` config specifies a numeric UID or an explicit user/group pair. Resolve the identity to an envd account while preserving the requested UID/GID, image environment, and working directory.

## Why

OCI permits numeric identities without a passwd entry, but envd requires an account name. Passing `12345` or `12345:23456` directly to envd can prevent image startup.

## Related issue

Extracted from #247 alongside #252 (volume deletion) and #254 (BuildKit).

## Scope and non-goals

Guest identity resolution, privileged internal filesystem maintenance, and regression tests. BuildKit integration and volume-deletion optimization are separate PRs.

## Design and behavior changes

- Bootstrap authenticated envd as root before account resolution, then apply the final image configuration.
- Reuse existing accounts for UID-only identities. Explicit groups and missing numeric users get a separate account preserving UID, GID, and home, reused after snapshot restore without rewriting existing accounts.
- Resolve named groups, reject invalid IDs or missing named identities, cap account-file reads at 1 MiB, and bound account setup. Parse account files as bytes and report malformed passwd records with line numbers.
- Use the provided BusyBox and explicitly select root for internal filesystem operations independently of the image's default user.

## Compatibility and operations

- Public API or generated protocol: unchanged.
- Configuration or defaults: unchanged; an unknown numeric UID without an explicit group uses GID 0.
- Snapshot manifest, artifact layout, or storage format: unchanged. Added guest passwd entries are captured normally.
- Upgrade and rollback: no host-state migration; existing guest accounts are preserved.
- Host requirements, permissions, ports, or dependencies: unchanged; uses the existing tools drive.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] Documentation updated (no documentation changes included)

Commands and results:

```text
make fmt clippy: passed
RUST_TEST_THREADS=2 make test-unit: passed, including capability and ublk checks
cargo test -p agentenv --test integration numeric_image_users_preserve_identity_after_start_and_resume -- --nocapture: passed
git diff --check: passed
```

The VM test ran through the repository capability runner as a non-root user with isolated test state and dependency copies. Unit coverage includes existing and missing UIDs, explicit numeric and named groups, account-name collisions, invalid IDs, non-UTF-8 fields, malformed passwd records, authenticated initialization, and image environment preservation. The VM test discovers named-account IDs from the guest fixture. Validation used `CARGO_TARGET_DIR=/tmp/aenv-target`. The initial parallel unit run encountered transient `ETXTBSY` failures in two helper-script tests; both passed individually. A single-thread retry exposed an existing output-marker parsing issue in the network panic-cleanup test; two-thread execution passed that test. Go, code generation, and performance benchmarks do not apply.

## Risks and reviewer notes

Review `src/sandbox/envd/user.rs`. The fix adds passwd entries only when needed and leaves existing accounts intact. The new VM test checks six identities across cold startup and resume without depending on BuildKit.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by focused regression tests.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] No generated code was manually edited.
