### PR TITLE
feat(snapshot): compress layers at publish time when uploading to OSS/ACR

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -231,6 +231,18 @@ p2p_enabled = true
 # [snapshot.image_publish]
 # enabled = true
 
+# Compress memory layers and incremental read-write layers once, when they are
+# uploaded to OSS/ACR. Local layers always stay raw, so local resume pays no
+# decompression cost; enabled by default to cut network bytes for cross-node
+# resume. Disable when upload CPU matters more than transfer bytes.
+[snapshot.publish_compression]
+enabled = true
+# Supported algorithms are "lz4" and "zstd".
+algorithm = "lz4"
+# Workers compressing 4 KiB blocks. One is sequential; higher values run in
+# parallel without changing the output layout.
+workers = 1
+
 # POSIX storage defaults under AENV_HOME. Set this for a shared or independent
 # snapshot filesystem.
 # [backend.posix_fs]
@@ -239,8 +251,8 @@ p2p_enabled = true
 # OSS requires an endpoint, bucket, region, and either credential_process or
 # static credentials. credential_process takes precedence over static values.
 # [backend.oss]
-# endpoint = "https://oss-cn-beijing-internal.aliyuncs.com"
-# bucket = "agentenv-snapshots"
+# endpoint = "https://<your-oss-endpoint>"
+# bucket = "your-snapshot-bucket"
 # region = "cn-beijing"
 # Bucket addressing style: "virtual" or "path". Leave unset to use
 # endpoint-based auto-detection.
@@ -317,15 +329,6 @@ fill_concurrency = 4
 # OverlayBD path. Disable with AGENTENV_MEMORY_SNAPSHOT_TRACK_DIRTY_PAGES=false.
 track_dirty_pages = true
 
-# Compress memory snapshot layers. The algorithm is parsed but ignored when
-# compression is disabled.
-compression_enabled = false
-# Supported algorithms are "lz4" and "zstd".
-compression_algorithm = "lz4"
-# Workers compressing 4 KiB blocks. One is sequential; higher values run in
-# parallel without changing the output layout.
-compression_workers = 1
-
 [memory_snapshot.background_download]
 # Download missing blocks from remote memory layers; never start before envd
 # becomes ready.
@@ -346,19 +349,6 @@ concurrency = 4
 # block_size must not exceed 2 GiB; defaults use 256 MiB. Per-image overrides
 # cannot resize it.
 max_inflight_blocks = 16
-
-[template_build]
-# Compress snapshot artifacts captured by template builds, independent of
-# [memory_snapshot].compression_enabled (template builds consult only this
-# section). When enabled, both memory layers and the sealed rootfs read-write
-# layer are compressed. Pause/snapshot captures of running sandboxes are not
-# affected.
-compression_enabled = false
-# Supported algorithms are "lz4" and "zstd".
-compression_algorithm = "lz4"
-# Workers compressing 4 KiB blocks. One is sequential; higher values run in
-# parallel without changing the output layout.
-compression_workers = 1
 
 [observability]
 # Expose node identity, host metrics, and orchestrator runtime metrics.

--- a/crates/e2e-tests/tests/snapshot_oss_e2e_test.rs
+++ b/crates/e2e-tests/tests/snapshot_oss_e2e_test.rs
@@ -1,7 +1,10 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
-use agentenv::cfg::{ConfigManager, OssBackendConfig};
+use agentenv::cfg::{
+    ConfigManager, OssBackendConfig, OverlaybdCompressionAlgorithm,
+    SnapshotPublishCompressionConfig,
+};
 use agentenv::sandbox::FirecrackerSnapshotManifest;
 use agentenv::snapshot::mock::write_mock_built_artifacts;
 use agentenv::snapshot::repository::backends::OssBackend;
@@ -14,9 +17,11 @@ use agentenv::types::SandboxResources;
 use agentenv_test_support::minio::{MinioFixture, MINIO_PASS, MINIO_USER};
 use anyhow::{Context, Result};
 use overlaybd::backend::local::LocalFile;
-use overlaybd::index_file::{CommitArgs, LSMTFile};
+use overlaybd::backend::switch::new_switch_file;
+use overlaybd::backend::tar::new_tar_file_adaptor;
+use overlaybd::index_file::{CommitArgs, LSMTFile, LSMTReadOnlyFile};
 use overlaybd::virtual_file::VirtualFile;
-use overlaybd::zfile::{CompressArgs, CompressOptions, ZFileCompactWriter};
+use overlaybd::zfile::{is_zfile, CompressArgs, CompressOptions, ZFileCompactWriter};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
@@ -29,8 +34,9 @@ fn test_runtime_versions() -> SnapshotRuntimeVersions {
     }
 }
 
