### PR TITLE
fix(api): support official E2B SDK volume mounts

### DIFF
--- a/crates/aenv/src/client/sandboxes.rs
+++ b/crates/aenv/src/client/sandboxes.rs
@@ -6,6 +6,12 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 #[derive(Debug, Serialize)]
+pub struct SandboxVolumeMount {
+    pub name: String,
+    pub path: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct NewSandbox<'a> {
     #[serde(rename = "templateID")]
     pub template_id: &'a str,
@@ -13,7 +19,7 @@ pub struct NewSandbox<'a> {
     pub timeout: Option<u32>,
     pub secure: bool,
     #[serde(skip_serializing_if = "Option::is_none", rename = "volumeMounts")]
-    pub volume_mounts: Option<HashMap<String, String>>,
+    pub volume_mounts: Option<Vec<SandboxVolumeMount>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -29,7 +35,7 @@ pub struct NewColdSandbox<'a> {
     pub disk_size_mb: Option<u32>,
     pub secure: bool,
     #[serde(skip_serializing_if = "Option::is_none", rename = "volumeMounts")]
-    pub volume_mounts: Option<HashMap<String, String>>,
+    pub volume_mounts: Option<Vec<SandboxVolumeMount>>,
 }
 
 #[derive(Deserialize)]
@@ -86,7 +92,7 @@ impl Client {
             template_id,
             timeout,
             secure: true,
-            volume_mounts,
+            volume_mounts: volume_mounts.map(volume_mounts_to_model),
         };
         let resp = handle_status(self.post("/sandboxes").send_json(&body))?;
         let sandbox: Sandbox = resp.into_json()?;
@@ -110,7 +116,7 @@ impl Client {
             memory_mb,
             disk_size_mb,
             secure: true,
-            volume_mounts,
+            volume_mounts: volume_mounts.map(volume_mounts_to_model),
         };
         let resp = handle_status(self.post("/sandboxes-cold").send_json(&body))?;
         let sandbox: Sandbox = resp.into_json()?;
@@ -182,9 +188,20 @@ impl Client {
     }
 }
 
+fn volume_mounts_to_model(mounts: HashMap<String, String>) -> Vec<SandboxVolumeMount> {
+    let mut mounts = mounts
+        .into_iter()
+        .map(|(path, name)| SandboxVolumeMount { name, path })
+        .collect::<Vec<_>>();
+    mounts.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    mounts
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{NewColdSandbox, NewSandbox, RefreshSandbox};
+    use std::collections::HashMap;
+
+    use super::{volume_mounts_to_model, NewColdSandbox, NewSandbox, RefreshSandbox};
 
     #[test]
     fn new_sandbox_serializes_template_start() {
@@ -192,13 +209,23 @@ mod tests {
             template_id: "base-template",
             timeout: Some(300),
             secure: true,
-            volume_mounts: None,
+            volume_mounts: Some(volume_mounts_to_model(HashMap::from([
+                ("/workspace".to_owned(), "source".to_owned()),
+                ("/data".to_owned(), "dataset".to_owned()),
+            ]))),
         };
 
         let value = serde_json::to_value(body).unwrap();
         assert_eq!(value["templateID"], "base-template");
         assert_eq!(value["timeout"], 300);
         assert_eq!(value["secure"], true);
+        assert_eq!(
+            value["volumeMounts"],
+            serde_json::json!([
+                {"name": "dataset", "path": "/data"},
+                {"name": "source", "path": "/workspace"}
+            ])
+        );
         assert!(value.get("cpuCount").is_none());
         assert!(value.get("memoryMB").is_none());
     }

--- a/docs/src/concepts/volumes.md
+++ b/docs/src/concepts/volumes.md
@@ -206,11 +206,20 @@ curl -fsS -X POST "$AENV_URL/sandboxes" \
   -H "Content-Type: application/json" \
   -d '{
     "templateID": "ubuntu",
-    "volumeMounts": {
-      "/workspace/data": "job-42-data"
-    }
+    "volumeMounts": [
+      {
+        "name": "job-42-data",
+        "path": "/workspace/data"
+      }
+    ]
   }'
 ```
+
+The official E2B SDK can create, connect, list, and mount AgentENV volumes. Its
+`Volume.list()` method returns the first bounded page because the SDK does not expose
+AgentENV's pagination cursor. AgentENV also does not implement E2B's standalone
+`/volumecontent` file API; read and write volume content through a sandbox where the
+volume is mounted instead.
 
 List and inspect volumes:
 

--- a/docs/src/concepts/volumes.md
+++ b/docs/src/concepts/volumes.md
@@ -221,6 +221,9 @@ AgentENV's pagination cursor. AgentENV also does not implement E2B's standalone
 `/volumecontent` file API; read and write volume content through a sandbox where the
 volume is mounted instead.
 
+Sandbox responses and new clients use the array representation shown above. For
+backward compatibility, sandbox creation also accepts the legacy path-to-volume map.
+
 List and inspect volumes:
 
 ```bash

--- a/scripts/tests/e2e/e2b_ts_sdk_compat.ts
+++ b/scripts/tests/e2e/e2b_ts_sdk_compat.ts
@@ -2,7 +2,7 @@
 /**
  * E2B TypeScript SDK compatibility checks for AgentENV.
  */
-import { Sandbox, Template, type BuildInfo } from "e2b";
+import { Sandbox, Template, Volume, type BuildInfo } from "e2b";
 
 function log(message: string): void {
   console.log(`[e2b-ts-sdk] ${message}`);
@@ -40,6 +40,8 @@ async function main(): Promise<void> {
     process.env.E2B_COMPAT_TEMPLATE_NAME ?? `e2b-ts-sdk-${Date.now()}`;
   const publicTemplate = (process.env.AENV_TEMPLATE_ID ?? "").trim();
   const derivedTemplateName = `${templateName}-from-template`;
+  const volumeName = `${templateName}-volume`;
+  const volumeMountPath = "/volume";
   const baseImage = process.env.E2B_COMPAT_USER_IMAGE ?? "ghcr.io/linuxserver/baseimage-ubuntu:noble";
   const workdir = `/tmp/${templateName}`;
   const derivedWorkdir = `/tmp/${derivedTemplateName}`;
@@ -58,6 +60,7 @@ async function main(): Promise<void> {
   let derivedBuildInfo: BuildInfo | null = null;
   let sandbox: Sandbox | null = null;
   let derivedSandbox: Sandbox | null = null;
+  let volumeId: string | null = null;
 
   try {
     log(`building template ${templateName} from ${baseImage}`);
@@ -88,7 +91,26 @@ async function main(): Promise<void> {
     check(buildInfo.name === templateName, "template build returned the wrong name");
     log(`template ready: templateId=${buildInfo.templateId} buildId=${buildInfo.buildId}`);
 
-    log("creating sandbox from SDK-built template");
+    log(`creating and connecting volume ${volumeName}`);
+    const createdVolume = await Volume.create(volumeName, connOpts);
+    volumeId = createdVolume.volumeId;
+    check(!!volumeId, "volume create returned an empty volumeId");
+    check(createdVolume.name === volumeName, "volume create returned the wrong name");
+
+    const volumeInfo = await Volume.getInfo(volumeId, connOpts);
+    check(volumeInfo.volumeId === volumeId, "volume getInfo returned the wrong volumeId");
+    check(volumeInfo.name === volumeName, "volume getInfo returned the wrong name");
+
+    const connectedVolume = await Volume.connect(volumeId, connOpts);
+    check(connectedVolume.volumeId === volumeId, "volume connect returned the wrong volumeId");
+    const listedVolumes = await Volume.list(connOpts);
+    check(
+      listedVolumes.some((item) => item.volumeId === volumeId),
+      "Volume.list did not include the created volume in the first page",
+    );
+    log(`volume ready: volumeId=${volumeId}`);
+
+    log("creating sandbox from SDK-built template with an SDK volume mount");
     sandbox = await Sandbox.create(templateName, {
       metadata: {
         suite: "e2b-ts-sdk",
@@ -96,6 +118,9 @@ async function main(): Promise<void> {
       },
       timeoutMs: 90_000,
       secure: true,
+      volumeMounts: {
+        [volumeMountPath]: connectedVolume,
+      },
       ...connOpts,
     });
     check(!!sandbox.sandboxId, "sandbox create returned an empty sandboxId");
@@ -114,7 +139,9 @@ async function main(): Promise<void> {
             `printf 'marker=' && cat marker.txt && ` +
             `printf '\\nworkdir=' && cat workdir.txt && ` +
             `printf '\\nstartup=' && cat startup-ready.txt && ` +
-            `printf '\\nprocess=%s' "$pid_line"`,
+            `printf '\\nprocess=%s' "$pid_line" && ` +
+            `printf '${buildMarker}' > ${volumeMountPath}/sdk-volume-marker && ` +
+            `printf '\\nvolume=' && cat ${volumeMountPath}/sdk-volume-marker`,
           {
             cwd: workdir,
             timeoutMs: 30_000,
@@ -132,6 +159,10 @@ async function main(): Promise<void> {
     check(
       result.stdout.includes(`agentenv-startup-${startupMarker}`),
       "startCmd process was not preserved in the template snapshot",
+    );
+    check(
+      result.stdout.includes(`volume=${buildMarker}`),
+      "SDK-mounted volume was not writable from the sandbox",
     );
     log("command execution returned expected build artifacts and startup state");
 
@@ -238,6 +269,14 @@ async function main(): Promise<void> {
         await sandbox.kill();
       } catch (error) {
         log(`cleanup sandbox kill failed: ${error}`);
+      }
+    }
+
+    if (volumeId !== null) {
+      try {
+        await Volume.destroy(volumeId, connOpts);
+      } catch (error) {
+        log(`cleanup volume destroy failed: ${error}`);
       }
     }
 

--- a/scripts/tests/e2e/e2b_ts_sdk_compat.ts
+++ b/scripts/tests/e2e/e2b_ts_sdk_compat.ts
@@ -104,11 +104,12 @@ async function main(): Promise<void> {
     const connectedVolume = await Volume.connect(volumeId, connOpts);
     check(connectedVolume.volumeId === volumeId, "volume connect returned the wrong volumeId");
     const listedVolumes = await Volume.list(connOpts);
+    check(listedVolumes.length > 0, "Volume.list returned an empty first page");
     check(
-      listedVolumes.some((item) => item.volumeId === volumeId),
-      "Volume.list did not include the created volume in the first page",
+      listedVolumes.every((item) => !!item.volumeId && !!item.name),
+      "Volume.list returned an invalid volume entry",
     );
-    log(`volume ready: volumeId=${volumeId}`);
+    log(`volume ready: volumeId=${volumeId}; first page size=${listedVolumes.length}`);
 
     log("creating sandbox from SDK-built template with an SDK volume mount");
     sandbox = await Sandbox.create(templateName, {

--- a/scripts/tests/e2e/suites/09_e2b_compat.sh
+++ b/scripts/tests/e2e/suites/09_e2b_compat.sh
@@ -149,8 +149,9 @@ fi
 ts_sdk_script="${SUITE_DIR}/../e2b_ts_sdk_compat.ts"
 tsx_bin="${SUITE_DIR}/../node_modules/.bin/tsx"
 if [[ -f "$ts_sdk_script" ]] && command -v npm >/dev/null 2>&1; then
-  log "Installing TypeScript SDK dependencies"
-  (cd "${SUITE_DIR}/.." && npm install --no-save --package-lock=false e2b@latest 2>&1)
+  e2b_ts_sdk_version="${E2B_COMPAT_TS_SDK_VERSION:-2.38.0}"
+  log "Installing TypeScript SDK dependencies (e2b@${e2b_ts_sdk_version})"
+  (cd "${SUITE_DIR}/.." && npm install --no-save --package-lock=false "e2b@${e2b_ts_sdk_version}" 2>&1)
   if ! "$tsx_bin" --version >/dev/null 2>&1; then
     warn "tsx not available after npm install; skipping TypeScript SDK checks"
     _pass "skipped TypeScript SDK checks (tsx not available)"
@@ -159,13 +160,13 @@ if [[ -f "$ts_sdk_script" ]] && command -v npm >/dev/null 2>&1; then
   log "Running: e2b TypeScript SDK compatibility (${ts_sdk_script})"
   if command -v timeout >/dev/null 2>&1; then
     if sdk_output=$(timeout "${sdk_timeout}" "$tsx_bin" "$ts_sdk_script" 2>&1); then
-      _pass "e2b TypeScript SDK template build, startCmd/readyCmd, sandbox lifecycle, and commands"
+      _pass "e2b TypeScript SDK template, volume mount, sandbox lifecycle, and commands"
     else
       log "e2b TypeScript SDK output: ${sdk_output:0:1200}"
       _fail "e2b TypeScript SDK compatibility" "exit 0" "non-zero"
     fi
   elif sdk_output=$("$tsx_bin" "$ts_sdk_script" 2>&1); then
-    _pass "e2b TypeScript SDK template build, startCmd/readyCmd, sandbox lifecycle, and commands"
+    _pass "e2b TypeScript SDK template, volume mount, sandbox lifecycle, and commands"
   else
     log "e2b TypeScript SDK output: ${sdk_output:0:1200}"
     _fail "e2b TypeScript SDK compatibility" "exit 0" "non-zero"

--- a/scripts/tests/e2e/suites/15_volume.sh
+++ b/scripts/tests/e2e/suites/15_volume.sh
@@ -98,7 +98,7 @@ cold_payload=$(jq -nc \
     image: $image,
     timeout: 300,
     autoPause: false,
-    volumeMounts: {($mount_path): $volume_id}
+    volumeMounts: [{name: $volume_id, path: $mount_path}]
   }')
 api_post "/sandboxes-cold" "${cold_payload}"
 assert_status "${HTTP_STATUS}" "201" "create cold-image sandbox with a volume"
@@ -139,7 +139,7 @@ track_sandbox "${restored_sandbox_id}"
 api_get "/sandboxes/${restored_sandbox_id}"
 assert_status "${HTTP_STATUS}" "200" "get restored cold-image sandbox"
 restored_volume_id="$(echo "${HTTP_BODY}" | jq -r \
-  --arg path "${VOLUME_MOUNT_PATH}" '.volumeMounts[$path] // empty')"
+  --arg path "${VOLUME_MOUNT_PATH}" '.volumeMounts[] | select(.path == $path) | .name')"
 assert_not_empty "${restored_volume_id}" "automatically restored volume ID is present"
 assert_not_eq "${restored_volume_id}" "${source_volume_id}" \
   "volume snapshot restore creates an independent volume"

--- a/scripts/tests/e2e/suites/15_volume.sh
+++ b/scripts/tests/e2e/suites/15_volume.sh
@@ -90,6 +90,7 @@ source_volume_id="$(echo "${HTTP_BODY}" | jq -r '.volumeID // empty')"
 assert_not_empty "${source_volume_id}" "cold-image source volume ID is present"
 CREATED_VOLUME_IDS+=("${source_volume_id}")
 
+# Keep one E2E request on the legacy map representation for compatibility coverage.
 cold_payload=$(jq -nc \
   --arg image "${E2E_DEFAULT_USER_IMAGE}" \
   --arg volume_id "${source_volume_id}" \
@@ -98,7 +99,7 @@ cold_payload=$(jq -nc \
     image: $image,
     timeout: 300,
     autoPause: false,
-    volumeMounts: [{name: $volume_id, path: $mount_path}]
+    volumeMounts: {($mount_path): $volume_id}
   }')
 api_post "/sandboxes-cold" "${cold_payload}"
 assert_status "${HTTP_STATUS}" "201" "create cold-image sandbox with a volume"

--- a/scripts/tests/e2e/suites/16_volume_randomized.sh
+++ b/scripts/tests/e2e/suites/16_volume_randomized.sh
@@ -169,7 +169,7 @@ start_volume_sandbox() {
     --arg suite "${run_name}" \
     --arg step "${CURRENT_STEP}" \
     --arg mount_path "${VOLUME_MOUNT_PATH}" \
-    '{autoPause: false, metadata: {suite: $suite, step: $step}, volumeMounts: {($mount_path): $volume_id}}')
+    '{autoPause: false, metadata: {suite: $suite, step: $step}, volumeMounts: [{name: $volume_id, path: $mount_path}]}')
   LAST_SANDBOX_ID=$(create_sandbox "${AENV_TEMPLATE_ID}" 300 "${mount_payload}")
   _sync_http
   assert_status "${HTTP_STATUS}" "201" "${CURRENT_STEP}: create volume sandbox through gateway"
@@ -293,7 +293,8 @@ fork_volume_cycle() {
   assert_status "${HTTP_STATUS}" "200" \
     "${CURRENT_STEP}: fork child is immediately routable through gateway"
   local child_volume_id
-  child_volume_id="$(echo "${HTTP_BODY}" | jq -r --arg path "${VOLUME_MOUNT_PATH}" '.volumeMounts[$path] // empty')"
+  child_volume_id="$(echo "${HTTP_BODY}" | jq -r --arg path "${VOLUME_MOUNT_PATH}" \
+    '.volumeMounts[] | select(.path == $path) | .name')"
   assert_not_empty "${child_volume_id}" "${CURRENT_STEP}: fork child volume ID is present"
   register_volume "${child_volume_id}" "exclusive" "${VOLUME_CONTENT[${source_volume_id}]}"
   log "seed=${VOLUME_RANDOM_SEED} step=${CURRENT_STEP} fork-volume=${child_volume_id} source=${source_volume_id}"

--- a/src/api/generated/src/models.rs
+++ b/src/api/generated/src/models.rs
@@ -2604,11 +2604,10 @@ pub struct NewColdSandbox {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_extension_params: Option<std::collections::HashMap<String, crate::types::Object>>,
 
-    /// Volumes to mount in the sandbox.
     #[serde(rename = "volumeMounts")]
     #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_mounts: Option<Vec<models::SandboxVolumeMount>>,
+    pub volume_mounts: Option<models::VolumeMountsRequest>,
 
     /// CPU cores for the cold-start sandbox.
     #[serde(rename = "cpuCount")]
@@ -2747,7 +2746,7 @@ impl std::str::FromStr for NewColdSandbox {
             pub env_vars: Vec<std::collections::HashMap<String, String>>,
             pub custom_extension_params:
                 Vec<std::collections::HashMap<String, crate::types::Object>>,
-            pub volume_mounts: Vec<Vec<models::SandboxVolumeMount>>,
+            pub volume_mounts: Vec<models::VolumeMountsRequest>,
             pub cpu_count: Vec<u32>,
             pub memory_mb: Vec<u32>,
             pub disk_size_mb: Vec<u32>,
@@ -2822,12 +2821,11 @@ impl std::str::FromStr for NewColdSandbox {
                                 .to_string(),
                         );
                     }
-                    "volumeMounts" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in NewColdSandbox"
-                                .to_string(),
-                        );
-                    }
+                    #[allow(clippy::redundant_clone)]
+                    "volumeMounts" => intermediate_rep.volume_mounts.push(
+                        <models::VolumeMountsRequest as std::str::FromStr>::from_str(val)
+                            .map_err(|x| x.to_string())?,
+                    ),
                     #[allow(clippy::redundant_clone)]
                     "cpuCount" => intermediate_rep.cpu_count.push(
                         <u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
@@ -2992,11 +2990,10 @@ pub struct NewSandbox {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mcp: Option<Nullable<std::collections::HashMap<String, crate::types::Object>>>,
 
-    /// Volumes to mount in the sandbox.
     #[serde(rename = "volumeMounts")]
     #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_mounts: Option<Vec<models::SandboxVolumeMount>>,
+    pub volume_mounts: Option<models::VolumeMountsRequest>,
 }
 
 impl NewSandbox {
@@ -3092,7 +3089,7 @@ impl std::str::FromStr for NewSandbox {
             pub custom_extension_params:
                 Vec<std::collections::HashMap<String, crate::types::Object>>,
             pub mcp: Vec<std::collections::HashMap<String, crate::types::Object>>,
-            pub volume_mounts: Vec<Vec<models::SandboxVolumeMount>>,
+            pub volume_mounts: Vec<models::VolumeMountsRequest>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -3168,12 +3165,11 @@ impl std::str::FromStr for NewSandbox {
                                 .to_string(),
                         );
                     }
-                    "volumeMounts" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in NewSandbox"
-                                .to_string(),
-                        );
-                    }
+                    #[allow(clippy::redundant_clone)]
+                    "volumeMounts" => intermediate_rep.volume_mounts.push(
+                        <models::VolumeMountsRequest as std::str::FromStr>::from_str(val)
+                            .map_err(|x| x.to_string())?,
+                    ),
                     _ => {
                         return std::result::Result::Err(
                             "Unexpected key while parsing NewSandbox".to_string(),
@@ -9712,5 +9708,45 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Volume> {
                 r#"Unable to convert header: {hdr_value:?} to string: {e}"#
             )),
         }
+    }
+}
+
+/// Volumes to mount in the sandbox.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+#[allow(non_camel_case_types, clippy::large_enum_variant)]
+pub enum VolumeMountsRequest {
+    VecOfSandboxVolumeMount(Vec<models::SandboxVolumeMount>),
+    HashMapOfStringString(std::collections::HashMap<String, String>),
+}
+
+impl validator::Validate for VolumeMountsRequest {
+    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
+        match self {
+            Self::VecOfSandboxVolumeMount(_) => std::result::Result::Ok(()),
+            Self::HashMapOfStringString(_) => std::result::Result::Ok(()),
+        }
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a VolumeMountsRequest value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for VolumeMountsRequest {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl From<Vec<models::SandboxVolumeMount>> for VolumeMountsRequest {
+    fn from(value: Vec<models::SandboxVolumeMount>) -> Self {
+        Self::VecOfSandboxVolumeMount(value)
+    }
+}
+impl From<std::collections::HashMap<String, String>> for VolumeMountsRequest {
+    fn from(value: std::collections::HashMap<String, String>) -> Self {
+        Self::HashMapOfStringString(value)
     }
 }

--- a/src/api/generated/src/models.rs
+++ b/src/api/generated/src/models.rs
@@ -1887,11 +1887,11 @@ pub struct ListedSandbox {
     #[validate(custom(function = "check_xss_string"))]
     pub envd_version: String,
 
-    /// Map of absolute guest mount paths to volume IDs or names.
+    /// Volumes to mount in the sandbox.
     #[serde(rename = "volumeMounts")]
-    #[validate(custom(function = "check_xss_map_string"))]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_mounts: Option<std::collections::HashMap<String, String>>,
+    pub volume_mounts: Option<Vec<models::SandboxVolumeMount>>,
 }
 
 impl ListedSandbox {
@@ -1989,7 +1989,7 @@ impl std::str::FromStr for ListedSandbox {
             pub metadata: Vec<std::collections::HashMap<String, String>>,
             pub state: Vec<models::SandboxState>,
             pub envd_version: Vec<String>,
-            pub volume_mounts: Vec<std::collections::HashMap<String, String>>,
+            pub volume_mounts: Vec<Vec<models::SandboxVolumeMount>>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -2604,11 +2604,11 @@ pub struct NewColdSandbox {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_extension_params: Option<std::collections::HashMap<String, crate::types::Object>>,
 
-    /// Map of absolute guest mount paths to volume IDs or names.
+    /// Volumes to mount in the sandbox.
     #[serde(rename = "volumeMounts")]
-    #[validate(custom(function = "check_xss_map_string"))]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_mounts: Option<std::collections::HashMap<String, String>>,
+    pub volume_mounts: Option<Vec<models::SandboxVolumeMount>>,
 
     /// CPU cores for the cold-start sandbox.
     #[serde(rename = "cpuCount")]
@@ -2747,7 +2747,7 @@ impl std::str::FromStr for NewColdSandbox {
             pub env_vars: Vec<std::collections::HashMap<String, String>>,
             pub custom_extension_params:
                 Vec<std::collections::HashMap<String, crate::types::Object>>,
-            pub volume_mounts: Vec<std::collections::HashMap<String, String>>,
+            pub volume_mounts: Vec<Vec<models::SandboxVolumeMount>>,
             pub cpu_count: Vec<u32>,
             pub memory_mb: Vec<u32>,
             pub disk_size_mb: Vec<u32>,
@@ -2992,11 +2992,11 @@ pub struct NewSandbox {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mcp: Option<Nullable<std::collections::HashMap<String, crate::types::Object>>>,
 
-    /// Map of absolute guest mount paths to volume IDs or names.
+    /// Volumes to mount in the sandbox.
     #[serde(rename = "volumeMounts")]
-    #[validate(custom(function = "check_xss_map_string"))]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_mounts: Option<std::collections::HashMap<String, String>>,
+    pub volume_mounts: Option<Vec<models::SandboxVolumeMount>>,
 }
 
 impl NewSandbox {
@@ -3092,7 +3092,7 @@ impl std::str::FromStr for NewSandbox {
             pub custom_extension_params:
                 Vec<std::collections::HashMap<String, crate::types::Object>>,
             pub mcp: Vec<std::collections::HashMap<String, crate::types::Object>>,
-            pub volume_mounts: Vec<std::collections::HashMap<String, String>>,
+            pub volume_mounts: Vec<Vec<models::SandboxVolumeMount>>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -5227,11 +5227,11 @@ pub struct SandboxDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<models::SandboxLifecycle>,
 
-    /// Map of absolute guest mount paths to volume IDs or names.
+    /// Volumes to mount in the sandbox.
     #[serde(rename = "volumeMounts")]
-    #[validate(custom(function = "check_xss_map_string"))]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_mounts: Option<std::collections::HashMap<String, String>>,
+    pub volume_mounts: Option<Vec<models::SandboxVolumeMount>>,
 }
 
 impl SandboxDetail {
@@ -5367,7 +5367,7 @@ impl std::str::FromStr for SandboxDetail {
             pub state: Vec<models::SandboxState>,
             pub network: Vec<models::SandboxNetworkConfig>,
             pub lifecycle: Vec<models::SandboxLifecycle>,
-            pub volume_mounts: Vec<std::collections::HashMap<String, String>>,
+            pub volume_mounts: Vec<Vec<models::SandboxVolumeMount>>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -6899,6 +6899,159 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<SandboxTimeo
                     }
                     std::result::Result::Err(err) => std::result::Result::Err(format!(
                         r#"Unable to convert header value '{value}' into SandboxTimeoutRequest - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SandboxVolumeMount {
+    /// Volume ID or unique name.
+    #[serde(rename = "name")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub name: String,
+
+    /// Absolute guest mount path.
+    #[serde(rename = "path")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub path: String,
+}
+
+impl SandboxVolumeMount {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(name: String, path: String) -> SandboxVolumeMount {
+        SandboxVolumeMount { name, path }
+    }
+}
+
+/// Converts the SandboxVolumeMount value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for SandboxVolumeMount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("name".to_string()),
+            Some(self.name.to_string()),
+            Some("path".to_string()),
+            Some(self.path.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a SandboxVolumeMount value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for SandboxVolumeMount {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub name: Vec<String>,
+            pub path: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing SandboxVolumeMount".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "name" => intermediate_rep.name.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "path" => intermediate_rep.path.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing SandboxVolumeMount".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(SandboxVolumeMount {
+            name: intermediate_rep
+                .name
+                .into_iter()
+                .next()
+                .ok_or_else(|| "name missing in SandboxVolumeMount".to_string())?,
+            path: intermediate_rep
+                .path
+                .into_iter()
+                .next()
+                .ok_or_else(|| "path missing in SandboxVolumeMount".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<SandboxVolumeMount> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<SandboxVolumeMount>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<SandboxVolumeMount>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for SandboxVolumeMount - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<SandboxVolumeMount> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <SandboxVolumeMount as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into SandboxVolumeMount - {err}"#
                     )),
                 }
             }

--- a/src/api/impls/sandbox.rs
+++ b/src/api/impls/sandbox.rs
@@ -118,8 +118,27 @@ fn volume_mounts_model(
 }
 
 fn volume_mounts_from_model(
-    mounts: &[models::SandboxVolumeMount],
+    mounts: &models::VolumeMountsRequest,
 ) -> Result<HashMap<String, String>, models::Error> {
+    // OpenAPI Generator's oneOf validation is shallow, so validate both aliases here.
+    let mounts = match mounts {
+        models::VolumeMountsRequest::VecOfSandboxVolumeMount(mounts) => {
+            if mounts.iter().any(|mount| {
+                models::check_xss_string(&mount.name).is_err()
+                    || models::check_xss_string(&mount.path).is_err()
+            }) {
+                return Err(ApiImpl::error(400, "volume mounts contain invalid text"));
+            }
+            mounts
+        }
+        models::VolumeMountsRequest::HashMapOfStringString(mounts) => {
+            if models::check_xss_map_string(mounts).is_err() {
+                return Err(ApiImpl::error(400, "volume mounts contain invalid text"));
+            }
+            return Ok(mounts.clone());
+        }
+    };
+
     let mut result = HashMap::with_capacity(mounts.len());
     for mount in mounts {
         if result
@@ -747,7 +766,7 @@ impl Sandboxes<()> for ApiImpl {
             ));
         }
 
-        let requested_volume_mounts = match body.volume_mounts.as_deref() {
+        let requested_volume_mounts = match body.volume_mounts.as_ref() {
             Some(mounts) => match volume_mounts_from_model(mounts) {
                 Ok(mounts) => Some(mounts),
                 Err(error) => {
@@ -961,7 +980,7 @@ impl Sandboxes<()> for ApiImpl {
         let extra_drives_in_snapshot =
             body.volume_mounts.is_none() && !snapshot.committed().volume_snapshots.is_empty();
         let (requested_volume_mounts, restored_volume_ids) = if let Some(mounts) =
-            body.volume_mounts.as_deref()
+            body.volume_mounts.as_ref()
         {
             match volume_mounts_from_model(mounts) {
                 Ok(mounts) => (Some(mounts), Vec::new()),
@@ -1924,15 +1943,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn volume_mount_models_reject_duplicate_paths() {
-        let mounts = vec![
+    fn volume_mount_models_accept_legacy_maps_and_validate_both_forms() {
+        let mounts = models::VolumeMountsRequest::VecOfSandboxVolumeMount(vec![
             models::SandboxVolumeMount::new("first".to_owned(), "/data".to_owned()),
             models::SandboxVolumeMount::new("second".to_owned(), "/data".to_owned()),
-        ];
+        ]);
 
         let error = volume_mounts_from_model(&mounts).unwrap_err();
         assert_eq!(error.code, 400);
         assert!(error.message.contains("duplicated"));
+
+        let legacy_mounts = HashMap::from([("/data".to_owned(), "volume".to_owned())]);
+        let mounts = models::VolumeMountsRequest::HashMapOfStringString(legacy_mounts.clone());
+        assert_eq!(volume_mounts_from_model(&mounts).unwrap(), legacy_mounts);
+
+        let mounts = models::VolumeMountsRequest::VecOfSandboxVolumeMount(vec![
+            models::SandboxVolumeMount::new("<script>bad</script>".to_owned(), "/data".to_owned()),
+        ]);
+        assert_eq!(volume_mounts_from_model(&mounts).unwrap_err().code, 400);
+
+        let mounts = models::VolumeMountsRequest::HashMapOfStringString(HashMap::from([(
+            "/data".to_owned(),
+            "<script>bad</script>".to_owned(),
+        )]));
+        assert_eq!(volume_mounts_from_model(&mounts).unwrap_err().code, 400);
     }
 
     #[test]

--- a/src/api/impls/sandbox.rs
+++ b/src/api/impls/sandbox.rs
@@ -102,8 +102,37 @@ fn end_at(expires_at: Option<SystemTime>) -> chrono::DateTime<chrono::Utc> {
         ))
 }
 
-fn volume_mounts_model(mounts: &HashMap<String, String>) -> Option<HashMap<String, String>> {
-    (!mounts.is_empty()).then(|| mounts.clone())
+fn volume_mounts_model(
+    mounts: &HashMap<String, String>,
+) -> Option<Vec<models::SandboxVolumeMount>> {
+    if mounts.is_empty() {
+        return None;
+    }
+
+    let mut mounts = mounts
+        .iter()
+        .map(|(path, name)| models::SandboxVolumeMount::new(name.clone(), path.clone()))
+        .collect::<Vec<_>>();
+    mounts.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    Some(mounts)
+}
+
+fn volume_mounts_from_model(
+    mounts: &[models::SandboxVolumeMount],
+) -> Result<HashMap<String, String>, models::Error> {
+    let mut result = HashMap::with_capacity(mounts.len());
+    for mount in mounts {
+        if result
+            .insert(mount.path.clone(), mount.name.clone())
+            .is_some()
+        {
+            return Err(ApiImpl::error(
+                400,
+                format!("volume mount path is duplicated: {}", mount.path),
+            ));
+        }
+    }
+    Ok(result)
 }
 
 #[derive(Default)]
@@ -718,12 +747,21 @@ impl Sandboxes<()> for ApiImpl {
             ));
         }
 
+        let requested_volume_mounts = match body.volume_mounts.as_deref() {
+            Some(mounts) => match volume_mounts_from_model(mounts) {
+                Ok(mounts) => Some(mounts),
+                Err(error) => {
+                    return Ok(SandboxesColdPostResponse::Status400_BadRequest(error));
+                }
+            },
+            None => None,
+        };
         let PreparedVolumeMounts {
             owner: pending_volume_owner,
             drives: volume_drives,
             mounts: volume_mounts,
             volume_ids: reserved_volume_ids,
-        } = match prepare_volume_mounts(self, body.volume_mounts.as_ref()).await {
+        } = match prepare_volume_mounts(self, requested_volume_mounts.as_ref()).await {
             Ok(prepared) => prepared,
             Err(error) if error.code >= 500 => {
                 return Ok(SandboxesColdPostResponse::Status500_ServerError(error));
@@ -922,8 +960,15 @@ impl Sandboxes<()> for ApiImpl {
 
         let extra_drives_in_snapshot =
             body.volume_mounts.is_none() && !snapshot.committed().volume_snapshots.is_empty();
-        let (requested_volume_mounts, restored_volume_ids) = if body.volume_mounts.is_some() {
-            (body.volume_mounts.clone(), Vec::new())
+        let (requested_volume_mounts, restored_volume_ids) = if let Some(mounts) =
+            body.volume_mounts.as_deref()
+        {
+            match volume_mounts_from_model(mounts) {
+                Ok(mounts) => (Some(mounts), Vec::new()),
+                Err(error) => {
+                    return Ok(SandboxesPostResponse::Status400_BadRequest(error));
+                }
+            }
         } else {
             match restore_snapshot_volume_mounts(self, &snapshot).await {
                 Ok((mounts, volume_ids)) => ((!mounts.is_empty()).then_some(mounts), volume_ids),
@@ -1877,6 +1922,18 @@ impl Sandboxes<()> for ApiImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn volume_mount_models_reject_duplicate_paths() {
+        let mounts = vec![
+            models::SandboxVolumeMount::new("first".to_owned(), "/data".to_owned()),
+            models::SandboxVolumeMount::new("second".to_owned(), "/data".to_owned()),
+        ];
+
+        let error = volume_mounts_from_model(&mounts).unwrap_err();
+        assert_eq!(error.code, 400);
+        assert!(error.message.contains("duplicated"));
+    }
 
     #[test]
     fn parse_metadata_filter_with_none_returns_none() {

--- a/src/api/openapi.yml
+++ b/src/api/openapi.yml
@@ -301,11 +301,24 @@ components:
           type: string
           description: OCI or OverlayBD image reference for the initial content.
 
-    VolumeMounts:
+    SandboxVolumeMount:
       type: object
-      description: Map of absolute guest mount paths to volume IDs or names.
-      additionalProperties:
-        type: string
+      required:
+        - name
+        - path
+      properties:
+        name:
+          type: string
+          description: Volume ID or unique name.
+        path:
+          type: string
+          description: Absolute guest mount path.
+
+    VolumeMounts:
+      type: array
+      description: Volumes to mount in the sandbox.
+      items:
+        $ref: "#/components/schemas/SandboxVolumeMount"
 
     AttachedDriveSource:
       type: object

--- a/src/api/openapi.yml
+++ b/src/api/openapi.yml
@@ -320,6 +320,20 @@ components:
       items:
         $ref: "#/components/schemas/SandboxVolumeMount"
 
+    LegacyVolumeMounts:
+      type: object
+      description: >-
+        Legacy map of absolute guest mount paths to volume IDs or names. New
+        clients should use the SandboxVolumeMount array representation.
+      additionalProperties:
+        type: string
+
+    VolumeMountsRequest:
+      description: Volumes to mount in the sandbox.
+      oneOf:
+        - $ref: "#/components/schemas/VolumeMounts"
+        - $ref: "#/components/schemas/LegacyVolumeMounts"
+
     AttachedDriveSource:
       type: object
       description: >
@@ -651,7 +665,7 @@ components:
         mcp:
           $ref: "#/components/schemas/Mcp"
         volumeMounts:
-          $ref: "#/components/schemas/VolumeMounts"
+          $ref: "#/components/schemas/VolumeMountsRequest"
 
     ResumedSandbox:
       properties:
@@ -701,7 +715,7 @@ components:
         customExtensionParams:
           $ref: "#/components/schemas/CustomExtensionParams"
         volumeMounts:
-          $ref: "#/components/schemas/VolumeMounts"
+          $ref: "#/components/schemas/VolumeMountsRequest"
         cpuCount:
           allOf:
             - $ref: "#/components/schemas/CPUCount"

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1948,22 +1948,32 @@ mod tests {
     }
 
     #[test]
-    fn e2b_volume_mounts_use_the_sdk_array_representation() {
+    fn volume_mounts_accept_e2b_arrays_and_legacy_maps() {
         let request: agentenv_http_server::models::NewSandbox = serde_json::from_value(json!({
             "templateID": "template",
             "volumeMounts": [{"name": "vol_123", "path": "/mnt/data"}]
         }))
         .expect("E2B volumeMounts array should deserialize");
-        let mounts = request.volume_mounts.unwrap();
+        let agentenv_http_server::models::VolumeMountsRequest::VecOfSandboxVolumeMount(mounts) =
+            request.volume_mounts.unwrap()
+        else {
+            panic!("E2B volumeMounts should use the array variant");
+        };
         assert_eq!(mounts.len(), 1);
         assert_eq!(mounts[0].name, "vol_123");
         assert_eq!(mounts[0].path, "/mnt/data");
 
-        serde_json::from_value::<agentenv_http_server::models::NewSandbox>(json!({
+        let request: agentenv_http_server::models::NewSandbox = serde_json::from_value(json!({
             "templateID": "template",
             "volumeMounts": {"/mnt/data": "vol_123"}
         }))
-        .expect_err("map form is not the E2B API");
+        .expect("legacy volumeMounts map should deserialize");
+        let agentenv_http_server::models::VolumeMountsRequest::HashMapOfStringString(mounts) =
+            request.volume_mounts.unwrap()
+        else {
+            panic!("legacy volumeMounts should use the map variant");
+        };
+        assert_eq!(mounts.get("/mnt/data"), Some(&"vol_123".to_owned()));
     }
 
     #[tokio::test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1948,22 +1948,22 @@ mod tests {
     }
 
     #[test]
-    fn e2b_volume_mounts_use_a_path_to_volume_map() {
+    fn e2b_volume_mounts_use_the_sdk_array_representation() {
         let request: agentenv_http_server::models::NewSandbox = serde_json::from_value(json!({
-            "templateID": "template",
-            "volumeMounts": {"/mnt/data": "vol_123"}
-        }))
-        .expect("E2B volumeMounts map should deserialize");
-        assert_eq!(
-            request.volume_mounts.unwrap().get("/mnt/data"),
-            Some(&"vol_123".to_string())
-        );
-
-        serde_json::from_value::<agentenv_http_server::models::NewSandbox>(json!({
             "templateID": "template",
             "volumeMounts": [{"name": "vol_123", "path": "/mnt/data"}]
         }))
-        .expect_err("array form is not the issue 211 API");
+        .expect("E2B volumeMounts array should deserialize");
+        let mounts = request.volume_mounts.unwrap();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].name, "vol_123");
+        assert_eq!(mounts[0].path, "/mnt/data");
+
+        serde_json::from_value::<agentenv_http_server::models::NewSandbox>(json!({
+            "templateID": "template",
+            "volumeMounts": {"/mnt/data": "vol_123"}
+        }))
+        .expect_err("map form is not the E2B API");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

- use the official E2B `SandboxVolumeMount[]` wire representation for responses and new clients while accepting legacy map requests
- translate both request forms into AgentENV's internal path-to-volume map and reject duplicate array paths
- extend the TypeScript SDK E2E test with volume create, inspect, connect, bounded list, mount, and guest write/read coverage using `e2b@2.38.0`
- update the bundled CLI client, native volume E2E suites, and volume documentation for the array representation

## Why

The official TypeScript SDK serializes `volumeMounts` as an array of `{name, path}` objects. AgentENV expected a map, so otherwise valid SDK sandbox creation failed with HTTP 422 after volume control-plane calls succeeded.

## Related issue

Closes #257

## Scope and non-goals

This PR fixes SDK-managed volume mounting and documents the supported boundary. It does not add E2B's standalone `/volumecontent` data plane, so AgentENV does not return a volume token or domain. In particular, it does not return an empty, placeholder, or API-key-derived token. Volume contents remain accessible through a sandbox mount.

`Volume.list()` sends no pagination parameters and does not consume `X-Next-Token`. AgentENV intentionally keeps its existing bounded default page of 100 volumes instead of returning the full catalog; the SDK therefore sees the first page only.

## Design and behavior changes

The OpenAPI response schema uses an array of `SandboxVolumeMount` objects. Request models use an untagged `oneOf` that accepts either that array or the legacy path-to-volume map. API handlers convert both forms to the existing internal mount map before volume reservation and convert stored maps back to deterministically sorted arrays in responses. Duplicate array paths are rejected with HTTP 400 before any volume is reserved.

The E2E test uses the same SDK path as applications: `Volume.create`, `Volume.getInfo`, `Volume.connect`, `Volume.list`, and `Sandbox.create` with the connected volume. It writes and reads a marker through the guest mount to verify the mount is usable.

## Compatibility and operations

- Public API or generated protocol: `volumeMounts` requests accept both the AgentENV map and official E2B array representations. Responses and the bundled client use the E2B array. Generated server models were regenerated.
- Configuration or defaults: no change; volume listing without parameters remains bounded at 100 records.
- Snapshot manifest, artifact layout, or storage format: no change; internal mount maps and snapshot data are unchanged.
- Upgrade and rollback: existing map callers continue to work; new callers should use `{name, path}[]`. Rolling back requires new clients to restore the map payload.
- Host requirements, permissions, ports, or dependencies: no runtime change. The E2E suite pins `e2b@2.38.0` as a test-only dependency.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [ ] Relevant Rust integration tests
- [x] Generated clients/server regenerated with the documented `make` target
- [x] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
make agentenv-server
cargo test -p agentenv --lib volume_mount
cargo test -p aenv
make fmt
make clippy
make test-unit
bash -n scripts/tests/e2e/suites/09_e2b_compat.sh scripts/tests/e2e/suites/15_volume.sh scripts/tests/e2e/suites/16_volume_randomized.sh
shellcheck scripts/tests/e2e/suites/09_e2b_compat.sh scripts/tests/e2e/suites/15_volume.sh scripts/tests/e2e/suites/16_volume_randomized.sh
(cd scripts/tests/e2e && npm install --no-save --package-lock=false e2b@2.38.0 typescript)
(cd scripts/tests/e2e && ./node_modules/.bin/tsc --noEmit)
make test-e2e SUITE_FILTER='09_e2b_compat.sh' AENV_PORT=18158 AENV_HOME_PATH=/tmp/aenv-issue257-compat-e2e/sdk-home AENV_RUNTIME_PATH=/tmp/aenv-issue257-compat-e2e/sdk-run AENV_DEPS_PATH=/var/lib/aenv/deps E2B_COMPAT_TS_SDK_VERSION=2.38.0
make test-e2e SUITE_FILTER='15_volume.sh' AENV_PORT=18159 AENV_HOME_PATH=/tmp/aenv-issue257-compat-e2e/legacy-home AENV_RUNTIME_PATH=/tmp/aenv-issue257-compat-e2e/legacy-run AENV_DEPS_PATH=/var/lib/aenv/deps
```

All listed commands passed. The SDK E2E suite passed all 8 checks, and the legacy-map volume lifecycle suite passed all 39 checks while validating array responses. An initial SDK E2E retry timed out during base-template setup after repeated GHCR EOFs; the same command passed once the registry recovered.

Skipped checks and reasons:

- `make -C services test`: no `services/` changes.
- dedicated Rust integration targets: the focused official-SDK VM E2E directly exercises the changed API and mount path.
- benchmarks: no performance-sensitive implementation change.

## Risks and reviewer notes

The request compatibility model is intentionally limited to the two documented representations. Responses always use the E2B array, and the core volume reservation, snapshot, and storage paths remain unchanged behind the API conversion.

E2B's volume token is used only by its separate volume-content client as a Bearer token for `/volumecontent/{volumeID}` requests. Sandbox mount serialization uses the volume name and does not consume that token, which is why mounted access is supported without inventing data-plane credentials.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