-/// Write a real ZFile-compressed sealed LSMT layer, mirroring the memory
-/// snapshot output when `[memory_snapshot].compression_enabled = true`.
+/// Write a real ZFile-compressed sealed LSMT layer, mirroring a compressed
+/// memory lower as found in repositories published while capture-time
+/// compression existed (or produced by publish-time compression).
 async fn write_zfile_memory_lower(path: &Path) -> Result<()> {
     let data = Arc::new(LocalFile::new(path.with_extension("data"))?);
     let index = Arc::new(LocalFile::new(path.with_extension("index"))?);
@@ -50,10 +56,46 @@ async fn write_zfile_memory_lower(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Write a raw (uncompressed) sealed LSMT layer with constant pages, matching
+/// what every capture writes now that capture-time compression has been
+/// removed. Constant content keeps the publish-compression size assertions
+/// robust: the recontainerized ZFile is dramatically smaller than the raw
+/// commit.
+async fn write_raw_lsmt_lower(path: &Path, page_byte: u8) -> Result<()> {
+    let data = Arc::new(LocalFile::new(path.with_extension("data"))?);
+    let index = Arc::new(LocalFile::new(path.with_extension("index"))?);
+    let layer = LSMTFile::create(data, Some(index), 2 * 4096, false).await?;
+    layer.write_at(0, &[page_byte; 4096]).await?;
+    layer.write_at(4096, &[page_byte; 4096]).await?;
+    let output = Arc::new(LocalFile::new(path)?);
+    layer.commit_with_args(CommitArgs::new(output)).await?;
+    Ok(())
+}
+
+/// Read a sealed layer's full logical contents through the same tar + switch
+/// chain the runtime uses, transparently handling raw and ZFile layers.
+async fn read_lsmt_contents(path: &Path) -> Result<Vec<u8>> {
+    let local: Arc<dyn VirtualFile> = Arc::new(LocalFile::open_ro(path)?);
+    let display = path.display().to_string();
+    let tar_adapted = new_tar_file_adaptor(local).await?;
+    let switched = new_switch_file(tar_adapted, true, Some(&display)).await?;
+    let layer = LSMTReadOnlyFile::open(switched).await?;
+    Ok(layer.read_at(0, 2 * 4096).await?.to_vec())
+}
+
+fn digest_for_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
 /// Returns the rootfs/memory lower digests, the memory lower path, and the
 /// manifest. The memory lower is a real ZFile layer referenced without
-/// digest/size in the image config, matching the production publish path for
-/// freshly written memory lowers (digest is derived from the physical bytes).
+/// digest/size in the image config, so the publish path derives the digest by
+/// hashing the physical bytes. Capture-time compression was removed, so
+/// freshly captured memory lowers are raw; this pre-compressed fixture covers
+/// the publish path's idempotent passthrough of already-compressed layers
+/// (found in repositories published while capture-time compression existed).
 async fn write_built_artifacts(
     root: &Path,
 ) -> Result<(String, String, PathBuf, FirecrackerSnapshotManifest)> {
@@ -73,9 +115,35 @@ async fn write_built_artifacts(
 }
 
 fn digest_for_file(path: &Path) -> Result<String> {
-    let mut hasher = Sha256::new();
-    hasher.update(std::fs::read(path)?);
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    Ok(digest_for_bytes(&std::fs::read(path)?))
+}
+
+/// Build mock snapshot artifacts whose rootfs and memory lowers are real raw
+/// sealed LSMT layers, matching what captures write now that capture-time
+/// compression has been removed. Returns the lower paths and the manifest.
+async fn write_raw_built_artifacts(
+    root: &Path,
+) -> Result<(PathBuf, PathBuf, FirecrackerSnapshotManifest)> {
+    let (_, _, manifest) = write_mock_built_artifacts(root)?;
+    let rootfs_lower = root.join("base.raw.commit");
+    let memory_lower = root.join("mem.raw.commit");
+    write_raw_lsmt_lower(&rootfs_lower, 0x5A).await?;
+    write_raw_lsmt_lower(&memory_lower, 0xA5).await?;
+    let rootfs_size = std::fs::metadata(&rootfs_lower)?.len();
+    std::fs::write(
+        root.join(SNAPSHOT_ARTIFACT_LAYOUT.rootfs_image_config),
+        format!(
+            r#"{{"lowers":[{{"file":"{}","digest":"{}","size":{}}}]}}"#,
+            rootfs_lower.display(),
+            digest_for_file(&rootfs_lower)?,
+            rootfs_size,
+        ),
+    )?;
+    std::fs::write(
+        &manifest.memory.image_config_path,
+        format!(r#"{{"lowers":[{{"file":"{}"}}]}}"#, memory_lower.display()),
+    )?;
+    Ok((rootfs_lower, memory_lower, manifest))
 }
 
 fn ensure_test_config() -> Result<()> {
@@ -140,7 +208,15 @@ async fn snapshot_oss_publish_and_resolve_remote_managed_layers() -> Result<()> 
     ensure_test_config()?;
 
     let cache_root = workspace.path().join("oss-cache");
-    let (repository, resolver) = OssBackend::new(&oss, cache_root)?.into_parts();
+    let (repository, resolver) = OssBackend::new_with_publish_compression(
+        &oss,
+        cache_root,
+        &SnapshotPublishCompressionConfig {
+            enabled: false,
+            ..Default::default()
+        },
+    )?
+    .into_parts();
     let artifacts_root = workspace.path().join("local-artifacts");
     let (rootfs_digest, memory_digest, memory_lower_path, manifest) =
         write_built_artifacts(&artifacts_root).await?;
@@ -249,6 +325,135 @@ async fn snapshot_oss_publish_and_resolve_remote_managed_layers() -> Result<()> 
     Ok(())
 }
 
+/// With `[snapshot.publish_compression]` enabled, raw local layers are
+/// recontainerized as ZFile once during upload: committed digest/size
+/// describe the compressed bytes, the compressed object is clearly smaller
+/// than the raw layer, and resolution references the compressed bytes.
+#[tokio::test]
+#[ignore = "requires docker"]
+async fn snapshot_oss_publish_compresses_raw_layers_when_enabled() -> Result<()> {
+    let fixture = MinioFixture::start().await?;
+    let workspace = TempDir::new()?;
+    let prefix = "snapshots/e2e-publish-compression";
+    let oss = test_oss_config(&fixture, prefix);
+    ensure_test_config()?;
+
+    let cache_root = workspace.path().join("oss-cache");
+    let (repository, resolver) = OssBackend::new_with_publish_compression(
+        &oss,
+        cache_root,
+        &SnapshotPublishCompressionConfig {
+            enabled: true,
+            algorithm: OverlaybdCompressionAlgorithm::Lz4,
+            workers: 1,
+        },
+    )?
+    .into_parts();
+    let artifacts_root = workspace.path().join("local-artifacts");
+    let (rootfs_lower, memory_lower, manifest) = write_raw_built_artifacts(&artifacts_root).await?;
+    let raw_rootfs_digest = digest_for_file(&rootfs_lower)?;
+    let raw_memory_digest = digest_for_file(&memory_lower)?;
+    let raw_memory_size = std::fs::metadata(&memory_lower)?.len();
+    let snapshot_id = SnapshotId::generate();
+
+    let stored = repository
+        .publish(
+            SnapshotPublishMetadata {
+                id: snapshot_id,
+                alias: None,
+                source: SnapshotPublishSource::Template,
+                context: agentenv::snapshot::CommandContext::default(),
+                startup: None,
+                resources: SandboxResources::default(),
+                runtime_versions: test_runtime_versions(),
+                virtualization_mode: ConfigManager::global_config().virtualization_mode,
+                image_configs: agentenv::types::ImageConfigs::new(),
+                volume_snapshots: Vec::new(),
+                custom_extension_params: None,
+            },
+            manifest,
+        )
+        .await?;
+
+    let committed = stored
+        .committed
+        .as_ref()
+        .expect("published snapshot should be committed");
+
+    // Every committed layer reference must describe the uploaded compressed
+    // bytes, not the raw local files. ZFile layers carry no LSMT uuid.
+    let managed_rootfs = match committed.rootfs_layers.as_slice() {
+        [OverlaybdLayerRef::Managed(layer)] => layer.clone(),
+        other => panic!("expected one managed rootfs layer, got {other:?}"),
+    };
+    assert_ne!(managed_rootfs.digest, raw_rootfs_digest);
+    assert!(managed_rootfs.uuid.is_none());
+    assert_eq!(committed.memory_layers.len(), 1);
+    let managed_memory = committed.memory_layers[0].clone();
+    assert_ne!(managed_memory.digest, raw_memory_digest);
+    assert!(managed_memory.uuid.is_none());
+    assert!(
+        managed_memory.size * 2 < raw_memory_size,
+        "compressed memory layer ({} bytes) should be clearly smaller than the raw layer ({} bytes)",
+        managed_memory.size,
+        raw_memory_size,
+    );
+
+    // The uploaded objects are ZFile artifacts whose physical bytes match the
+    // committed digest/size and decode to the raw layers' logical contents.
+    for (managed, raw_path) in [
+        (&managed_rootfs, &rootfs_lower),
+        (&managed_memory, &memory_lower),
+    ] {
+        let object_bytes = fixture
+            .client
+            .get_object()
+            .bucket(&fixture.bucket)
+            .key(format!("{prefix}/managed-layers/{}", managed.digest))
+            .send()
+            .await?
+            .body
+            .collect()
+            .await?
+            .into_bytes();
+        assert_eq!(object_bytes.len() as u64, managed.size);
+        assert_eq!(digest_for_bytes(&object_bytes), managed.digest);
+        let object_path = workspace.path().join(format!(
+            "uploaded-{}.commit",
+            managed.digest.replace(':', "_")
+        ));
+        std::fs::write(&object_path, &object_bytes)?;
+        let probe: Arc<dyn VirtualFile> = Arc::new(LocalFile::open_ro(&object_path)?);
+        assert_eq!(
+            is_zfile(probe).await?,
+            1,
+            "uploaded managed layer {} must be a ZFile artifact",
+            managed.digest,
+        );
+        assert_eq!(
+            read_lsmt_contents(&object_path).await?,
+            read_lsmt_contents(raw_path).await?,
+            "compressed layer must decode to the raw layer's logical contents",
+        );
+    }
+
+    // Resolution succeeds and references the compressed bytes remotely.
+    let runnable = resolver.resolve(Arc::new(stored)).await?;
+    let mem_config: serde_json::Value = serde_json::from_slice(&std::fs::read(
+        runnable.manifest().memory.image_config_path.as_path(),
+    )?)?;
+    assert_eq!(mem_config["lowers"][0]["digest"], managed_memory.digest);
+    assert_eq!(mem_config["lowers"][0]["size"], managed_memory.size);
+    assert_eq!(mem_config["lowers"][0]["file"], "");
+    let rootfs_config: serde_json::Value = serde_json::from_slice(&std::fs::read(
+        runnable.manifest().rootfs.image_config_path.as_path(),
+    )?)?;
+    assert_eq!(rootfs_config["lowers"][0]["digest"], managed_rootfs.digest);
+    assert_eq!(rootfs_config["lowers"][0]["file"], "");
+
+    Ok(())
+}
+
 #[tokio::test]
 #[ignore = "requires docker"]
 async fn snapshot_oss_resolve_alias_cleans_up_stale_binding() -> Result<()> {
@@ -258,7 +463,15 @@ async fn snapshot_oss_resolve_alias_cleans_up_stale_binding() -> Result<()> {
     let oss = test_oss_config(&fixture, prefix);
     ensure_test_config()?;
 
-    let (repository, _) = OssBackend::new(&oss, workspace.path().join("oss-cache"))?.into_parts();
+    let (repository, _) = OssBackend::new_with_publish_compression(
+        &oss,
+        workspace.path().join("oss-cache"),
+        &SnapshotPublishCompressionConfig {
+            enabled: false,
+            ..Default::default()
+        },
+    )?
+    .into_parts();
     let artifacts_root = workspace.path().join("local-artifacts");
     let (_, _, _, manifest) = write_built_artifacts(&artifacts_root).await?;
     let alias = SnapshotAlias::parse("stale-alias").expect("alias should parse");
@@ -314,8 +527,15 @@ async fn snapshot_oss_resolve_reports_missing_managed_layer() -> Result<()> {
     let oss = test_oss_config(&fixture, prefix);
     ensure_test_config()?;
 
-    let (repository, resolver) =
-        OssBackend::new(&oss, workspace.path().join("oss-cache"))?.into_parts();
+    let (repository, resolver) = OssBackend::new_with_publish_compression(
+        &oss,
+        workspace.path().join("oss-cache"),
+        &SnapshotPublishCompressionConfig {
+            enabled: false,
+            ..Default::default()
+        },
+    )?
+    .into_parts();
     let artifacts_root = workspace.path().join("local-artifacts");
     let (rootfs_digest, _, _, manifest) = write_built_artifacts(&artifacts_root).await?;
     let snapshot_id = SnapshotId::generate();
@@ -374,7 +594,15 @@ async fn snapshot_oss_delete_by_alias_removes_manifest_and_listing() -> Result<(
     let oss = test_oss_config(&fixture, prefix);
     ensure_test_config()?;
 
-    let (repository, _) = OssBackend::new(&oss, workspace.path().join("oss-cache"))?.into_parts();
+    let (repository, _) = OssBackend::new_with_publish_compression(
+        &oss,
+        workspace.path().join("oss-cache"),
+        &SnapshotPublishCompressionConfig {
+            enabled: false,
+            ..Default::default()
+        },
+    )?
+    .into_parts();
     let artifacts_root = workspace.path().join("local-artifacts");
     let (_, _, _, manifest) = write_built_artifacts(&artifacts_root).await?;
     let alias = SnapshotAlias::parse("delete-me").expect("alias should parse");

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -403,6 +403,28 @@ Source-registry image publication. Only takes effect when `snapshot.repository_b
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | When enabled, publishing a snapshot also pushes its rootfs as an OverlayBD-native OCI image tag `agentenv-snapshot-{snapshot_id}` to the original source registry. Requires source images to be OverlayBD-native in that registry and push credentials in the Docker config (`~/.docker/config.json`). Existing remote layers are referenced by digest; only new delta layers are uploaded. The published reference is exposed as `imageRef` in snapshot APIs. Memory and VM-state artifacts always remain in the snapshot repository. |
 
+## `[snapshot.publish_compression]`
+
+Publish-time compression for snapshot layers uploaded to OSS/ACR. Local layers
+always stay raw, so local resume pays no decompression cost; enabled by default,
+memory layers and incremental read-write layers are compressed once as they
+are uploaded, cutting network bytes for cross-node resume. This is the only
+compression switch; the legacy capture-time knobs under `[memory_snapshot]`
+and `[template_build]` were removed from the configuration schema.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Compress memory layers and incremental read-write layers when uploading them to OSS/ACR. |
+| `algorithm` | string | `"lz4"` | Compression algorithm. Valid values are only `lz4` and `zstd`. |
+| `workers` | integer | `1` | Number of blocking threads used to compress 4 KiB blocks within a layer. `1` is sequential; higher values run in parallel without changing the output layout. Clamped to 64. |
+
+Known impact: compressed layers are recorded without a layer uuid (ZFile
+layers carry no LSMT uuid), so P2P uuid-keyed acceleration does not apply to
+them. Snapshot P2P publication also skips digest-keyed advertisements for
+local raw layers whose digest is absent from the committed record — the
+record names the compressed bytes, so the raw digest key would never be
+looked up by consumers.
+
 ## `[backend.posix_fs]`
 
 POSIX filesystem-backed snapshot repository configuration. This section is used when `snapshot.repository_backend = "posix_fs"`.
@@ -524,8 +546,6 @@ the default path on every startup.
 |-----|------|---------|-------------|
 | `overlaybd_global_config_path` | string | `"$AENV_HOME/overlaybd/mem-overlaybd-global.json"` | Path to the overlaybd global config used for the memory-snapshot ublk backend. Regenerated at startup (manual edits are overwritten); change only to relocate the generated file. |
 | `track_dirty_pages` | bool | `true` | Enable Firecracker KVM dirty-page tracking for memory snapshots. PVM automatically disables it because this combination has not been tested. Memory snapshot packaging always uses the direct OverlayBD path. Set `AGENTENV_MEMORY_SNAPSHOT_TRACK_DIRTY_PAGES=false` to disable it. |
-| `compression_enabled` | bool | `false` | Enable compression for memory snapshot layers. When disabled, `compression_algorithm` is still parsed but has no effect. This setting affects only memory layers; the physical file name remains `overlaybd.commit`. |
-| `compression_algorithm` | string | `"lz4"` | Compression algorithm for memory snapshot layers. Valid values are only `lz4` and `zstd`. |
 
 ## `[memory_snapshot.background_download]`
 
@@ -565,17 +585,3 @@ and are then re-fetched on demand.
 | `block_size` | integer | `16777216` | Background download chunk size in bytes (16 MiB): one source request fetches a chunk of this size, aligned down to whole cache blocks. The cache keeps its own smaller block size for foreground reads, so background downloads keep large-request throughput while foreground keeps fine-grained on-demand reads. Peak scratch per active layer download is `block_size × concurrency`. |
 | `concurrency` | integer | `4` | Maximum number of in-flight block remote reads within a single remote layer. `1` keeps the historical serial behavior. Must be greater than zero. |
 | `max_inflight_blocks` | integer | `16` | Cap on concurrently downloading chunks enforced by each file-cache backend's download scheduler, shared by every concurrent layer download on that backend; bounds total scratch memory to `max_inflight_blocks` × the download chunk size (`block_size`). The value is fixed when the backend is created from the global config; a per-image `download` override never resizes the scheduler-owned cap (the first mismatch per scheduler is logged as `max_inflight_blocks_override_ignored`). Must be greater than zero. |
-
-## `[template_build]`
-
-Compression settings applied when a template build captures its snapshot.
-This section is fully independent of `[memory_snapshot].compression_enabled`:
-template builds consult only these keys, for both memory layers and the
-sealed rootfs read-write layer. Pause/snapshot captures of running sandboxes
-are not affected, and rootfs seals stay raw there.
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `compression_enabled` | bool | `false` | Enable compression for snapshot artifacts captured by template builds. When enabled, both the memory layers and the sealed rootfs read-write layer are written as ZFile-compressed layers. |
-| `compression_algorithm` | string | `"lz4"` | Compression algorithm. Valid values are only `lz4` and `zstd`. Parsed but ignored when compression is disabled. |
-| `compression_workers` | integer | `1` | Number of blocking threads used to compress 4 KiB blocks within a layer. `1` is sequential; higher values run in parallel without changing the output layout. Clamped to 64. |

--- a/docs/src/internals/p2p-design.md
+++ b/docs/src/internals/p2p-design.md
@@ -138,6 +138,8 @@ Snapshot publication advertises:
   - `firecracker-manifest.json` is serialized from the committed manifest and published as bytes.
 - Overlaybd layers referenced by the snapshot's rootfs, memory, and attached-drive image configs. These are not published under a snapshot-specific key. They reuse the overlaybd layer artifact protocol owned by `src/overlaybd/p2p/artifact.rs`, with keys like `overlaybd-layer/v1/sha256:<digest>` and `LayerMetadata` understood by the overlaybd HTTP facade.
 
+Digest-keyed layer publication is guarded against the committed record: a local layer is only advertised under `overlaybd-layer/v1/sha256:<digest>` when that digest is one the committed record references for the same subject (memory, rootfs, or the matching attached drive). When `[snapshot.publish_compression]` recontainerizes a raw local layer as ZFile during upload, the record names the compressed bytes, so the raw layer's digest key is skipped rather than advertised under a key no consumer will look up. ZFile layers also carry no LSMT uuid (`uuid = None` in the committed record), so uuid-keyed acceleration never applies to recontainerized layers.
+
 That split is important. Snapshot fixed artifacts are scoped to one snapshot ID and are only consumed by snapshot runtime resolvers. Overlaybd commit layers are content-addressed and may be consumed by any overlaybd runtime path, including foreground range reads through `/p2p-http/{origin}`. Do not add a second snapshot-specific key format for overlaybd layers; doing so publishes bytes that overlaybd cannot discover.
 
 OSS snapshot resolution consumes fixed artifacts through P2P first:

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -128,8 +128,6 @@ pub struct AppConfig {
     #[config(nested)]
     pub memory_snapshot: MemorySnapshotConfig,
     #[config(nested)]
-    pub template_build: TemplateBuildConfig,
-    #[config(nested)]
     pub pool: PoolTomlConfig,
     #[config(nested)]
     pub p2p: P2pConfig,
@@ -354,12 +352,30 @@ pub struct SnapshotConfig {
     pub p2p_enabled: bool,
     #[config(nested)]
     pub image_publish: SnapshotImagePublishConfig,
+    #[config(nested)]
+    pub publish_compression: SnapshotPublishCompressionConfig,
 }
 
 #[derive(Debug, Config, Clone)]
 pub struct SnapshotImagePublishConfig {
     #[config(default = false)]
     pub enabled: bool,
+}
+
+/// Publish-time compression for snapshot layers uploaded to OSS/ACR. Local
+/// layers always stay raw so local resume pays no decompression cost; when
+/// enabled, memory layers and incremental read-write layers are compressed
+/// once as they are uploaded, cutting network bytes for cross-node resume.
+#[derive(Debug, Config, Clone)]
+pub struct SnapshotPublishCompressionConfig {
+    #[config(default = true)]
+    pub enabled: bool,
+    #[config(default = "lz4")]
+    pub algorithm: OverlaybdCompressionAlgorithm,
+    /// Number of blocking threads used to compress 4KiB blocks within a
+    /// layer. 1 = sequential (identical output layout at any value).
+    #[config(default = 1)]
+    pub workers: usize,
 }
 
 /// Bucket addressing style for the S3-compatible snapshot backend.
@@ -467,31 +483,8 @@ pub struct MemorySnapshotConfig {
     /// Default: true; set the environment variable to false to use mincore.
     #[config(env = "AGENTENV_MEMORY_SNAPSHOT_TRACK_DIRTY_PAGES", default = true)]
     pub track_dirty_pages: bool,
-    #[config(default = false)]
-    pub compression_enabled: bool,
-    #[config(default = "lz4")]
-    pub compression_algorithm: OverlaybdCompressionAlgorithm,
-    /// Number of blocking threads used to compress 4KiB blocks within a
-    /// memory layer. 1 = sequential (identical output layout at any value).
-    #[config(default = 1)]
-    pub compression_workers: usize,
     #[config(nested)]
     pub background_download: MemorySnapshotBackgroundDownloadConfig,
-}
-
-/// Compression settings applied when a template build captures its snapshot.
-/// Independent of `[memory_snapshot]`: template builds consult only this
-/// section, for both memory layers and the sealed rootfs read-write layer.
-#[derive(Debug, Config, Clone)]
-pub struct TemplateBuildConfig {
-    #[config(default = false)]
-    pub compression_enabled: bool,
-    #[config(default = "lz4")]
-    pub compression_algorithm: OverlaybdCompressionAlgorithm,
-    /// Number of blocking threads used to compress 4KiB blocks within a
-    /// layer. 1 = sequential (identical output layout at any value).
-    #[config(default = 1)]
-    pub compression_workers: usize,
 }
 
 #[derive(Debug, Config, Clone)]
@@ -657,6 +650,7 @@ impl_config_default!(
     MachineConfig,
     SnapshotConfig,
     SnapshotImagePublishConfig,
+    SnapshotPublishCompressionConfig,
     UblkTomlConfig,
     UblkOverlaybdTomlConfig,
     MemorySnapshotConfig,

--- a/src/image/local_layer.rs
+++ b/src/image/local_layer.rs
@@ -4,8 +4,10 @@ use overlaybd::config::LayerConfig;
 
 const SNAPSHOT_DELTA_LAYER_FILE: &str = "snapshot.commit";
 const SELF_CONTAINED_BASE_LAYER_FILE: &str = "managed-base.commit";
-/// ZFile-recontainerized variant of [`SNAPSHOT_DELTA_LAYER_FILE`], produced
-/// when a template build requests compressed seal output.
+/// ZFile-recontainerized variant of [`SNAPSHOT_DELTA_LAYER_FILE`]. No longer
+/// produced: capture-time compression was removed and local layers always
+/// stay raw. Kept in the delta allowlist so layers in repositories published
+/// while the old capture-time switches existed are still recognized.
 pub(crate) const SNAPSHOT_ZFILE_DELTA_LAYER_FILE: &str = "snapshot.zfile.commit";
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/sandbox/firecracker/overlaybd_snapshot.rs
+++ b/src/sandbox/firecracker/overlaybd_snapshot.rs
@@ -5,10 +5,9 @@
 //! `close_seal + restack` the live upper before writing the persisted
 //! snapshot config.
 //!
-//! Sealed layers stay raw by default. Callers (template builds) may request
-//! compressed seal output, in which case only the staged snapshot artifact
-//! is recontainerized as ZFile — the live runtime keeps referencing the raw
-//! sealed layer written by the daemon.
+//! Sealed layers always stay raw locally: compression, when enabled via
+//! `[snapshot.publish_compression]`, happens once at publish time when the
+//! snapshot repository uploads layers to OSS/ACR.
 //!
 use std::ffi::OsStr;
 use std::fs;
@@ -30,7 +29,6 @@ use tracing::{debug, warn};
 use super::process_vm_reader::ProcessVmReader;
 use super::sandbox::managed_snapshot_base;
 use crate::cfg::ConfigManager;
-use crate::image::local_layer::SNAPSHOT_ZFILE_DELTA_LAYER_FILE;
 use crate::sandbox::ublk::UblkDevice;
 use crate::sandbox::ublk::{
     compact_layers, create_commit_args, OverlaybdCompactOutput, UblkDeviceManager,
@@ -342,7 +340,6 @@ pub(super) async fn stage_overlaybd_snapshot_from_live_runtime(
     live_runtime_image_config_path: &Path,
     output_dir: &Path,
     snapshot_layer_path: Option<&Path>,
-    seal_output: OverlaybdCompactOutput,
 ) -> Result<PathBuf> {
     tokio::fs::create_dir_all(output_dir)
         .await
@@ -377,30 +374,14 @@ pub(super) async fn stage_overlaybd_snapshot_from_live_runtime(
         None
     };
 
-    // Compress the freshly sealed layer when the caller requested compressed
-    // seal output. The live runtime config was already rewritten to reference
-    // the raw sealed layer; only the staged snapshot artifact is
-    // recontainerized as ZFile.
-    let appended_layer = match (appended_layer, seal_output) {
-        (Some(layer), OverlaybdCompactOutput::ZFile { .. }) => {
-            let compressed_path = output_dir.join(SNAPSHOT_ZFILE_DELTA_LAYER_FILE);
-            compact_layers(std::slice::from_ref(&layer), &compressed_path, seal_output)
-                .await
-                .context("compress sealed snapshot layer")?
-                .context("compress sealed snapshot layer produced no output")?;
-            Some(local_layer_config(&compressed_path))
-        }
-        (layer, _) => layer,
-    };
-
     let rewritten_lowers = rewrite_lowers_with_owned_runtime_suffix(
         image_config.lowers,
         output_dir,
         appended_layer,
         MANAGED_BASE_LAYER_FILE,
-        // Rootfs seals stay raw unless the caller (template builds) requested
-        // compressed seal output; memory snapshots have their own switch.
-        seal_output,
+        // Sealed rootfs layers always stay raw; compression happens once at
+        // publish time under `[snapshot.publish_compression]`.
+        OverlaybdCompactOutput::Raw,
     )
     .await?;
     image_config.lowers = rewritten_lowers;
@@ -617,9 +598,8 @@ pub(super) async fn build_mem_snapshot_image_config(
 ///
 /// Writable runtimes are first restacked in-place so the sealed old upper
 /// becomes the newest lower. Read-only runtimes skip the restack phase and
-/// only stage the persisted snapshot image config. `seal_output` controls
-/// whether the staged sealed layer is recontainerized as ZFile; the live
-/// runtime always keeps the raw sealed layer.
+/// only stage the persisted snapshot image config. The sealed layer always
+/// stays raw; compression, when enabled, happens once at publish time.
 pub(super) async fn restack_snapshot_overlaybd_device(
     ublk_device: &UblkDevice,
     read_only: bool,
@@ -627,7 +607,6 @@ pub(super) async fn restack_snapshot_overlaybd_device(
     output_dir: &Path,
     snapshot_layer_file_name: &str,
     kind: &'static str,
-    seal_output: OverlaybdCompactOutput,
 ) -> Result<PathBuf> {
     tokio::fs::create_dir_all(output_dir)
         .await
@@ -647,7 +626,6 @@ pub(super) async fn restack_snapshot_overlaybd_device(
         live_runtime_image_config_path,
         output_dir,
         live_snapshot.snapshot_layer_path(),
-        seal_output,
     )
     .await;
 
@@ -659,7 +637,6 @@ pub(super) async fn restack_snapshot_overlaybd_rootfs(
     read_only: bool,
     live_runtime_image_config_path: &Path,
     snapshot_root: &Path,
-    seal_output: OverlaybdCompactOutput,
 ) -> Result<PathBuf> {
     restack_snapshot_overlaybd_device(
         ublk_device,
@@ -668,7 +645,6 @@ pub(super) async fn restack_snapshot_overlaybd_rootfs(
         &snapshot_root.join("rootfs"),
         "snapshot.commit",
         "rootfs",
-        seal_output,
     )
     .await
 }
@@ -1195,7 +1171,6 @@ mod tests {
             &live_runtime_image_config_path,
             &output_dir,
             Some(&snapshot_lower),
-            OverlaybdCompactOutput::Raw,
         )
         .await
         .expect("stage snapshot");
@@ -1206,97 +1181,6 @@ mod tests {
         assert_eq!(PathBuf::from(&latest.file), snapshot_lower);
         assert_eq!(latest.digest, "sha256:descriptor");
         assert_eq!(latest.size, 8);
-    }
-
-    async fn read_sealed_layer_bytes(path: &Path, len: usize) -> Vec<u8> {
-        use overlaybd::backend::switch::new_switch_file;
-        use overlaybd::backend::tar::new_tar_file_adaptor;
-        use overlaybd::index_file::LSMTReadOnlyFile;
-
-        let local: Arc<dyn VirtualFile> =
-            Arc::new(LocalFile::open_ro(path).expect("open sealed layer"));
-        let display = path.display().to_string();
-        let tar_adapted = new_tar_file_adaptor(local).await.expect("tar adaptor");
-        let switched = new_switch_file(tar_adapted, true, Some(&display))
-            .await
-            .expect("switch file");
-        let layer = LSMTReadOnlyFile::open(switched)
-            .await
-            .expect("open sealed layer as LSMT");
-        layer
-            .read_at(0, len)
-            .await
-            .expect("read sealed layer")
-            .to_vec()
-    }
-
-    #[tokio::test]
-    async fn stage_recontainerizes_sealed_layer_as_zfile_when_requested() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let live_dir = temp.path().join("live");
-        let output_dir = temp.path().join("out");
-        std::fs::create_dir_all(&live_dir).expect("create live dir");
-        std::fs::create_dir_all(&output_dir).expect("create output dir");
-
-        let vsize = 3 * 4096u64;
-        let sealed_path =
-            seal_raw_test_layer(&output_dir, "snapshot", vsize, &[(0, 0xAB), (4096, 0xCD)]).await;
-        let live_runtime_image_config_path = live_dir.join("image.json");
-        std::fs::write(
-            &live_runtime_image_config_path,
-            serde_json::to_vec_pretty(&json!({
-                "repoBlobUrl": "s3://bucket/prefix",
-                "lowers": [
-                    {
-                        "digest": "sha256:base",
-                        "size": 10
-                    },
-                    {
-                        "file": sealed_path,
-                    }
-                ],
-                "upper": {},
-                "resultFile": live_dir.join("result.txt"),
-                "download": {}
-            }))
-            .expect("serialize live image config"),
-        )
-        .expect("write live image config");
-
-        let output_path = stage_overlaybd_snapshot_from_live_runtime(
-            &live_runtime_image_config_path,
-            &output_dir,
-            Some(&sealed_path),
-            OverlaybdCompactOutput::ZFile {
-                algorithm: crate::cfg::OverlaybdCompressionAlgorithm::Lz4,
-                workers: 1,
-            },
-        )
-        .await
-        .expect("stage snapshot with compressed seal");
-
-        let staged =
-            overlaybd::config::load_image_config(&output_path).expect("load staged image config");
-        assert_eq!(staged.lowers.len(), 2);
-        assert_eq!(staged.lowers[0].digest, "sha256:base");
-
-        let staged_layer = PathBuf::from(&staged.lowers[1].file);
-        assert!(staged_layer.ends_with(SNAPSHOT_ZFILE_DELTA_LAYER_FILE));
-        let staged_file: Arc<dyn VirtualFile> =
-            Arc::new(LocalFile::open_ro(&staged_layer).expect("open staged zfile layer"));
-        assert_eq!(
-            overlaybd::zfile::is_zfile(staged_file)
-                .await
-                .expect("probe staged layer"),
-            1
-        );
-
-        // The live runtime's raw sealed layer is untouched, and the staged
-        // ZFile layer carries identical logical content.
-        assert_eq!(
-            read_sealed_layer_bytes(&staged_layer, vsize as usize).await,
-            read_sealed_layer_bytes(&sealed_path, vsize as usize).await
-        );
     }
 
     #[tokio::test]

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -198,10 +198,6 @@ pub struct FirecrackerSandbox {
     initial_guest_drive_mounts: Vec<(usize, ExtraDrive)>,
     current_rootfs_virtual_size: Option<u64>,
     live_snapshot_root: Option<Arc<PersistentSnapshotRootGuard>>,
-    /// Per-snapshot compression override. Template builds set this to isolate
-    /// their compression switch from `[memory_snapshot]`; when unset, memory
-    /// layers follow `[memory_snapshot]` and rootfs seals stay raw.
-    snapshot_compression_override: Option<OverlaybdCompactOutput>,
     /// Delivers the custom extension stop hook exactly once: `stop()` calls
     /// [`CustomExtensionHookGuard::stop`], otherwise its own drop fires the
     /// best-effort notification. `None` when no start hook was delivered (or
@@ -940,14 +936,6 @@ impl FirecrackerSandbox {
         Ok(snapshot)
     }
 
-    /// Override the compression applied to snapshot artifacts captured by this
-    /// sandbox. Template builds use this to isolate their compression switch
-    /// from `[memory_snapshot]`; when unset, memory layers follow
-    /// `[memory_snapshot]` and rootfs seals stay raw.
-    pub(crate) fn set_snapshot_compression_override(&mut self, output: OverlaybdCompactOutput) {
-        self.snapshot_compression_override = Some(output);
-    }
-
     /// Pause the running sandbox and persist its snapshot artifacts into a caller-managed directory.
     #[tracing::instrument(skip(self, snapshot_dir))]
     pub async fn pause_to_dir(
@@ -983,13 +971,10 @@ impl FirecrackerSandbox {
         snapshot_dir: &Path,
     ) -> Result<(FirecrackerSnapshotConfig, FirecrackerSnapshotManifest)> {
         let vm_state_path = snapshot_dir.join(VM_STATE_FILE_NAME);
-        let memory_output = self.snapshot_compression_override.unwrap_or_else(|| {
-            OverlaybdCompactOutput::from_memory_snapshot_config(
-                &ConfigManager::global_config().memory_snapshot,
-            )
-        });
+        // Local layers are always captured raw; when enabled, compression
+        // happens once at publish time under `[snapshot.publish_compression]`.
         let (mem_layer_path, mem_virtual_size) = self
-            .snapshot_memory_to_overlaybd(&vm_state_path, snapshot_dir, memory_output)
+            .snapshot_memory_to_overlaybd(&vm_state_path, snapshot_dir, OverlaybdCompactOutput::Raw)
             .await?;
 
         // Build the memory image config: collect parent layers, make runtime
@@ -1005,7 +990,7 @@ impl FirecrackerSandbox {
             resume_mem_image_config_path,
             &mem_layer_path,
             snapshot_dir,
-            memory_output,
+            OverlaybdCompactOutput::Raw,
         )
         .await?;
         let mem_image_config_path = snapshot_dir.join("mem_image.json");
@@ -1047,10 +1032,6 @@ impl FirecrackerSandbox {
                 overlaybd_source.read_only,
                 &rootfs_runtime.image_config_path,
                 snapshot_dir,
-                // Rootfs seals stay raw unless a per-sandbox override
-                // (template builds) requests compression.
-                self.snapshot_compression_override
-                    .unwrap_or(OverlaybdCompactOutput::Raw),
             )
             .await
             .context("snapshot overlaybd runtime state to persistent dir")?;
@@ -1503,7 +1484,6 @@ impl FirecrackerSandbox {
             extra_drive_runtimes: Vec::new(),
             initial_guest_drive_mounts: Vec::new(),
             live_snapshot_root: None,
-            snapshot_compression_override: None,
             custom_extension_hook_guard: None,
         })
     }
@@ -2286,8 +2266,6 @@ impl FirecrackerSandbox {
                 &output_dir,
                 &snapshot_layer_file_name,
                 "drive",
-                // Attached drive seals always stay raw.
-                OverlaybdCompactOutput::Raw,
             )
             .await
             .with_context(|| format!("snapshot extra drive '{}'", drive.drive_id()))?;
@@ -2333,8 +2311,6 @@ impl FirecrackerSandbox {
                 output_dir,
                 &snapshot_layer_file_name,
                 "volume",
-                // Persistent volume seals always stay raw.
-                OverlaybdCompactOutput::Raw,
             )
             .await
             .with_context(|| format!("snapshot persistent volume '{}'", drive.drive_id()))?;

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -40,7 +40,7 @@ pub use network::{
     ALL_INTERNET_TRAFFIC_CIDR,
 };
 pub use process::{Executor, ProcessHandle, ProcessOpts, ProcessOutput};
-pub(crate) use ublk::OverlaybdCompactOutput;
+pub(crate) use ublk::{compact_layers, OverlaybdCompactOutput};
 pub use ublk::{OverlaybdConfig, UblkBackend, UblkConfig, UblkDaemonConfig, UblkDeviceManager};
 
 #[derive(Clone, Debug)]

--- a/src/sandbox/ublk/overlaybd.rs
+++ b/src/sandbox/ublk/overlaybd.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 use uuid::Uuid;
 
 use super::device::UblkDevice;
-use crate::cfg::{MemorySnapshotConfig, OverlaybdCompressionAlgorithm, TemplateBuildConfig};
+use crate::cfg::{OverlaybdCompressionAlgorithm, SnapshotPublishCompressionConfig};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum OverlaybdCompactOutput {
@@ -25,34 +25,19 @@ pub(crate) enum OverlaybdCompactOutput {
 
 impl OverlaybdCompactOutput {
     /// Maximum persistent compression threads. Prevents absurd config values
-    /// from spawning thousands of OS threads during a production pause.
+    /// from spawning thousands of OS threads during layer upload.
     const MAX_COMPRESSION_WORKERS: usize = 64;
 
-    pub(crate) fn from_memory_snapshot_config(config: &MemorySnapshotConfig) -> Self {
-        Self::from_compression_parts(
-            config.compression_enabled,
-            config.compression_algorithm,
-            config.compression_workers,
-        )
-    }
-
-    pub(crate) fn from_template_build_config(config: &TemplateBuildConfig) -> Self {
-        Self::from_compression_parts(
-            config.compression_enabled,
-            config.compression_algorithm,
-            config.compression_workers,
-        )
-    }
-
-    fn from_compression_parts(
-        enabled: bool,
-        algorithm: OverlaybdCompressionAlgorithm,
-        workers: usize,
+    /// Resolve the `[snapshot.publish_compression]` switch into the layer
+    /// output mode applied when recontainerizing local raw layers for upload.
+    /// Capture paths never consult this: local layers always stay raw.
+    pub(crate) fn from_publish_compression_config(
+        config: &SnapshotPublishCompressionConfig,
     ) -> Self {
-        if enabled {
+        if config.enabled {
             Self::ZFile {
-                algorithm,
-                workers: workers.clamp(1, Self::MAX_COMPRESSION_WORKERS),
+                algorithm: config.algorithm,
+                workers: config.workers.clamp(1, Self::MAX_COMPRESSION_WORKERS),
             }
         } else {
             Self::Raw
@@ -346,38 +331,38 @@ mod tests {
     }
 
     #[test]
-    fn compact_output_from_template_build_config() {
-        let disabled = TemplateBuildConfig {
-            compression_enabled: false,
-            compression_algorithm: OverlaybdCompressionAlgorithm::Lz4,
-            compression_workers: 1,
+    fn compact_output_from_publish_compression_config() {
+        let disabled = SnapshotPublishCompressionConfig {
+            enabled: false,
+            algorithm: OverlaybdCompressionAlgorithm::Lz4,
+            workers: 1,
         };
         assert_eq!(
-            OverlaybdCompactOutput::from_template_build_config(&disabled),
+            OverlaybdCompactOutput::from_publish_compression_config(&disabled),
             OverlaybdCompactOutput::Raw
         );
 
-        let zstd = TemplateBuildConfig {
-            compression_enabled: true,
-            compression_algorithm: OverlaybdCompressionAlgorithm::Zstd,
+        let zstd = SnapshotPublishCompressionConfig {
+            enabled: true,
+            algorithm: OverlaybdCompressionAlgorithm::Zstd,
             // Zero workers clamps to sequential.
-            compression_workers: 0,
+            workers: 0,
         };
         assert_eq!(
-            OverlaybdCompactOutput::from_template_build_config(&zstd),
+            OverlaybdCompactOutput::from_publish_compression_config(&zstd),
             OverlaybdCompactOutput::ZFile {
                 algorithm: OverlaybdCompressionAlgorithm::Zstd,
                 workers: 1,
             }
         );
 
-        let clamped = TemplateBuildConfig {
-            compression_enabled: true,
-            compression_algorithm: OverlaybdCompressionAlgorithm::Lz4,
-            compression_workers: usize::MAX,
+        let clamped = SnapshotPublishCompressionConfig {
+            enabled: true,
+            algorithm: OverlaybdCompressionAlgorithm::Lz4,
+            workers: usize::MAX,
         };
         assert_eq!(
-            OverlaybdCompactOutput::from_template_build_config(&clamped),
+            OverlaybdCompactOutput::from_publish_compression_config(&clamped),
             OverlaybdCompactOutput::ZFile {
                 algorithm: OverlaybdCompressionAlgorithm::Lz4,
                 workers: OverlaybdCompactOutput::MAX_COMPRESSION_WORKERS,

--- a/src/snapshot/image_export/service.rs
+++ b/src/snapshot/image_export/service.rs
@@ -75,6 +75,7 @@ impl SnapshotImageService {
                         config.backend.oss.as_ref().context(
                             "backend.oss config is required when repository_backend = oss",
                         )?;
+                    let publish_compression = &config.snapshot.publish_compression;
                     let policy = if config.snapshot.image_publish.enabled {
                         SnapshotImageStoragePolicy::SourceRegistry
                     } else {
@@ -92,6 +93,7 @@ impl SnapshotImageService {
                     let repository = Arc::new(oss::OssSnapshotRepository::new(
                         Arc::clone(&client),
                         config.snapshot_image_storage(),
+                        publish_compression,
                     ));
                     (repository, ManagedLayerLocator::Oss { client })
                 }

--- a/src/snapshot/manager.rs
+++ b/src/snapshot/manager.rs
@@ -39,6 +39,22 @@ fn managed_layer_uuids_from_managed(layers: &[ManagedLayer]) -> HashSet<String> 
         .collect()
 }
 
+/// Every layer digest the committed record references for one snapshot
+/// subject (rootfs or one attached drive), managed and external alike.
+fn committed_layer_digests(layers: &[OverlaybdLayerRef]) -> HashSet<String> {
+    layers
+        .iter()
+        .map(|layer| match layer {
+            OverlaybdLayerRef::Managed(managed) => managed.digest.clone(),
+            OverlaybdLayerRef::External(external) => external.digest.clone(),
+        })
+        .collect()
+}
+
+fn committed_memory_layer_digests(layers: &[ManagedLayer]) -> HashSet<String> {
+    layers.iter().map(|layer| layer.digest.clone()).collect()
+}
+
 #[derive(Clone)]
 /// Coordinates committed snapshot lifecycle operations over repository-backed state.
 ///
@@ -157,28 +173,35 @@ impl SnapshotManager {
 
         // Collect any overlaybd layers referenced by this snapshot's runtime images.
         let rootfs_uuids = managed_layer_uuids(&committed.rootfs_layers);
+        let rootfs_digests = committed_layer_digests(&committed.rootfs_layers);
         artifacts.extend(SnapshotP2pArtifact::local_overlaybd_layers(
             &manifest.rootfs.image_config_path,
+            &rootfs_digests,
             &rootfs_uuids,
         ));
         let memory_uuids = managed_layer_uuids_from_managed(&committed.memory_layers);
+        let memory_digests = committed_memory_layer_digests(&committed.memory_layers);
         artifacts.extend(SnapshotP2pArtifact::local_overlaybd_layers(
             &manifest.memory.image_config_path,
+            &memory_digests,
             &memory_uuids,
         ));
         for drive in &manifest.attached_drives {
-            let drive_uuids = committed
+            let (drive_digests, drive_uuids) = committed
                 .attached_drives
                 .iter()
                 .find_map(|committed_drive| match committed_drive {
                     crate::snapshot::CommittedAttachedDrive::Overlaybd {
                         drive_id, layers, ..
-                    } if drive_id == &drive.drive_id => Some(managed_layer_uuids(layers)),
+                    } if drive_id == &drive.drive_id => {
+                        Some((committed_layer_digests(layers), managed_layer_uuids(layers)))
+                    }
                     _ => None,
                 })
                 .unwrap_or_default();
             artifacts.extend(SnapshotP2pArtifact::local_overlaybd_layers(
                 &drive.image_config_path,
+                &drive_digests,
                 &drive_uuids,
             ));
         }

--- a/src/snapshot/p2p.rs
+++ b/src/snapshot/p2p.rs
@@ -81,8 +81,23 @@ impl SnapshotP2pArtifact {
         }
     }
 
+    /// Collect the local overlaybd layers referenced by a snapshot image
+    /// config into publishable P2P artifacts.
+    ///
+    /// `committed_digests` holds every layer digest the committed record
+    /// carries for this image config's subject (memory, rootfs, or one
+    /// attached drive). A local layer is only published under its
+    /// descriptor digest when that digest is what the committed record
+    /// references: publish-time compression recontainerizes raw local layers
+    /// as zfile before upload, so the record names the compressed bytes and a
+    /// raw-digest key would never be looked up by consumers.
+    ///
+    /// `committed_uuids` gates uuid-keyed publication as before; zfile layers
+    /// record `uuid = None`, so recontainerized layers are filtered out of it
+    /// naturally.
     pub(crate) fn local_overlaybd_layers(
         image_config_path: &Path,
+        committed_digests: &HashSet<String>,
         committed_uuids: &HashSet<String>,
     ) -> Vec<Self> {
         let image_config = match load_overlaybd_image_config(image_config_path) {
@@ -107,11 +122,31 @@ impl SnapshotP2pArtifact {
 
                 let mut artifacts = Vec::new();
                 if !layer.digest.is_empty() && layer.size > 0 {
-                    artifacts.push(Self::content_addressed_overlaybd_layer(
-                        layer.file.clone(),
-                        layer.digest,
-                        layer.size,
-                    ));
+                    if committed_digests.contains(&layer.digest) {
+                        artifacts.push(Self::content_addressed_overlaybd_layer(
+                            layer.file.clone(),
+                            layer.digest,
+                            layer.size,
+                        ));
+                    } else {
+                        // The committed record references different bytes for
+                        // this layer, which means publish-time compression
+                        // recontainerized the local raw layer as zfile during
+                        // upload. Publishing the raw file under its raw digest
+                        // would create a key no consumer ever looks up.
+                        // TODO: propagate the uploaded (compressed) layer
+                        // paths out of repository publish so digest-keyed P2P
+                        // publication can advertise the same bytes the
+                        // committed manifest records.
+                        debug!(
+                            path = %layer.file,
+                            digest = %layer.digest,
+                            "skipping digest-keyed snapshot P2P layer publication: \
+                             layer digest is absent from the committed record, so the \
+                             layer was recontainerized during upload and the raw-digest \
+                             key would not match the manifest"
+                        );
+                    }
                 }
                 if committed_uuids.is_empty() {
                     return artifacts;
@@ -256,6 +291,8 @@ mod tests {
         write_sealed_layer(&descriptorless, uuid).await;
         std::fs::write(&described, b"described").expect("write described layer");
 
+        let described_digest =
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
         let image_config = ImageConfig {
             lowers: vec![
                 LayerConfig {
@@ -264,9 +301,7 @@ mod tests {
                 },
                 LayerConfig {
                     file: described.display().to_string(),
-                    digest:
-                        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                            .to_string(),
+                    digest: described_digest.clone(),
                     size: 9,
                     ..Default::default()
                 },
@@ -280,8 +315,11 @@ mod tests {
         )
         .expect("write image config");
 
-        let artifacts =
-            SnapshotP2pArtifact::local_overlaybd_layers(&image_config_path, &HashSet::new());
+        let artifacts = SnapshotP2pArtifact::local_overlaybd_layers(
+            &image_config_path,
+            &HashSet::from([described_digest]),
+            &HashSet::new(),
+        );
 
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].publish_mode, P2pPublishMode::Copy);
@@ -289,6 +327,58 @@ mod tests {
             artifacts[0].key,
             "overlaybd-layer/v1/sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
+    }
+
+    /// Publish-time compression recontainerizes a raw local layer before
+    /// upload, so the committed record names the compressed digest and the
+    /// raw descriptor digest must not be published: no consumer ever looks
+    /// the raw key up. The uuid-keyed publication is unaffected by the
+    /// digest guard.
+    #[tokio::test]
+    async fn local_overlaybd_layers_skips_digest_absent_from_committed_record() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let layer_path = temp.path().join("snapshot.commit");
+        let uuid = Uuid::parse_str("44444444-5555-6666-7777-888888888888").unwrap();
+        write_sealed_layer(&layer_path, uuid).await;
+        let raw_descriptor = crate::digest::FileDigest::describe(&layer_path)
+            .await
+            .expect("describe raw layer");
+        let image_config = ImageConfig {
+            lowers: vec![LayerConfig {
+                file: layer_path.display().to_string(),
+                digest: raw_descriptor.sha256.clone(),
+                size: raw_descriptor.size,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let image_config_path = temp.path().join("image.json");
+        std::fs::write(
+            &image_config_path,
+            serde_json::to_vec(&image_config).expect("serialize image config"),
+        )
+        .expect("write image config");
+        // The committed record references the recontainerized (compressed)
+        // bytes, not the raw local file.
+        let committed_digests = HashSet::from([
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        ]);
+        let committed_uuids = HashSet::from([uuid.to_string()]);
+
+        let artifacts = SnapshotP2pArtifact::local_overlaybd_layers(
+            &image_config_path,
+            &committed_digests,
+            &committed_uuids,
+        );
+
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(
+            artifacts[0].key,
+            "overlaybd-layer/v1/uuid/44444444-5555-6666-7777-888888888888"
+        );
+        assert!(!artifacts
+            .iter()
+            .any(|artifact| artifact.key == layer_key_from_digest(&raw_descriptor.sha256)));
     }
 
     #[tokio::test]
@@ -324,10 +414,14 @@ mod tests {
             serde_json::to_vec(&image_config).expect("serialize image config"),
         )
         .expect("write image config");
+        let committed_digests = HashSet::from([committed_descriptor.sha256.clone()]);
         let committed_uuids = HashSet::from([committed_uuid.to_string()]);
 
-        let artifacts =
-            SnapshotP2pArtifact::local_overlaybd_layers(&image_config_path, &committed_uuids);
+        let artifacts = SnapshotP2pArtifact::local_overlaybd_layers(
+            &image_config_path,
+            &committed_digests,
+            &committed_uuids,
+        );
 
         assert_eq!(artifacts.len(), 2);
         assert!(artifacts

--- a/src/snapshot/repository/backends/common/acr/client.rs
+++ b/src/snapshot/repository/backends/common/acr/client.rs
@@ -1088,7 +1088,7 @@ pub(super) mod tests {
     #[derive(Default)]
     pub(crate) struct FakeState {
         token_scopes: Vec<String>,
-        uploads: Vec<Vec<u8>>,
+        pub(crate) uploads: Vec<Vec<u8>>,
         upload_completes: usize,
         pub(crate) manifest_puts: Vec<Vec<u8>>,
         deletes: Vec<String>,

--- a/src/snapshot/repository/backends/common/acr/publisher.rs
+++ b/src/snapshot/repository/backends/common/acr/publisher.rs
@@ -7,6 +7,8 @@ use tempfile::NamedTempFile;
 use tracing::warn;
 
 use crate::digest;
+use crate::sandbox::OverlaybdCompactOutput;
+use crate::snapshot::repository::backends::common::recontainerize::prepare_layer_upload;
 use crate::snapshot::repository::backends::common::write_dense_overlaybd_layer_to_file;
 use crate::snapshot::repository::{RepositoryError, RepositoryResult};
 use crate::snapshot::rootfs_snapshot_image_tag;
@@ -52,21 +54,27 @@ pub(crate) struct AcrDiskImageExporter {
     // an await point; client construction happens outside the lock as well.
     clients: Mutex<HashMap<String, AcrClient>>,
     client_builder: Arc<AcrClientBuilder>,
+    publish_compression: OverlaybdCompactOutput,
 }
 
 impl AcrDiskImageExporter {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(publish_compression: OverlaybdCompactOutput) -> Self {
         Self {
             clients: Mutex::new(HashMap::new()),
             client_builder: Arc::new(AcrClient::from_docker_config),
+            publish_compression,
         }
     }
 
     #[cfg(test)]
-    fn new_with_client_builder(client_builder: Arc<AcrClientBuilder>) -> Self {
+    fn new_with_client_builder(
+        client_builder: Arc<AcrClientBuilder>,
+        publish_compression: OverlaybdCompactOutput,
+    ) -> Self {
         Self {
             clients: Mutex::new(HashMap::new()),
             client_builder,
+            publish_compression,
         }
     }
 
@@ -222,17 +230,32 @@ impl AcrDiskImageExporter {
         local: &LocalSnapshotDelta,
     ) -> RepositoryResult<(String, u64)> {
         match &local.descriptor {
-            LocalSnapshotDeltaDescriptor::Raw { digest, size } => client
-                .upload_blob_with_descriptor(
-                    upload_url,
-                    repo_blob_url,
-                    repository,
+            LocalSnapshotDeltaDescriptor::Raw { digest, size } => {
+                // Publish compression recontainerizes raw deltas as zfile,
+                // which changes the physical bytes; the returned blob digest
+                // and size (and thus the manifest's overlaybd blob
+                // annotations) always describe the uploaded bytes. ZFile
+                // inputs are uploaded unchanged, so their descriptor stays
+                // valid — the same handling pre-existing zfile deltas
+                // received.
+                let upload = prepare_layer_upload(
                     &local.path,
-                    digest,
-                    *size,
+                    self.publish_compression,
+                    Some((digest.as_str(), *size)),
                 )
-                .await
-                .map_err(RepositoryError::from),
+                .await?;
+                client
+                    .upload_blob_with_descriptor(
+                        upload_url,
+                        repo_blob_url,
+                        repository,
+                        upload.path(),
+                        upload.digest(),
+                        upload.size(),
+                    )
+                    .await
+                    .map_err(RepositoryError::from)
+            }
             LocalSnapshotDeltaDescriptor::DenseOverlaybd => {
                 let dense_temp = NamedTempFile::new().map_err(|e| {
                     RepositoryError::backend(
@@ -252,18 +275,23 @@ impl AcrDiskImageExporter {
                             e,
                         )
                     })?;
-                let uploaded = client
+                let upload = prepare_layer_upload(
+                    &dense_path,
+                    self.publish_compression,
+                    Some((&descriptor.digest, descriptor.size)),
+                )
+                .await?;
+                client
                     .upload_blob_with_descriptor(
                         upload_url,
                         repo_blob_url,
                         repository,
-                        &dense_path,
-                        &descriptor.digest,
-                        descriptor.size,
+                        upload.path(),
+                        upload.digest(),
+                        upload.size(),
                     )
                     .await
-                    .map_err(RepositoryError::from)?;
-                Ok(uploaded)
+                    .map_err(RepositoryError::from)
             }
         }
     }
@@ -324,12 +352,20 @@ fn is_tag_char(ch: char) -> bool {
 mod tests {
     use std::collections::HashMap;
     use std::fs;
+    use std::path::PathBuf;
 
+    use overlaybd::backend::local::LocalFile;
+    use overlaybd::backend::switch::new_switch_file;
+    use overlaybd::backend::tar::new_tar_file_adaptor;
+    use overlaybd::index_file::{CommitArgs, LSMTFile, LSMTReadOnlyFile};
+    use overlaybd::virtual_file::VirtualFile;
+    use overlaybd::zfile::{is_zfile, CompressArgs, CompressOptions, ZFileCompactWriter};
     use serde_json::json;
     use tempfile::TempDir;
 
     use super::super::client::tests::{client as test_client, fake_server, FakeState};
     use super::*;
+    use crate::digest::FileDigest;
     use crate::snapshot::CommandContext;
 
     #[test]
@@ -376,11 +412,14 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
-        let publisher = AcrDiskImageExporter::new_with_client_builder(Arc::new(|registry| {
-            Err(AcrClientError::MissingCredentials {
-                registry: registry.to_string(),
-            })
-        }));
+        let publisher = AcrDiskImageExporter::new_with_client_builder(
+            Arc::new(|registry| {
+                Err(AcrClientError::MissingCredentials {
+                    registry: registry.to_string(),
+                })
+            }),
+            OverlaybdCompactOutput::Raw,
+        );
 
         let err = publisher
             .export(
@@ -425,8 +464,10 @@ mod tests {
         )
         .unwrap();
         let client = test_client();
-        let publisher =
-            AcrDiskImageExporter::new_with_client_builder(Arc::new(move |_| Ok(client.clone())));
+        let publisher = AcrDiskImageExporter::new_with_client_builder(
+            Arc::new(move |_| Ok(client.clone())),
+            OverlaybdCompactOutput::Raw,
+        );
         let snapshot_id = crate::snapshot::SnapshotId::generate();
         let context = CommandContext::new(
             HashMap::from([("APP_ENV".to_string(), "snapshot".to_string())]),
@@ -485,5 +526,255 @@ mod tests {
             manifest["annotations"]["io.agentenv.snapshot.tag"],
             expected_tag
         );
+    }
+
+    const DELTA_VSIZE: u64 = 3 * 4096;
+    const SPARSE_VSIZE: u64 = 64 * 1024;
+
+    fn zfile_mode() -> OverlaybdCompactOutput {
+        OverlaybdCompactOutput::ZFile {
+            algorithm: crate::cfg::OverlaybdCompressionAlgorithm::Lz4,
+            workers: 1,
+        }
+    }
+
+    /// Write a sealed commit-style LSMT layer at `path`, raw or zfile, with
+    /// one distinct byte pattern per 4KiB page.
+    async fn write_sealed_delta(path: &Path, zfile: bool) {
+        let data = Arc::new(LocalFile::new(path.with_extension("data")).unwrap());
+        let index = Arc::new(LocalFile::new(path.with_extension("index")).unwrap());
+        let layer = LSMTFile::create(data, Some(index), DELTA_VSIZE, false)
+            .await
+            .unwrap();
+        for (page, byte) in [(0u64, 0x11u8), (4096, 0x22), (8192, 0x33)] {
+            layer.write_at(page, &[byte; 4096]).await.unwrap();
+        }
+        let output: Arc<dyn VirtualFile> = Arc::new(LocalFile::new(path).unwrap());
+        if zfile {
+            let compress_args = CompressArgs::new(CompressOptions::new(
+                CompressOptions::LZ4,
+                CompressOptions::DEFAULT_BLOCK_SIZE,
+                0,
+            ));
+            let writer = Arc::new(
+                ZFileCompactWriter::new(output, &compress_args)
+                    .await
+                    .unwrap(),
+            );
+            layer
+                .commit_with_args(CommitArgs::from_writer(writer))
+                .await
+                .unwrap();
+        } else {
+            layer
+                .commit_with_args(CommitArgs::new(output))
+                .await
+                .unwrap();
+        }
+    }
+
+    /// Write a sparse read-write LSMT layer sealed in place, the shape that
+    /// routes through the dense-export branch.
+    async fn write_sparse_delta(path: &Path) {
+        let data: Arc<dyn VirtualFile> = Arc::new(LocalFile::new(path).unwrap());
+        let lsmt = LSMTFile::create(data, None, SPARSE_VSIZE, true)
+            .await
+            .unwrap();
+        lsmt.write_at(0, &[0xAB; 4096]).await.unwrap();
+        lsmt.close_seal().await.unwrap();
+    }
+
+    fn expected_delta_contents() -> Vec<u8> {
+        let mut expected = vec![0u8; DELTA_VSIZE as usize];
+        expected[..4096].fill(0x11);
+        expected[4096..8192].fill(0x22);
+        expected[8192..].fill(0x33);
+        expected
+    }
+
+    fn expected_sparse_contents() -> Vec<u8> {
+        let mut expected = vec![0u8; SPARSE_VSIZE as usize];
+        expected[..4096].fill(0xAB);
+        expected
+    }
+
+    /// Read a sealed layer's logical contents through the same tar + switch
+    /// chain the runtime uses, transparently handling raw and zfile.
+    async fn read_layer_contents(path: &Path, len: usize) -> Vec<u8> {
+        let local: Arc<dyn VirtualFile> = Arc::new(LocalFile::open_ro(path).unwrap());
+        let display = path.display().to_string();
+        let tar_adapted = new_tar_file_adaptor(local).await.unwrap();
+        let switched = new_switch_file(tar_adapted, true, Some(&display))
+            .await
+            .unwrap();
+        let layer = LSMTReadOnlyFile::open(switched).await.unwrap();
+        layer.read_at(0, len).await.unwrap().to_vec()
+    }
+
+    /// Export an image whose only local lower is `dir/snapshot.commit`
+    /// against the fake registry and return the outcome plus recorded state.
+    async fn export_with_local_delta(
+        dir: &TempDir,
+        mode: OverlaybdCompactOutput,
+    ) -> (DiskImageExportOutcome, Arc<Mutex<FakeState>>, String) {
+        let state = Arc::new(Mutex::new(FakeState::default()));
+        let base = fake_server(Arc::clone(&state)).await;
+        let image = dir.path().join("image.json");
+        fs::write(
+            &image,
+            serde_json::to_vec_pretty(&json!({
+                "repoBlobUrl": format!("{base}/v2/ns/repo/blobs"),
+                "lowers": [
+                    {"digest": "sha256:base", "size": 123},
+                    {"file": dir.path().join("snapshot.commit")}
+                ],
+                "upper": {},
+                "resultFile": ""
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let client = test_client();
+        let publisher = AcrDiskImageExporter::new_with_client_builder(
+            Arc::new(move |_| Ok(client.clone())),
+            mode,
+        );
+        let outcome = publisher
+            .export(
+                &crate::snapshot::SnapshotId::generate(),
+                DiskImageSubject::Rootfs,
+                &image,
+                None,
+            )
+            .await
+            .unwrap();
+        (outcome, state, base)
+    }
+
+    /// Reassemble the uploaded layer blob from the PATCH chunks recorded by
+    /// the fake registry (the config blob goes through a one-shot PUT, so
+    /// only layer bytes land in `uploads`).
+    fn uploaded_blob(state: &FakeState, dir: &TempDir) -> PathBuf {
+        let path = dir.path().join("uploaded.blob");
+        fs::write(&path, state.uploads.concat()).unwrap();
+        path
+    }
+
+    /// The committed layer ref, the blob digest/size annotations in the
+    /// manifest, and the actual uploaded bytes must all agree.
+    fn assert_uploaded_layer_identity(
+        outcome: &DiskImageExportOutcome,
+        state: &FakeState,
+        base: &str,
+        blob: &Path,
+    ) {
+        let descriptor = FileDigest::describe_blocking(blob).unwrap();
+        assert_eq!(
+            outcome.layers,
+            vec![
+                OverlaybdLayerRef::External(ExternalLayer {
+                    digest: "sha256:base".to_string(),
+                    repo_blob_url: format!("{base}/v2/ns/repo/blobs"),
+                    size: 123,
+                }),
+                OverlaybdLayerRef::External(ExternalLayer {
+                    digest: descriptor.sha256.clone(),
+                    repo_blob_url: format!("{base}/v2/ns/repo/blobs"),
+                    size: descriptor.size,
+                }),
+            ]
+        );
+        assert_eq!(state.manifest_puts.len(), 1);
+        let manifest: serde_json::Value = serde_json::from_slice(&state.manifest_puts[0]).unwrap();
+        assert_eq!(manifest["layers"][1]["digest"], descriptor.sha256);
+        assert_eq!(manifest["layers"][1]["size"], descriptor.size);
+        assert_eq!(
+            manifest["layers"][1]["annotations"]["containerd.io/snapshot/overlaybd/blob-digest"],
+            descriptor.sha256
+        );
+        assert_eq!(
+            manifest["layers"][1]["annotations"]["containerd.io/snapshot/overlaybd/blob-size"],
+            descriptor.size.to_string()
+        );
+    }
+
+    async fn assert_zfile_with_contents(blob: &Path, expected: &[u8]) {
+        let file: Arc<dyn VirtualFile> = Arc::new(LocalFile::open_ro(blob).unwrap());
+        assert_eq!(is_zfile(file).await.unwrap(), 1);
+        assert_eq!(read_layer_contents(blob, expected.len()).await, expected);
+    }
+
+    #[tokio::test]
+    async fn publish_compression_uploads_zfile_delta_with_matching_manifest_annotations() {
+        let dir = TempDir::new().unwrap();
+        let delta = dir.path().join("snapshot.commit");
+        write_sealed_delta(&delta, false).await;
+
+        let (outcome, state, base) = export_with_local_delta(&dir, zfile_mode()).await;
+
+        let blob = {
+            let state = state.lock().unwrap();
+            let blob = uploaded_blob(&state, &dir);
+            assert_uploaded_layer_identity(&outcome, &state, &base, &blob);
+            blob
+        };
+        // The uploaded blob is the recontainerized zfile, decodes to the raw
+        // delta's contents, and differs from the raw bytes.
+        assert_zfile_with_contents(&blob, &expected_delta_contents()).await;
+        assert_ne!(fs::read(&blob).unwrap(), fs::read(&delta).unwrap());
+    }
+
+    #[tokio::test]
+    async fn publish_compression_skips_already_zfile_delta() {
+        let dir = TempDir::new().unwrap();
+        let delta = dir.path().join("snapshot.commit");
+        write_sealed_delta(&delta, true).await;
+
+        let (outcome, state, base) = export_with_local_delta(&dir, zfile_mode()).await;
+
+        let state = state.lock().unwrap();
+        let blob = uploaded_blob(&state, &dir);
+        assert_uploaded_layer_identity(&outcome, &state, &base, &blob);
+        // Idempotent: the pre-compressed input is uploaded byte for byte.
+        assert_eq!(fs::read(&blob).unwrap(), fs::read(&delta).unwrap());
+    }
+
+    #[tokio::test]
+    async fn publish_compression_disabled_uploads_raw_delta() {
+        let dir = TempDir::new().unwrap();
+        let delta = dir.path().join("snapshot.commit");
+        write_sealed_delta(&delta, false).await;
+
+        let (outcome, state, base) =
+            export_with_local_delta(&dir, OverlaybdCompactOutput::Raw).await;
+
+        let blob = {
+            let state = state.lock().unwrap();
+            let blob = uploaded_blob(&state, &dir);
+            assert_uploaded_layer_identity(&outcome, &state, &base, &blob);
+            blob
+        };
+        // Disabled: the raw layer is uploaded byte for byte.
+        assert_eq!(fs::read(&blob).unwrap(), fs::read(&delta).unwrap());
+        let file: Arc<dyn VirtualFile> = Arc::new(LocalFile::open_ro(&blob).unwrap());
+        assert_eq!(is_zfile(file).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn publish_compression_uploads_recontainerized_dense_sparse_delta() {
+        let dir = TempDir::new().unwrap();
+        write_sparse_delta(&dir.path().join("snapshot.commit")).await;
+
+        let (outcome, state, base) = export_with_local_delta(&dir, zfile_mode()).await;
+
+        let blob = {
+            let state = state.lock().unwrap();
+            let blob = uploaded_blob(&state, &dir);
+            assert_uploaded_layer_identity(&outcome, &state, &base, &blob);
+            blob
+        };
+        // Sparse deltas are dense-exported first; the recontainerized blob
+        // decodes to the dense logical view.
+        assert_zfile_with_contents(&blob, &expected_sparse_contents()).await;
     }
 }

--- a/src/snapshot/repository/backends/common/mod.rs
+++ b/src/snapshot/repository/backends/common/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod acr;
+pub(crate) mod recontainerize;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/src/snapshot/repository/backends/common/recontainerize.rs
+++ b/src/snapshot/repository/backends/common/recontainerize.rs
@@ -1,0 +1,379 @@
+//! Publish-time recontainerization of local overlaybd layers.
+//!
+//! Local layers always stay raw so local resume pays no decompression cost.
+//! When `[snapshot.publish_compression]` is enabled, the OSS/ACR upload paths
+//! recontainerize each raw local layer as zfile exactly once before upload:
+//! the compressed bytes are what gets uploaded, so every content reference
+//! derived here (managed-layer digest/size, OSS object key, ACR blob digest
+//! and overlaybd blob annotations) describes the compressed bytes.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use overlaybd::backend::local::LocalFile;
+use overlaybd::config::LayerConfig;
+use overlaybd::virtual_file::VirtualFile;
+use overlaybd::zfile::is_zfile;
+use tempfile::NamedTempFile;
+use tracing::debug;
+
+use crate::digest::FileDigest;
+use crate::sandbox::{compact_layers, OverlaybdCompactOutput};
+use crate::snapshot::repository::{RepositoryError, RepositoryResult};
+
+/// A local layer file prepared for upload, plus the content descriptor of
+/// exactly the bytes that will be uploaded.
+///
+/// Owns the temporary recontainerized copy (when one was produced) so it is
+/// removed once the upload completes.
+#[derive(Debug)]
+pub(crate) struct PreparedLayerUpload {
+    path: PathBuf,
+    digest: String,
+    size: u64,
+    _temp: Option<NamedTempFile>,
+}
+
+impl PreparedLayerUpload {
+    /// Local file holding the exact bytes to upload. Differs from the source
+    /// path exactly when the layer was recontainerized as zfile.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// `sha256:<hex>` digest of the bytes at [`Self::path`].
+    pub(crate) fn digest(&self) -> &str {
+        &self.digest
+    }
+
+    /// Byte size of the file at [`Self::path`].
+    pub(crate) fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+/// Prepare the local layer `source` for upload under the publish-compression
+/// `mode`.
+///
+/// With compression enabled, a raw local layer is compacted into a temporary
+/// zfile and the returned descriptor is computed over the compressed bytes.
+/// Inputs that are already zfile are uploaded unchanged (idempotent), as are
+/// all inputs when compression is disabled.
+///
+/// `trusted` carries a capture-side descriptor of `source`'s current bytes
+/// when the image config provides one. It is only honored when the file is
+/// uploaded unchanged; a recontainerized layer no longer matches it, so the
+/// zfile is re-hashed instead.
+pub(crate) async fn prepare_layer_upload(
+    source: &Path,
+    mode: OverlaybdCompactOutput,
+    trusted: Option<(&str, u64)>,
+) -> RepositoryResult<PreparedLayerUpload> {
+    if matches!(mode, OverlaybdCompactOutput::Raw) {
+        return passthrough(source, trusted).await;
+    }
+
+    let probe: Arc<dyn VirtualFile> = Arc::new(LocalFile::open_ro(source).map_err(|e| {
+        RepositoryError::backend(
+            format!("open layer '{}' for zfile probe", source.display()),
+            e,
+        )
+    })?);
+    let zfile = is_zfile(probe).await.map_err(|e| {
+        RepositoryError::backend(
+            format!("probe zfile header of layer '{}'", source.display()),
+            e,
+        )
+    })?;
+    if zfile == 1 {
+        return passthrough(source, trusted).await;
+    }
+
+    let temp = NamedTempFile::new().map_err(|e| {
+        RepositoryError::backend(
+            format!(
+                "create temp zfile layer for recontainerizing '{}'",
+                source.display()
+            ),
+            e,
+        )
+    })?;
+    let layer = LayerConfig {
+        file: source.display().to_string(),
+        ..LayerConfig::default()
+    };
+    let Some(recontainerized_path) =
+        compact_layers(&[layer], temp.path(), mode)
+            .await
+            .map_err(|e| {
+                RepositoryError::backend(
+                    format!("recontainerize layer '{}' as zfile", source.display()),
+                    e,
+                )
+            })?
+    else {
+        // A single input layer always produces output; fall back to the
+        // original bytes if the compactor ever reports no data.
+        return passthrough(source, trusted).await;
+    };
+    debug!(
+        source = %source.display(),
+        output = %recontainerized_path.display(),
+        "recontainerized local layer as zfile for upload; layer uuid will be unset"
+    );
+
+    let descriptor = FileDigest::describe(&recontainerized_path)
+        .await
+        .map_err(|e| {
+            RepositoryError::backend(
+                format!(
+                    "describe recontainerized zfile layer '{}'",
+                    recontainerized_path.display()
+                ),
+                e,
+            )
+        })?;
+    Ok(PreparedLayerUpload {
+        path: recontainerized_path,
+        digest: descriptor.sha256,
+        size: descriptor.size,
+        _temp: Some(temp),
+    })
+}
+
+/// Upload the source bytes unchanged: honor the trusted descriptor when one
+/// is available, otherwise hash the file.
+async fn passthrough(
+    source: &Path,
+    trusted: Option<(&str, u64)>,
+) -> RepositoryResult<PreparedLayerUpload> {
+    let (digest, size) = match trusted {
+        Some((digest, size)) => (digest.to_string(), size),
+        None => {
+            let descriptor = FileDigest::describe(source).await.map_err(|e| {
+                RepositoryError::backend(
+                    format!("describe managed layer '{}'", source.display()),
+                    e,
+                )
+            })?;
+            (descriptor.sha256, descriptor.size)
+        }
+    };
+    Ok(PreparedLayerUpload {
+        path: source.to_path_buf(),
+        digest,
+        size,
+        _temp: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use overlaybd::backend::switch::new_switch_file;
+    use overlaybd::backend::tar::new_tar_file_adaptor;
+    use overlaybd::index_file::{CommitArgs, LSMTFile, LSMTReadOnlyFile};
+    use overlaybd::zfile::{CompressArgs, CompressOptions, ZFileCompactWriter};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::cfg::OverlaybdCompressionAlgorithm;
+
+    const VSIZE: u64 = 3 * 4096;
+
+    /// Write a sealed LSMT layer at `dir/name.commit`, raw or zfile, with one
+    /// distinct byte pattern per 4KiB page.
+    async fn create_sealed_layer(dir: &Path, name: &str, zfile: bool) -> PathBuf {
+        let data = Arc::new(
+            LocalFile::new(dir.join(format!("{name}.data"))).expect("create layer data file"),
+        );
+        let index = Arc::new(
+            LocalFile::new(dir.join(format!("{name}.index"))).expect("create layer index file"),
+        );
+        let layer = LSMTFile::create(data, Some(index), VSIZE, false)
+            .await
+            .expect("create layer");
+        for (page, byte) in [(0u64, 0x11u8), (4096, 0x22), (8192, 0x33)] {
+            layer
+                .write_at(page, &[byte; 4096])
+                .await
+                .expect("write layer page");
+        }
+        let commit_path = dir.join(format!("{name}.commit"));
+        let output: Arc<dyn VirtualFile> =
+            Arc::new(LocalFile::new(&commit_path).expect("create layer commit output"));
+        if zfile {
+            let compress_args = CompressArgs::new(CompressOptions::new(
+                CompressOptions::LZ4,
+                CompressOptions::DEFAULT_BLOCK_SIZE,
+                0,
+            ));
+            let writer = Arc::new(
+                ZFileCompactWriter::new(output, &compress_args)
+                    .await
+                    .expect("create zfile compact writer"),
+            );
+            layer
+                .commit_with_args(CommitArgs::from_writer(writer))
+                .await
+                .expect("commit zfile layer");
+        } else {
+            layer
+                .commit_with_args(CommitArgs::new(output))
+                .await
+                .expect("commit raw layer");
+        }
+        commit_path
+    }
+
+    /// Read a sealed layer's full logical contents through the same tar +
+    /// switch chain the runtime uses, transparently handling raw and zfile.
+    async fn read_layer_contents(path: &Path) -> Vec<u8> {
+        let local: Arc<dyn VirtualFile> =
+            Arc::new(LocalFile::open_ro(path).expect("open sealed layer"));
+        let display = path.display().to_string();
+        let tar_adapted = new_tar_file_adaptor(local).await.expect("tar adaptor");
+        let switched = new_switch_file(tar_adapted, true, Some(&display))
+            .await
+            .expect("switch file");
+        let layer = LSMTReadOnlyFile::open(switched)
+            .await
+            .expect("open sealed layer as LSMT");
+        layer
+            .read_at(0, VSIZE as usize)
+            .await
+            .expect("read sealed layer")
+            .to_vec()
+    }
+
+    async fn probe_zfile(path: &Path) -> i32 {
+        let file: Arc<dyn VirtualFile> = Arc::new(LocalFile::open_ro(path).expect("open layer"));
+        is_zfile(file).await.expect("probe zfile header")
+    }
+
+    fn zfile_mode() -> OverlaybdCompactOutput {
+        OverlaybdCompactOutput::ZFile {
+            algorithm: OverlaybdCompressionAlgorithm::Lz4,
+            workers: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_passes_raw_layer_through() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = create_sealed_layer(temp.path(), "raw", false).await;
+
+        let prepared = prepare_layer_upload(&source, OverlaybdCompactOutput::Raw, None)
+            .await
+            .expect("prepare upload");
+
+        assert_eq!(prepared.path(), source);
+        let descriptor = FileDigest::describe(&source).await.expect("describe raw");
+        assert_eq!(prepared.digest(), descriptor.sha256);
+        assert_eq!(prepared.size(), descriptor.size);
+        assert_eq!(probe_zfile(prepared.path()).await, 0);
+    }
+
+    #[tokio::test]
+    async fn enabled_recontainerizes_raw_layer_as_zfile() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = create_sealed_layer(temp.path(), "raw", false).await;
+
+        let prepared = prepare_layer_upload(&source, zfile_mode(), None)
+            .await
+            .expect("prepare upload");
+
+        assert_ne!(prepared.path(), source);
+        assert_eq!(probe_zfile(prepared.path()).await, 1);
+        // The descriptor must describe the uploaded (compressed) bytes.
+        let descriptor = FileDigest::describe(prepared.path())
+            .await
+            .expect("describe zfile");
+        assert_eq!(prepared.digest(), descriptor.sha256);
+        assert_eq!(prepared.size(), descriptor.size);
+        let raw_descriptor = FileDigest::describe(&source).await.expect("describe raw");
+        assert_ne!(prepared.digest(), raw_descriptor.sha256);
+        // The compressed layer must decode to the same logical contents.
+        let expected = read_layer_contents(&source).await;
+        assert_eq!(read_layer_contents(prepared.path()).await, expected);
+    }
+
+    #[tokio::test]
+    async fn enabled_skips_zfile_input() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = create_sealed_layer(temp.path(), "zfile", true).await;
+
+        let prepared = prepare_layer_upload(&source, zfile_mode(), None)
+            .await
+            .expect("prepare upload");
+
+        assert_eq!(prepared.path(), source);
+        let descriptor = FileDigest::describe(&source).await.expect("describe zfile");
+        assert_eq!(prepared.digest(), descriptor.sha256);
+        assert_eq!(prepared.size(), descriptor.size);
+    }
+
+    #[tokio::test]
+    async fn trusted_descriptor_honored_only_without_recontainerize() {
+        let temp = TempDir::new().expect("tempdir");
+        let raw = create_sealed_layer(temp.path(), "raw", false).await;
+        let raw_size = std::fs::metadata(&raw).expect("raw metadata").len();
+        let trusted = ("sha256:declared", raw_size);
+
+        // Disabled: the trusted descriptor is kept as-is.
+        let prepared = prepare_layer_upload(&raw, OverlaybdCompactOutput::Raw, Some(trusted))
+            .await
+            .expect("prepare disabled");
+        assert_eq!(prepared.path(), raw);
+        assert_eq!(prepared.digest(), "sha256:declared");
+        assert_eq!(prepared.size(), raw_size);
+
+        // Enabled on a raw layer: the descriptor was computed over raw bytes,
+        // so the recontainerized zfile must be re-hashed.
+        let prepared = prepare_layer_upload(&raw, zfile_mode(), Some(trusted))
+            .await
+            .expect("prepare enabled");
+        assert_ne!(prepared.path(), raw);
+        let descriptor = FileDigest::describe(prepared.path())
+            .await
+            .expect("describe zfile");
+        assert_eq!(prepared.digest(), descriptor.sha256);
+        assert_ne!(prepared.digest(), "sha256:declared");
+
+        // Enabled on an already-zfile layer: the input is uploaded unchanged,
+        // so the trusted descriptor still describes the physical bytes.
+        let zfile = create_sealed_layer(temp.path(), "zfile", true).await;
+        let zfile_size = std::fs::metadata(&zfile).expect("zfile metadata").len();
+        let prepared =
+            prepare_layer_upload(&zfile, zfile_mode(), Some(("sha256:declared", zfile_size)))
+                .await
+                .expect("prepare zfile input");
+        assert_eq!(prepared.path(), zfile);
+        assert_eq!(prepared.digest(), "sha256:declared");
+        assert_eq!(prepared.size(), zfile_size);
+    }
+
+    #[tokio::test]
+    async fn temp_zfile_removed_on_drop() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = create_sealed_layer(temp.path(), "raw", false).await;
+
+        let prepared = prepare_layer_upload(&source, zfile_mode(), None)
+            .await
+            .expect("prepare upload");
+        let path = prepared.path().to_path_buf();
+        assert!(path.exists());
+        drop(prepared);
+        assert!(!path.exists(), "temporary zfile must be removed on drop");
+    }
+
+    #[tokio::test]
+    async fn corrupt_input_fails_probe_instead_of_uploading() {
+        let temp = TempDir::new().expect("tempdir");
+        let bogus = temp.path().join("snapshot.commit");
+        std::fs::write(&bogus, b"not-an-overlaybd-layer").expect("write bogus layer");
+
+        prepare_layer_upload(&bogus, zfile_mode(), None)
+            .await
+            .expect_err("corrupt layer must fail the publish");
+    }
+}

--- a/src/snapshot/repository/backends/mod.rs
+++ b/src/snapshot/repository/backends/mod.rs
@@ -62,6 +62,7 @@ pub fn build_snapshot_backend(
             Ok(OssBackend::from_parts(
                 oss_config,
                 snapshot_image_storage,
+                &config.snapshot.publish_compression,
                 cache,
                 shared_cache_root.join("runtime"),
                 overlaybd_layers,

--- a/src/snapshot/repository/backends/oss/mod.rs
+++ b/src/snapshot/repository/backends/oss/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
-use crate::cfg::{OssBackendConfig, SnapshotImageStoragePolicy};
+use crate::cfg::{OssBackendConfig, SnapshotImageStoragePolicy, SnapshotPublishCompressionConfig};
 use crate::image::cache::{local_image_services_from_global_config, OverlaybdLayerStore};
 use crate::p2p::P2pTransport;
 use crate::snapshot::artifact_cache::LocalArtifactCache;
@@ -35,12 +35,30 @@ impl OssBackend {
     ///
     /// This convenience constructor remains available for tests and direct
     /// callers. The main backend factory constructs a shared cache once and
-    /// uses [`OssBackend::from_parts`] instead.
+    /// uses [`OssBackend::from_parts`] instead. Publish compression stays
+    /// disabled here; use [`OssBackend::new_with_publish_compression`] to
+    /// exercise `[snapshot.publish_compression]`.
     pub fn new(config: &OssBackendConfig, cache_root: PathBuf) -> Result<Self> {
+        Self::new_with_publish_compression(
+            config,
+            cache_root,
+            &SnapshotPublishCompressionConfig::default(),
+        )
+    }
+
+    /// Build the OSS backend from config with explicit publish-compression
+    /// settings, for tests and direct callers that cannot go through the
+    /// global config.
+    pub fn new_with_publish_compression(
+        config: &OssBackendConfig,
+        cache_root: PathBuf,
+        publish_compression: &SnapshotPublishCompressionConfig,
+    ) -> Result<Self> {
         let cache = LocalArtifactCache::new(cache_root.clone(), config.cache_max_size_gb)?;
         Self::from_parts(
             config,
             SnapshotImageStoragePolicy::default(),
+            publish_compression,
             cache,
             cache_root.join("runtime"),
             local_image_services_from_global_config().overlaybd_layers,
@@ -52,6 +70,7 @@ impl OssBackend {
     pub(crate) fn from_parts(
         config: &OssBackendConfig,
         snapshot_image_storage: SnapshotImageStoragePolicy,
+        publish_compression: &SnapshotPublishCompressionConfig,
         cache: Arc<LocalArtifactCache>,
         runtime_root: PathBuf,
         store: Arc<dyn OverlaybdLayerStore>,
@@ -71,6 +90,7 @@ impl OssBackend {
         let repository: Arc<dyn SnapshotRepository> = Arc::new(OssSnapshotRepository::new(
             Arc::clone(&client),
             config.snapshot_image_storage(),
+            publish_compression,
         ));
 
         std::fs::create_dir_all(&runtime_root)

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -12,10 +12,13 @@ use tracing::{debug, info, warn};
 
 use super::client::{OssClient, OssUploadArtifact};
 use super::layout::OssSnapshotArtifactLayout;
-use crate::cfg::SnapshotImageStoragePolicy;
-use crate::sandbox::FirecrackerSnapshotManifest;
+use crate::cfg::{SnapshotImageStoragePolicy, SnapshotPublishCompressionConfig};
+use crate::sandbox::{FirecrackerSnapshotManifest, OverlaybdCompactOutput};
 use crate::snapshot::repository::backends::common::acr::{
     AcrDiskImageExporter, DiskImageExportOutcome, DiskImageSubject, SnapshotOciConfigInput,
+};
+use crate::snapshot::repository::backends::common::recontainerize::{
+    prepare_layer_upload, PreparedLayerUpload,
 };
 use crate::snapshot::repository::backends::common::{
     materialize_volume_image_config, write_dense_overlaybd_layer_to_file,
@@ -47,6 +50,7 @@ pub(crate) struct OssSnapshotRepository {
     client: Arc<OssClient>,
     snapshot_image_storage: SnapshotImageStoragePolicy,
     acr_exporter: AcrDiskImageExporter,
+    publish_compression: OverlaybdCompactOutput,
 }
 
 const MAX_ALIAS_BIND_ATTEMPTS: usize = 5;
@@ -56,11 +60,15 @@ impl OssSnapshotRepository {
     pub(crate) fn new(
         client: Arc<OssClient>,
         snapshot_image_storage: SnapshotImageStoragePolicy,
+        publish_compression: &SnapshotPublishCompressionConfig,
     ) -> Self {
+        let publish_compression =
+            OverlaybdCompactOutput::from_publish_compression_config(publish_compression);
         Self {
             client,
             snapshot_image_storage,
-            acr_exporter: AcrDiskImageExporter::new(),
+            acr_exporter: AcrDiskImageExporter::new(publish_compression),
+            publish_compression,
         }
     }
 
@@ -1583,14 +1591,14 @@ impl OssSnapshotRepository {
                     e,
                 )
             })?;
-        let oss_key = OssSnapshotArtifactLayout::managed_layer_key(&descriptor.digest);
-        upload_managed_layer_if_missing(&self.client, &oss_key, &dense_path, artifact).await?;
-
-        Ok(ManagedLayer {
-            digest: descriptor.digest,
-            size: descriptor.size,
-            uuid: None,
-        })
+        let upload = prepare_layer_upload(
+            &dense_path,
+            self.publish_compression,
+            Some((&descriptor.digest, descriptor.size)),
+        )
+        .await?;
+        // Dense-exported layers never carry a layer uuid, recontainerized or not.
+        self.upload_prepared_layer(upload, None, artifact).await
     }
 
     async fn import_managed_layer_by_hash(
@@ -1604,22 +1612,9 @@ impl OssSnapshotRepository {
                 e,
             )
         })?;
-        let descriptor = crate::digest::FileDigest::describe(&canonical)
-            .await
-            .map_err(|e| {
-                RepositoryError::backend(
-                    format!("describe managed layer '{}'", canonical.display()),
-                    e,
-                )
-            })?;
-        let oss_key = OssSnapshotArtifactLayout::managed_layer_key(&descriptor.sha256);
-        upload_managed_layer_if_missing(&self.client, &oss_key, &canonical, artifact).await?;
-
-        Ok(ManagedLayer {
-            digest: descriptor.sha256,
-            size: descriptor.size,
-            uuid: overlaybd_layer_uuid(&canonical),
-        })
+        let upload = prepare_layer_upload(&canonical, self.publish_compression, None).await?;
+        let uuid = overlaybd_layer_uuid(upload.path());
+        self.upload_prepared_layer(upload, uuid, artifact).await
     }
 
     async fn import_managed_layer_with_descriptor(
@@ -1657,13 +1652,31 @@ impl OssSnapshotRepository {
 
         // Descriptor-backed imports intentionally trust internally generated
         // content digests and only validate the cheap size invariant here.
-        let oss_key = OssSnapshotArtifactLayout::managed_layer_key(digest);
-        upload_managed_layer_if_missing(&self.client, &oss_key, &canonical, artifact).await?;
+        // Publish compression recontainerizes raw layers as zfile, which
+        // changes the physical bytes, so `prepare_layer_upload` re-hashes the
+        // compressed output instead of trusting this descriptor.
+        let upload =
+            prepare_layer_upload(&canonical, self.publish_compression, Some((digest, size)))
+                .await?;
+        let uuid = overlaybd_layer_uuid(upload.path());
+        self.upload_prepared_layer(upload, uuid, artifact).await
+    }
 
+    /// Upload a prepared layer under its content-addressed key and build the
+    /// committed managed-layer reference. The object key, digest, and size all
+    /// describe exactly the prepared (possibly recontainerized) bytes.
+    async fn upload_prepared_layer(
+        &self,
+        upload: PreparedLayerUpload,
+        uuid: Option<String>,
+        artifact: OssUploadArtifact,
+    ) -> RepositoryResult<ManagedLayer> {
+        let oss_key = OssSnapshotArtifactLayout::managed_layer_key(upload.digest());
+        upload_managed_layer_if_missing(&self.client, &oss_key, upload.path(), artifact).await?;
         Ok(ManagedLayer {
-            digest: digest.to_string(),
-            size,
-            uuid: overlaybd_layer_uuid(&canonical),
+            digest: upload.digest().to_string(),
+            size: upload.size(),
+            uuid,
         })
     }
 }
@@ -1768,7 +1781,58 @@ mod tests {
             None,
         )
         .expect("oss client");
-        OssSnapshotRepository::new(Arc::new(client), SnapshotImageStoragePolicy::ObjectStorage)
+        OssSnapshotRepository::new(
+            Arc::new(client),
+            SnapshotImageStoragePolicy::ObjectStorage,
+            &SnapshotPublishCompressionConfig {
+                enabled: false,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[test]
+    fn publish_compression_config_resolves_into_compact_output() {
+        let client = || {
+            Arc::new(
+                OssClient::new(
+                    "bucket".to_string(),
+                    "https://oss.example.com".to_string(),
+                    "region".to_string(),
+                    "prefix".to_string(),
+                    CredentialSource::Anonymous,
+                    None,
+                )
+                .expect("oss client"),
+            )
+        };
+
+        let disabled = OssSnapshotRepository::new(
+            client(),
+            SnapshotImageStoragePolicy::ObjectStorage,
+            &SnapshotPublishCompressionConfig {
+                enabled: false,
+                ..Default::default()
+            },
+        );
+        assert_eq!(disabled.publish_compression, OverlaybdCompactOutput::Raw);
+
+        let enabled = OssSnapshotRepository::new(
+            client(),
+            SnapshotImageStoragePolicy::ObjectStorage,
+            &SnapshotPublishCompressionConfig {
+                enabled: true,
+                algorithm: crate::cfg::OverlaybdCompressionAlgorithm::Zstd,
+                workers: 4,
+            },
+        );
+        assert_eq!(
+            enabled.publish_compression,
+            OverlaybdCompactOutput::ZFile {
+                algorithm: crate::cfg::OverlaybdCompressionAlgorithm::Zstd,
+                workers: 4,
+            }
+        );
     }
 
     #[test]

--- a/src/snapshot/repository/backends/posixfs/artifacts.rs
+++ b/src/snapshot/repository/backends/posixfs/artifacts.rs
@@ -1021,8 +1021,9 @@ mod tests {
         );
     }
 
-    /// Write a real ZFile-compressed sealed LSMT layer, mirroring the memory
-    /// snapshot output when `[memory_snapshot].compression_enabled = true`.
+    /// Write a real ZFile-compressed sealed LSMT layer, mirroring a compressed
+    /// memory lower as found in repositories published while capture-time
+    /// compression existed (or produced by publish-time compression).
     async fn write_zfile_lsmt_layer(path: &std::path::Path) {
         let data =
             Arc::new(LocalFile::new(path.with_extension("data")).expect("create layer data file"));

--- a/src/template/builder.rs
+++ b/src/template/builder.rs
@@ -11,7 +11,7 @@ use super::errors::{
 };
 use super::runner::{TemplateBuildBase, TemplateBuildContext, TemplateBuildRunner};
 use crate::cfg::ConfigManager;
-use crate::sandbox::{OverlaybdCompactOutput, UblkConfig};
+use crate::sandbox::UblkConfig;
 use crate::snapshot::{
     CommandContext, RunnableSnapshot, SnapshotId, SnapshotManager, SnapshotPublishMetadata,
     SnapshotPublishSource, SnapshotRecord, StartupCommand, TemplateBuildErrorReason,
@@ -47,14 +47,6 @@ impl TemplateBuilder {
 
     fn current_cpu_config(&self) -> Option<String> {
         self.cpu_config_arc.as_ref()?.read().unwrap().clone()
-    }
-
-    /// Snapshot compression for template builds, resolved from the isolated
-    /// `[template_build]` switch (never `[memory_snapshot]`).
-    fn snapshot_compression_from_config() -> OverlaybdCompactOutput {
-        OverlaybdCompactOutput::from_template_build_config(
-            &ConfigManager::global_config().template_build,
-        )
     }
 
     /// Builds a new snapshot from `config`, publishes it, and returns the committed record.
@@ -222,7 +214,6 @@ impl TemplateBuilder {
             base,
             cpu_config_json: self.current_cpu_config(),
             virtualization_mode: ConfigManager::global_config().virtualization_mode,
-            snapshot_compression: Self::snapshot_compression_from_config(),
         })
     }
 
@@ -287,7 +278,6 @@ impl TemplateBuilder {
             },
             cpu_config_json: self.current_cpu_config(),
             virtualization_mode: base_mode,
-            snapshot_compression: Self::snapshot_compression_from_config(),
         })
     }
 
@@ -423,26 +413,6 @@ mod tests {
             .expect_err("snapshot-based build should reject resource changes");
 
         assert!(matches!(err, TemplateBuildError::InvalidInput { .. }));
-    }
-
-    #[test]
-    fn fresh_context_carries_template_build_snapshot_compression() {
-        use crate::types::ImageConfigs;
-
-        let tempdir = TempDir::new().expect("tempdir");
-        let image_config_path = tempdir.path().join("image.json");
-        std::fs::write(&image_config_path, "{}").expect("write image config placeholder");
-        let manager = TemplateBuilder::new();
-        let context = manager
-            .prepare_fresh_context(
-                &TemplateBuildSpec::new()
-                    .with_resolved_overlaybd_image(&image_config_path, ImageConfigs::new()),
-                crate::snapshot::SnapshotId::generate(),
-            )
-            .expect("fresh context preparation should succeed");
-
-        // The default `[template_build]` config disables compression.
-        assert_eq!(context.snapshot_compression, OverlaybdCompactOutput::Raw);
     }
 
     #[test]

--- a/src/template/runner.rs
+++ b/src/template/runner.rs
@@ -13,9 +13,8 @@ use super::build_spec::TemplateBuildStep;
 use super::errors::{command_output_suffix, TemplateBuildFailure};
 use super::step_executor::TemplateStepExecutor;
 use crate::sandbox::{
-    FirecrackerSandbox, FirecrackerSandboxConfig, FirecrackerSnapshotManifest,
-    OverlaybdCompactOutput, ProcessHandle, ProcessOpts, SandboxExecutor, SandboxLaunchConfig,
-    UblkConfig,
+    FirecrackerSandbox, FirecrackerSandboxConfig, FirecrackerSnapshotManifest, ProcessHandle,
+    ProcessOpts, SandboxExecutor, SandboxLaunchConfig, UblkConfig,
 };
 use crate::snapshot::{
     CommandContext, RunnableSnapshot, SnapshotAlias, SnapshotId, SnapshotRuntimeVersions,
@@ -70,10 +69,6 @@ pub(crate) struct TemplateBuildContext {
     pub base: TemplateBuildBase,
     pub cpu_config_json: Option<String>,
     pub virtualization_mode: VirtualizationMode,
-    /// Compression applied to the snapshot artifacts captured by this build,
-    /// resolved from `[template_build]`; isolates template builds from
-    /// `[memory_snapshot]`.
-    pub snapshot_compression: OverlaybdCompactOutput,
 }
 
 impl TemplateBuildContext {
@@ -209,7 +204,6 @@ impl TemplateBuildRunner {
         let initial_context = context.initial_context.clone();
         let startup = context.startup.clone();
         let override_startup = context.override_startup;
-        let snapshot_compression = context.snapshot_compression;
 
         let handle =
             spawn_with_trace_context(worker_span, move || -> Result<TemplateBuildExecution> {
@@ -219,7 +213,6 @@ impl TemplateBuildRunner {
                     .context("create tokio runtime")?;
                 rt.block_on(async move {
                     let mut sandbox = create_sandbox()?;
-                    sandbox.set_snapshot_compression_override(snapshot_compression);
                     let run_result = async {
                         debug!(
                             cpu_count = resources.cpu_count,

--- a/tests/integration/fc.rs
+++ b/tests/integration/fc.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use agentenv::cfg::{ConfigManager, OverlaybdCompressionAlgorithm};
+use agentenv::cfg::ConfigManager;
 use agentenv::sandbox::{
     BaseSandboxNetworkPolicy, FirecrackerSandbox, FirecrackerSnapshotConfig, SandboxBackend,
     SandboxExecutor, SandboxNetworkEgressPolicy, SandboxNetworkPolicy,
@@ -11,7 +11,7 @@ use anyhow::{bail, Context, Result};
 use overlaybd::backend::local::LocalFile;
 use overlaybd::config::ImageConfig;
 use overlaybd::virtual_file::VirtualFile;
-use overlaybd::zfile::{is_zfile, zfile_open_ro, CompressOptions};
+use overlaybd::zfile::is_zfile;
 
 use crate::common;
 
@@ -94,16 +94,15 @@ async fn verify_disk_marker(sandbox: &mut FirecrackerSandbox) -> Result<()> {
     Ok(())
 }
 
-/// Assert that the newest local memory lower of `snapshot` matches the global
-/// `[memory_snapshot]` compression policy:
-/// - `compression_enabled = false` -> raw LSMT layer (no ZFile wrapper)
-/// - `compression_enabled = true` -> ZFile layer with the configured algorithm
-///   and 4096-byte compression blocks
+/// Assert that the newest local memory lower of `snapshot` is a raw LSMT
+/// layer (no ZFile wrapper). Capture-time compression was removed: local
+/// layers always stay raw, so local resume pays no decompression cost.
+/// Compression, when enabled via `[snapshot.publish_compression]`, happens
+/// once at publish time on the repository upload path.
 ///
 /// Image config lowers are ordered bottom-to-top (oldest base layer first), so
 /// the newest local lower is the last entry with a `file` path.
-async fn assert_memory_layer_matches_config(snapshot: &FirecrackerSnapshotConfig) -> Result<()> {
-    let memory_config = &ConfigManager::global().config().memory_snapshot;
+async fn assert_memory_layer_is_raw(snapshot: &FirecrackerSnapshotConfig) -> Result<()> {
     let image_config_path = &snapshot.mem_overlaybd_config.image_config_path;
     let image_config: ImageConfig = serde_json::from_slice(
         &fs::read(image_config_path)
@@ -130,44 +129,13 @@ async fn assert_memory_layer_matches_config(snapshot: &FirecrackerSnapshotConfig
         LocalFile::open_ro(&lower_path)
             .with_context(|| format!("open memory lower {}", lower_path.display()))?,
     );
-    let zfile_flag = is_zfile(file.clone())
+    let zfile_flag = is_zfile(file)
         .await
         .with_context(|| format!("probe zfile header of {}", lower_path.display()))?;
-    if !memory_config.compression_enabled {
-        assert_eq!(
-            zfile_flag,
-            0,
-            "compression disabled: memory lower {} should be a raw LSMT layer",
-            lower_path.display()
-        );
-        return Ok(());
-    }
-
-    let expected_algo = match memory_config.compression_algorithm {
-        OverlaybdCompressionAlgorithm::Lz4 => CompressOptions::LZ4,
-        OverlaybdCompressionAlgorithm::Zstd => CompressOptions::ZSTD,
-    };
     assert_eq!(
         zfile_flag,
-        1,
-        "compression {:?}: memory lower {} should be a ZFile layer",
-        memory_config.compression_algorithm,
-        lower_path.display()
-    );
-    let zfile = zfile_open_ro(file, false)
-        .await
-        .with_context(|| format!("open zfile memory lower {}", lower_path.display()))?;
-    assert_eq!(
-        zfile.options().algo,
-        expected_algo,
-        "memory lower {} should use the configured compression algorithm",
-        lower_path.display()
-    );
-    // The memory snapshot format contract pins 4 KiB compression blocks.
-    assert_eq!(
-        zfile.options().block_size,
-        4096,
-        "memory lower {} should use 4096-byte compression blocks",
+        0,
+        "memory lower {} should be a raw LSMT layer",
         lower_path.display()
     );
     Ok(())
@@ -199,8 +167,8 @@ async fn microvm_lifecycle_and_snapshot_preserve_disk_state() -> Result<()> {
 
 /// Shared body of the memory snapshot format test: pause a marked sandbox into
 /// a temp dir, assert the direct OverlayBD snapshot artifact layout, validate
-/// the newest memory lower against the configured compression policy, and
-/// verify that a resume round-trip preserves guest disk state.
+/// that the newest memory lower is a raw LSMT layer, and verify that a resume
+/// round-trip preserves guest disk state.
 async fn run_memory_snapshot_format_and_resume_case() -> Result<()> {
     let sandbox_config = common::default_sandbox_config()?;
     let mut sandbox = FirecrackerSandbox::new(sandbox_config)?;
@@ -222,7 +190,7 @@ async fn run_memory_snapshot_format_and_resume_case() -> Result<()> {
         !snapshot_dir.path().join("mem.bin").exists(),
         "direct OverlayBD snapshot should not create mem.bin"
     );
-    assert_memory_layer_matches_config(&snapshot).await?;
+    assert_memory_layer_is_raw(&snapshot).await?;
 
     let mut resumed = FirecrackerSandbox::resume_from_snapshot_config(&snapshot).await?;
     verify_disk_marker(&mut resumed).await?;
@@ -231,8 +199,7 @@ async fn run_memory_snapshot_format_and_resume_case() -> Result<()> {
 }
 
 /// Direct OverlayBD memory layers are built from Firecracker memory ranges
-/// without an intermediate raw memory file. This test is run by three
-/// independent processes (raw/lz4/zstd temp configs) to cover all modes.
+/// without an intermediate raw memory file, and are always written raw.
 #[tokio::test]
 async fn memory_snapshot_format_matches_config_and_resumes() -> Result<()> {
     common::setup().await;
@@ -275,7 +242,7 @@ async fn snapshot_chain_survives_after_parent_snapshot_handle_is_dropped() -> Re
 
     write_disk_marker(&mut sandbox).await?;
     let first_snapshot = sandbox.pause().await?;
-    assert_memory_layer_matches_config(&first_snapshot).await?;
+    assert_memory_layer_is_raw(&first_snapshot).await?;
     sandbox.stop().await?;
     let first_snapshot_dir = fs::canonicalize(first_snapshot.vm_state_path.parent().unwrap())?;
     let first_persistent_generation = fs::canonicalize(
@@ -306,7 +273,7 @@ async fn snapshot_chain_survives_after_parent_snapshot_handle_is_dropped() -> Re
     let mut resumed = FirecrackerSandbox::resume_from_snapshot_config(&first_snapshot).await?;
     verify_disk_marker(&mut resumed).await?;
     let second_snapshot = resumed.pause().await?;
-    assert_memory_layer_matches_config(&second_snapshot).await?;
+    assert_memory_layer_is_raw(&second_snapshot).await?;
     resumed.stop().await?;
     let second_snapshot_dir = fs::canonicalize(second_snapshot.vm_state_path.parent().unwrap())?;
     let second_mem_lowers = lower_file_paths_from_image_config(

--- a/tests/integration/snapshot.rs
+++ b/tests/integration/snapshot.rs
@@ -28,43 +28,6 @@ fn sample_runtime_versions() -> SnapshotRuntimeVersions {
     }
 }
 
-/// When the run's config enables `[template_build].compression_enabled`, the
-/// newest (freshly sealed) rootfs and memory lowers of a template-built
-/// snapshot must be ZFile-compressed. Otherwise the check is a no-op so the
-/// same test passes under default configs.
-async fn assert_sealed_layers_compressed_when_enabled(
-    runnable: &agentenv::snapshot::RunnableSnapshot,
-) -> Result<()> {
-    if !ConfigManager::global_config()
-        .template_build
-        .compression_enabled
-    {
-        return Ok(());
-    }
-    for image_config_path in [
-        &runnable.manifest().rootfs.image_config_path,
-        &runnable.manifest().memory.image_config_path,
-    ] {
-        let image_config = overlaybd::config::load_image_config(image_config_path)
-            .with_context(|| format!("load resolved image config {image_config_path:?}"))?;
-        let latest = image_config
-            .lowers
-            .last()
-            .ok_or_else(|| anyhow!("resolved image config has no lowers"))?;
-        anyhow::ensure!(
-            !latest.file.is_empty(),
-            "newest lower is remote (no local file); cannot probe sealed layer compression"
-        );
-        let file: std::sync::Arc<dyn overlaybd::virtual_file::VirtualFile> = std::sync::Arc::new(
-            overlaybd::backend::local::LocalFile::open_ro(std::path::Path::new(&latest.file))
-                .with_context(|| format!("open sealed layer {}", latest.file))?,
-        );
-        let zfile = overlaybd::zfile::is_zfile(file).await?;
-        assert_eq!(zfile, 1, "sealed layer {} must be zfile", latest.file);
-    }
-    Ok(())
-}
-
 async fn write_guest_file(sandbox: &FirecrackerSandbox, path: &str, contents: &str) -> Result<()> {
     let escaped_path = path.replace('\'', "'\\''");
     let escaped_contents = contents.replace('\'', "'\\''");
@@ -285,7 +248,6 @@ async fn built_and_derived_snapshot_can_be_launched() -> Result<()> {
     let runnable = snapshot_manager
         .resolve_runnable(loaded_base.clone())
         .await?;
-    assert_sealed_layers_compressed_when_enabled(&runnable).await?;
     let derived_id = SnapshotId::generate();
     builder
         .build_from_snapshot_and_publish(
@@ -310,7 +272,6 @@ async fn built_and_derived_snapshot_can_be_launched() -> Result<()> {
     );
 
     let runnable = snapshot_manager.resolve_runnable(derived.clone()).await?;
-    assert_sealed_layers_compressed_when_enabled(&runnable).await?;
     let mut sandbox =
         FirecrackerSandbox::from_snapshot(&runnable, &SandboxLaunchConfig::default())?;
     sandbox.start().await?;


### PR DESCRIPTION
## What

Redesign snapshot layer compression: local layers always stay raw, and compression happens once when layers are uploaded to OSS/ACR. A single new switch, `[snapshot.publish_compression]` (`enabled` / `algorithm` (`lz4`|`zstd`) / `workers`, on by default), replaces the legacy capture-time knobs — `[memory_snapshot].compression_*` and `[template_build]` are removed from the configuration schema.

## Why

Benchmarks show capture-time compression is a local pessimization: the guest working set is unchanged by compression (~62 MiB in the test setup), and while layer files are page-cache-warm the saved bytes never materialize — yet decompression CPU is paid on every fault (cold resume: raw 63.8 ms vs lz4 +18% vs zstd +106%; hot path identical at ~15 ms). The bytes compression actually saves only matter on the network path: OSS/ACR upload and cross-node resume.

## Related issue

Closes # (no tracking issue; motivation is the measurement analysis above)

## Scope and non-goals

- Included: publish-time compression in the OSS managed-layer and ACR source-registry upload paths (memory layers, rootfs read-write deltas, attached-drive deltas uniformly); removal of capture-time compression and the template-build compression override pipeline; P2P digest-key consistency guard; config, docs, and tests.
- Non-goals: no `Repository` trait changes; POSIX backend unchanged (local stays raw); zero read-path changes (ZFile is already transparent via switch-file magic detection); full P2P alignment for compressed digests (left as a TODO).

## Design and behavior changes

- Capture path: memory / rootfs / attached-drive layers are always sealed raw (daemon `close_seal` unchanged).
- Publish path: new shared helper `prepare_layer_upload` (`common/recontainerize.rs`) probes `is_zfile`, recontainerizes raw local layers with `compact_layers` into a temporary ZFile, then hashes and uploads the compressed bytes. `ManagedLayer.digest/size`, OSS object keys, and ACR blob annotations all reference the actually-uploaded bytes. Remote lowers are re-referenced untouched; already-ZFile inputs are passed through (idempotent).
- Resolution/resume: unchanged — consuming nodes auto-detect the format by content magic and need no configuration or flag.
- Failure handling: compression/hash failures abort the publish through the existing rollback path (`delete_prefix`); no partial uploads; temp files are cleaned up by guard.
- Known trade-off: ZFile layers record `uuid = None`, so P2P uuid-keyed acceleration does not apply to them (the daemon virtual-size probe falls back to a full `ImageFile` open, one-time).

## Compatibility and operations

- Public API or generated protocol: unchanged.
- Configuration or defaults: new `[snapshot.publish_compression]` section (**enabled by default**, `lz4`) — OSS/ACR uploads start compressing on upgrade; set `enabled = false` to keep raw uploads. Legacy keys removed from the schema; unknown TOML keys are ignored by the config parser, so stale configs keep starting.
- Snapshot manifest, artifact layout, or storage format: when enabled, manifest digests/sizes reference compressed bytes; readers auto-detect by content magic, and existing repositories (raw or previously compressed layers) remain readable.
- Upgrade and rollback: rollback-safe — disabling the switch resumes raw uploads; no data migration needed. Note the default is **on**, so existing OSS deployments will upload compressed layers after upgrade (readers auto-detect; downgrade-safe).
- Host requirements, permissions, ports, or dependencies: none added.

## Validation

- [x] `make fmt` (`cargo fmt --all -- --check`)
- [x] `make clippy` (`cargo clippy -p agentenv -p agentenv-e2e-tests --all-targets -- -D warnings`)
- [x] `make test-unit` (`cargo test -p agentenv --lib`: 817/818; the single failure is a pre-existing flaky `api::proxy` test that passes in isolation, unrelated)
- [x] Relevant Rust integration tests (`fc::memory_snapshot_format_matches_config_and_resumes`, `fc::backend_pause_state_round_trips_through_encoded_artifacts`)
- [x] Documentation updated (AGENTS/CLAUDE.md, `reference.md`, `default.toml`, `p2p-design.md`)
- [x] Benchmarks or performance comparison completed

Commands and results:

```text
cargo fmt --all -- --check                                    # pass
cargo clippy -p agentenv -p agentenv-e2e-tests --all-targets -- -D warnings  # pass
cargo test -p agentenv --lib                                  # 817 passed, 1 flaky (unrelated)

# OSS e2e (minio), incl. the new compression case
cargo test -p agentenv-e2e-tests --test snapshot_oss_e2e_test -- --include-ignored --test-threads=1
# 5 passed (incl. snapshot_oss_publish_compresses_raw_layers_when_enabled)

# KVM integration (real Firecracker pause/resume)
cargo test -p agentenv --test integration --release -- fc::memory_snapshot_format_matches_config_and_resumes fc::backend_pause_state_round_trips_through_encoded_artifacts
# 2 passed

# Real OSS end-to-end (bucket agentenv-oss-validation):
# publish (compression on): memory layer 53MB -> 34.7MB; fresh-home cross-node
# resume succeeded with guest data intact; cached layer verified as ZFile magic;
# guest runtime upper stays raw.
```

Performance comparison (real OSS, release build; template-build scenario, memory layer 87.8 → 31.9 MiB, 2.75×):

| Metric | raw | publish_compression (lz4) |
|---|---|---|
| Build publish phase (capture + compress + upload) | 2.28 s | **1.02 s (2.2× faster)** |
| Memory-layer upload time | 1.60 s | 0.49 s |
| Cold start from template (fresh node, OSS caches cleared, mean of 3) | 3.01 s (3.42/3.17/2.44) | **2.05 s (2.02/2.07/2.06), −32%** |
| Bytes downloaded during cold start | ~64 MiB | ~30 MiB |

Evidence for removing capture-time compression: cold resume raw 63.8 ms vs lz4 75.1 ms (+18%) vs zstd 131.4 ms (+106%); hot path identical at ~15 ms; guest working set (~62 MiB) is codec-independent.

Skipped checks and reasons: `make -C services test` (`services/` untouched); no generated-code changes.

## Risks and reviewer notes

- Core invariant: manifest digest/size must equal the actually-uploaded (compressed) bytes — guarded by unit tests in `recontainerize.rs` and the minio e2e. Please focus review on `common/recontainerize.rs` (new), the three upload branches in `oss/repository.rs`, and `acr/publisher.rs::upload_local_delta`.
- P2P: digest-keyed publication is skipped when the committed record names different bytes than the local descriptor (conservative; see the TODO in `p2p.rs` about propagating compressed paths to restore acceleration).
- ZFile layers get `uuid = None`: P2P uuid-keyed acceleration is unavailable for them (pre-existing graceful degradation, not a regression).
- Benchmarks ran on a shared test host, so absolute numbers carry some noise; the compressed runs show noticeably tighter variance (2.02–2.07 s vs 2.44–3.42 s) because less of the critical path is network-exposed.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
