### PR TITLE
feat(snapshot): prefetch envd memory pages at resume for faster envd-ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ env/
 
 ### Node.js
 node_modules/
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,13 @@ implementation rather than after mistakes.
   to memory, rootfs, attached-drive, and volume layers. Capture leaves the source
   running; launching it creates a new sandbox. Pause/resume retains the existing
   ID through separate paused-sandbox persistence. Template builds commit snapshots.
+  At capture, the guest init daemon's (envd) resident guest-physical memory
+  ranges are also exported and published as a `memory-prefetch.json` artifact
+  next to `vm_state.bin`; at resume, AgentENV bulk-prefetches those pages into
+  the node's remote-block cache via the ublk daemon so the init path does not
+  stall on one-at-a-time remote reads. The prefetch is strictly best-effort:
+  missing, unreadable, or oversized manifests are ignored and resume always
+  falls back to the on-demand path.
 - **Volume:** An independently managed block filesystem that survives sandbox
   deletion. `exclusive` permits one writable mount; `ro` permits shared read-only
   mounts. `volumeMounts` references managed volumes; cold-start `attachedDrives`

--- a/docs/src/concepts/snapshots.md
+++ b/docs/src/concepts/snapshots.md
@@ -44,6 +44,25 @@ curl -H 'X-API-Key: test-key' \
   http://127.0.0.1:8000/snapshots/<snapshot-id-or-alias>
 ```
 
+## Resume-Time Memory Prefetch
+
+When a snapshot is created, AgentENV also records which guest-physical memory
+pages the sandbox's init process (envd) had resident, and stores the list as a
+small `memory-prefetch.json` artifact next to `vm_state.bin` in the snapshot
+repository. When a sandbox is later started from that snapshot, AgentENV
+bulk-prefetches those pages into the node's local remote-block cache before the
+VM resumes, so the init process and early startup path no longer wait on
+one-at-a-time remote reads.
+
+The prefetch is strictly best-effort:
+
+- Snapshots created before this feature (or from guests where the init process
+  cannot be inspected) simply resume through the normal on-demand path.
+- A missing, unreadable, or oversized manifest is ignored; resume never fails
+  because of it.
+
+No configuration is required.
+
 ## Use a Snapshot Rootfs as an OCI Image
 
 Starting with `aenv start <snapshot>` restores the complete snapshot state. If

--- a/src/sandbox/firecracker/config.rs
+++ b/src/sandbox/firecracker/config.rs
@@ -473,6 +473,10 @@ pub struct FirecrackerSnapshotConfig {
     /// `Some` is used for keeping the snapshot directory alive across multiple pause/resume cycles.
     #[serde(skip)]
     pub(super) managed_snapshot_root: Option<Arc<PersistentSnapshotRootGuard>>,
+    /// Local path of the optional memory prefetch manifest, resolved at
+    /// snapshot-resolve time. Runtime-only: not persisted across pause/resume.
+    #[serde(skip)]
+    pub memory_prefetch_path: Option<PathBuf>,
 }
 
 impl FirecrackerSnapshotConfig {
@@ -550,6 +554,7 @@ impl FirecrackerSnapshotConfig {
             mem_overlaybd_config,
             mem_virtual_size: manifest.memory.virtual_size,
             managed_snapshot_root: None,
+            memory_prefetch_path: manifest.memory_prefetch_path.clone(),
         })
     }
 
@@ -663,6 +668,7 @@ fn validate_overlaybd_extra_drive(
 mod tests {
     use super::*;
     use crate::cfg::{UblkOverlaybdTomlConfig, UblkTomlConfig};
+    use crate::sandbox::FirecrackerSnapshotManifest;
     use crate::snapshot::{CommittedSnapshot, ResolvedAttachedDrive, SnapshotRecord};
     use std::fs;
     use std::sync::{Mutex, OnceLock};
@@ -877,6 +883,7 @@ mod tests {
             },
             mem_virtual_size: 4096,
             managed_snapshot_root: None,
+            memory_prefetch_path: None,
         };
 
         let err = snapshot
@@ -906,6 +913,23 @@ mod tests {
 
         fs::write(&rootfs_path, b"rootfs")?;
         snapshot.validate_persisted()?;
+        Ok(())
+    }
+
+    #[test]
+    fn runnable_snapshot_carries_memory_prefetch_path() -> Result<()> {
+        struct TestLease;
+        impl crate::snapshot::RuntimeArtifactLease for TestLease {}
+
+        let prefetch_path = PathBuf::from("/tmp/memory-prefetch.json");
+        let mut manifest = FirecrackerSnapshotManifest::for_test(32768, &[]);
+        manifest.memory_prefetch_path = Some(prefetch_path.clone());
+        let record = SnapshotRecord::mock_ready(CommittedSnapshot::mock());
+        let snapshot = RunnableSnapshot::new(record, manifest, Arc::new(TestLease));
+
+        let config = FirecrackerSnapshotConfig::from_runnable_snapshot(&snapshot)?;
+
+        assert_eq!(config.memory_prefetch_path, Some(prefetch_path));
         Ok(())
     }
 

--- a/src/sandbox/firecracker/manifest.rs
+++ b/src/sandbox/firecracker/manifest.rs
@@ -30,6 +30,11 @@ pub struct FirecrackerSnapshotManifest {
     /// Launch-time volumes use the reserved slots that follow these drives.
     #[serde(default)]
     pub physical_extra_drive_count: usize,
+    /// Local path of the optional memory prefetch manifest
+    /// (`memory-prefetch.json`), resolved at snapshot-resolve time.
+    /// Runtime-only: never persisted into the repository.
+    #[serde(skip)]
+    pub memory_prefetch_path: Option<std::path::PathBuf>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -94,6 +99,7 @@ impl FirecrackerSnapshotManifest {
             attached_drives: Vec::new(),
             volume_drive_slots: 0,
             physical_extra_drive_count: attached_drives.len(),
+            memory_prefetch_path: None,
         }
         .with_extra_drives(attached_drives)
     }
@@ -223,6 +229,7 @@ mod tests {
             attached_drives: vec![known],
             volume_drive_slots: 0,
             physical_extra_drive_count: 1,
+            memory_prefetch_path: None,
         };
 
         let drives = manifest.extra_drives();

--- a/src/sandbox/firecracker/mod.rs
+++ b/src/sandbox/firecracker/mod.rs
@@ -11,6 +11,7 @@ mod instance;
 mod manifest;
 mod mmds;
 mod overlaybd_snapshot;
+mod pagedump;
 mod pool;
 mod process_vm_reader;
 mod sandbox;

--- a/src/sandbox/firecracker/pagedump.rs
+++ b/src/sandbox/firecracker/pagedump.rs
@@ -1,0 +1,101 @@
+//! Best-effort export of a guest process's resident GPA ranges.
+//!
+//! Used at snapshot capture time to record envd's working set for the
+//! memory prefetch path. Everything is best-effort: any failure yields
+//! `None`, and the caller simply proceeds without a prefetch manifest.
+//!
+//! The export runs the static `aenv-pagedump` binary shipped in the tools
+//! drive (`/agentenv/bin/aenv-pagedump`): one process that reads
+//! `/proc/<pid>/maps` and `/proc/<pid>/pagemap` directly and prints the GPA
+//! ranges as JSON. When the binary is unavailable (older tools drives), the
+//! export fails and the snapshot silently gets no prefetch manifest.
+
+use tracing::{debug, warn};
+
+use crate::sandbox::envd::EnvdInstance;
+use crate::sandbox::process::Executor;
+use crate::snapshot::{MAX_PREFETCH_BYTES, MAX_PREFETCH_RANGES};
+
+/// Export the present GPA ranges of `process_name` inside the sandbox.
+/// Returns `None` on any failure (process missing, pagemap unreadable,
+/// malformed output) — the prefetch path is strictly optional.
+///
+/// Takes the envd instance by value so callers can construct the executor
+/// inside whichever runtime drives the future (run_command's future is not
+/// `Send`; see `write_memory_prefetch_file` for the spawn_blocking pattern).
+pub(crate) async fn export_process_gpa_ranges(
+    envd_instance: EnvdInstance,
+    process_name: String,
+) -> Option<Vec<(u64, u64)>> {
+    let exec = Executor::new(envd_instance);
+    let ps = exec
+        .run_command(
+            "sh",
+            &["-lc", &format!("pgrep -x {process_name} | head -1")],
+        )
+        .await
+        .ok()?;
+    if ps.exit_code != 0 {
+        debug!(process_name, "prefetch export: process not found in guest");
+        return None;
+    }
+    let pid = ps.stdout.trim().parse::<u32>().ok()?;
+
+    let Some(ranges) = export_via_pagedump_binary(&exec, pid).await else {
+        debug!(pid, "prefetch export: aenv-pagedump unavailable or failed");
+        return None;
+    };
+    debug!(pid, "prefetch export: exported via aenv-pagedump binary");
+    if ranges.is_empty() {
+        return None;
+    }
+
+    let total_bytes: u64 = ranges.iter().map(|(_, len)| len).sum();
+    if ranges.len() > MAX_PREFETCH_RANGES || total_bytes > MAX_PREFETCH_BYTES {
+        warn!(
+            ranges = ranges.len(),
+            total_bytes, "prefetch manifest exceeds caps; disabling prefetch for this snapshot"
+        );
+        return None;
+    }
+    Some(ranges)
+}
+
+/// Run the tools-drive binary and parse its JSON output.
+async fn export_via_pagedump_binary(exec: &Executor, pid: u32) -> Option<Vec<(u64, u64)>> {
+    let out = exec
+        .run_command(
+            "sh",
+            &["-lc", &format!("/agentenv/bin/aenv-pagedump {pid}")],
+        )
+        .await
+        .ok()?;
+    if out.exit_code != 0 {
+        return None;
+    }
+    parse_pagedump_output(&out.stdout).ok()
+}
+
+fn parse_pagedump_output(text: &str) -> Result<Vec<(u64, u64)>, serde_json::Error> {
+    #[derive(serde::Deserialize)]
+    struct Dump {
+        ranges: Vec<(u64, u64)>,
+    }
+    let dump: Dump = serde_json::from_str(text)?;
+    Ok(dump.ranges)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pagedump_binary_json_output() {
+        let out = r#"{"ranges":[[4096,4096],[12288,8192]]}"#;
+        let ranges = parse_pagedump_output(out).unwrap();
+        assert_eq!(ranges, vec![(4096, 4096), (12288, 8192)]);
+
+        assert!(parse_pagedump_output("not json").is_err());
+        assert_eq!(parse_pagedump_output(r#"{"ranges":[]}"#).unwrap(), vec![]);
+    }
+}

--- a/src/sandbox/firecracker/pagedump.rs
+++ b/src/sandbox/firecracker/pagedump.rs
@@ -5,15 +5,18 @@
 //! `None`, and the caller simply proceeds without a prefetch manifest.
 //!
 //! The export runs the static `aenv-pagedump` binary shipped in the tools
-//! drive (`/agentenv/bin/aenv-pagedump`): one process that reads
-//! `/proc/<pid>/maps` and `/proc/<pid>/pagemap` directly and prints the GPA
-//! ranges as JSON. When the binary is unavailable (older tools drives), the
-//! export fails and the snapshot silently gets no prefetch manifest.
+//! drive (`/agentenv/bin/aenv-pagedump`) directly (no shell or pgrep
+//! dependency): one process that resolves the target by name, reads
+//! `/proc/<pid>/maps` and `/proc/<pid>/pagemap`, and prints the GPA ranges
+//! as JSON. When the binary is unavailable (older tools drives), the export
+//! fails and the snapshot silently gets no prefetch manifest.
+
+use std::time::Duration;
 
 use tracing::{debug, warn};
 
 use crate::sandbox::envd::EnvdInstance;
-use crate::sandbox::process::Executor;
+use crate::sandbox::process::{Executor, ProcessOpts};
 use crate::snapshot::{MAX_PREFETCH_BYTES, MAX_PREFETCH_RANGES};
 
 /// Export the present GPA ranges of `process_name` inside the sandbox.
@@ -28,29 +31,33 @@ pub(crate) async fn export_process_gpa_ranges(
     process_name: String,
 ) -> Option<Vec<(u64, u64)>> {
     let exec = Executor::new(envd_instance);
-    let ps = exec
-        .run_command(
-            "sh",
-            &["-lc", &format!("pgrep -x {process_name} | head -1")],
-        )
+    // Run the tools-drive binary directly (no shell/pgrep dependency): it
+    // resolves the process name itself. The timeout kills a stalled dump so
+    // it cannot linger into the snapshot.
+    let opts = ProcessOpts::new().with_timeout(Duration::from_secs(5));
+    let out = exec
+        .run_command_with_opts("/agentenv/bin/aenv-pagedump", &[&process_name], &opts)
         .await
         .ok()?;
-    if ps.exit_code != 0 {
-        debug!(process_name, "prefetch export: process not found in guest");
+    if out.exit_code != 0 {
+        debug!(
+            process_name,
+            "prefetch export: aenv-pagedump unavailable or failed"
+        );
         return None;
     }
-    let pid = ps.stdout.trim().parse::<u32>().ok()?;
-
-    let Some(ranges) = export_via_pagedump_binary(&exec, pid).await else {
-        debug!(pid, "prefetch export: aenv-pagedump unavailable or failed");
-        return None;
-    };
-    debug!(pid, "prefetch export: exported via aenv-pagedump binary");
+    let ranges = parse_pagedump_output(&out.stdout).ok()?;
     if ranges.is_empty() {
         return None;
     }
+    debug!(
+        process_name,
+        "prefetch export: exported via aenv-pagedump binary"
+    );
 
-    let total_bytes: u64 = ranges.iter().map(|(_, len)| len).sum();
+    let total_bytes = ranges
+        .iter()
+        .try_fold(0u64, |acc, (_, len)| acc.checked_add(*len))?;
     if ranges.len() > MAX_PREFETCH_RANGES || total_bytes > MAX_PREFETCH_BYTES {
         warn!(
             ranges = ranges.len(),
@@ -59,21 +66,6 @@ pub(crate) async fn export_process_gpa_ranges(
         return None;
     }
     Some(ranges)
-}
-
-/// Run the tools-drive binary and parse its JSON output.
-async fn export_via_pagedump_binary(exec: &Executor, pid: u32) -> Option<Vec<(u64, u64)>> {
-    let out = exec
-        .run_command(
-            "sh",
-            &["-lc", &format!("/agentenv/bin/aenv-pagedump {pid}")],
-        )
-        .await
-        .ok()?;
-    if out.exit_code != 0 {
-        return None;
-    }
-    parse_pagedump_output(&out.stdout).ok()
 }
 
 fn parse_pagedump_output(text: &str) -> Result<Vec<(u64, u64)>, serde_json::Error> {

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -538,6 +538,21 @@ impl FirecrackerSandbox {
         mem_image_config_path: &Path,
         mem_global_config_path: &Path,
     ) {
+        // Bound the read: a corrupt or oversized artifact must never cause an
+        // unbounded allocation. Anything larger than a few MiB of JSON cannot
+        // be a valid manifest anyway (it is capped at 4096 ranges).
+        const MAX_MANIFEST_BYTES: u64 = 4 * 1024 * 1024;
+        let Ok(meta) = tokio::fs::metadata(prefetch_path).await else {
+            return;
+        };
+        if meta.len() > MAX_MANIFEST_BYTES {
+            warn!(
+                path = %prefetch_path.display(),
+                size = meta.len(),
+                "memory prefetch manifest too large; skipping"
+            );
+            return;
+        }
         let Ok(bytes) = tokio::fs::read(prefetch_path).await else {
             return;
         };
@@ -566,10 +581,13 @@ impl FirecrackerSandbox {
         // the export future is cancelled on timeout and the blocking thread
         // (and its runtime) actually exits instead of lingering.
         let ranges = tokio::task::spawn_blocking(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
+            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .expect("build pagedump export runtime");
+            else {
+                tracing::debug!("memory prefetch: failed to build export runtime");
+                return None;
+            };
             runtime.block_on(async {
                 tokio::time::timeout(
                     std::time::Duration::from_secs(10),
@@ -585,6 +603,13 @@ impl FirecrackerSandbox {
         let Some(ranges) = ranges else {
             return;
         };
+        // Translate guest-physical addresses into memory-image file offsets.
+        // The identity holds only for the first Firecracker memory region
+        // (GPA < 3328 MiB); above that, RAM lives in a second region that is
+        // laid out sequentially in the snapshot memory file after the first
+        // region (Firecracker x86 memory layout). envd pages are almost always
+        // in low memory, but translate correctly regardless.
+        let ranges = Self::translate_gpa_ranges_to_file_offsets(ranges);
         let file = MemoryPrefetchFile {
             version: MEMORY_PREFETCH_VERSION,
             ranges,
@@ -601,6 +626,34 @@ impl FirecrackerSandbox {
         {
             debug!(%error, "memory prefetch: write manifest failed");
         }
+    }
+
+    /// Translate guest-physical address ranges into memory-image file offsets.
+    ///
+    /// Firecracker's x86 memory layout: region 1 covers GPA [0, 3328 MiB) and is
+    /// stored at file offset 0; region 2 starts at GPA 64 GiB and is stored
+    /// sequentially right after region 1 (file offset 3328 MiB). Ranges below
+    /// 3328 MiB pass through unchanged; ranges at or above 64 GiB are remapped.
+    /// (Ranges can never straddle the gap [3328 MiB, 64 GiB) — there is no RAM
+    /// there, so such input is dropped as invalid.)
+    fn translate_gpa_ranges_to_file_offsets(ranges: Vec<(u64, u64)>) -> Vec<(u64, u64)> {
+        const REGION1_END: u64 = 3328 * 1024 * 1024; // 3328 MiB
+        const REGION2_START: u64 = 64 * 1024 * 1024 * 1024; // 64 GiB
+        ranges
+            .into_iter()
+            .filter_map(|(start, len)| {
+                let end = start.checked_add(len)?;
+                if end <= REGION1_END {
+                    Some((start, len))
+                } else if start >= REGION2_START {
+                    // (start - 64 GiB) + 3328 MiB — cannot underflow given the check.
+                    Some((start - REGION2_START + REGION1_END, len))
+                } else {
+                    // Inside the architectural gap: no RAM there.
+                    None
+                }
+            })
+            .collect()
     }
 
     async fn recover_capture_failure<T>(
@@ -2991,5 +3044,43 @@ mod tests {
             .to_string()
             .contains("ensure start() was called before pause() or snapshot"));
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod gpa_offset_tests {
+    use super::FirecrackerSandbox;
+
+    #[test]
+    fn low_gpas_pass_through() {
+        assert_eq!(
+            FirecrackerSandbox::translate_gpa_ranges_to_file_offsets(vec![
+                (4096, 8192),
+                (0x1000_0000, 4096)
+            ]),
+            vec![(4096, 8192), (0x1000_0000, 4096)]
+        );
+    }
+
+    #[test]
+    fn high_region_is_remapped_sequentially() {
+        const GIB64: u64 = 64 * 1024 * 1024 * 1024;
+        const MIB3328: u64 = 3328 * 1024 * 1024;
+        assert_eq!(
+            FirecrackerSandbox::translate_gpa_ranges_to_file_offsets(vec![
+                (GIB64, 4096),
+                (GIB64 + 4096, 8192)
+            ]),
+            vec![(MIB3328, 4096), (MIB3328 + 4096, 8192)]
+        );
+    }
+
+    #[test]
+    fn gap_ranges_are_dropped() {
+        const MIB3328: u64 = 3328 * 1024 * 1024;
+        assert!(
+            FirecrackerSandbox::translate_gpa_ranges_to_file_offsets(vec![(MIB3328, 4096)])
+                .is_empty()
+        );
     }
 }

--- a/src/sandbox/firecracker/sandbox.rs
+++ b/src/sandbox/firecracker/sandbox.rs
@@ -22,6 +22,7 @@ use super::overlaybd_snapshot::{
     build_mem_snapshot_image_config, convert_dirty_memory_to_overlaybd,
     restack_snapshot_overlaybd_device, restack_snapshot_overlaybd_rootfs,
 };
+use super::pagedump::export_process_gpa_ranges;
 use super::pool::{warm_stderr_path, warm_stdout_path, FirecrackerPool};
 use super::FirecrackerInstance;
 use crate::sandbox::custom_extension::{
@@ -48,6 +49,9 @@ use crate::sandbox::ublk::{
 };
 use crate::sandbox::SandboxLaunchConfig;
 use crate::snapshot::RunnableSnapshot;
+use crate::snapshot::{
+    parse_prefetch_manifest, MemoryPrefetchFile, MEMORY_PREFETCH_ARTIFACT, MEMORY_PREFETCH_VERSION,
+};
 use crate::types::SandboxId;
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -352,6 +356,11 @@ impl SandboxBackend for FirecrackerSandbox {
             .map_err(SandboxCaptureError::from)?;
         let snapshot_dir = live_snapshot_root.path().join(Uuid::now_v7().to_string());
 
+        // Best-effort: export envd's resident GPA ranges for the resume-time
+        // memory prefetch. Runs before the VM is paused; any failure is
+        // logged and ignored (the snapshot itself must never depend on it).
+        self.write_memory_prefetch_file(snapshot_dir.clone()).await;
+
         let (_, manifest) = match self.pause_to_dir(&snapshot_dir).await {
             Ok(snapshot) => snapshot,
             Err(error) => {
@@ -520,6 +529,80 @@ impl SandboxExecutor for FirecrackerSandbox {
 // ── FirecrackerSandbox public API ────────────────────────────────────────────
 
 impl FirecrackerSandbox {
+    /// Best-effort: if a memory prefetch manifest was resolved for this
+    /// launch, ask the ublk daemon to bulk-prefetch those GPA ranges into the
+    /// local remote-block cache before the guest resumes. Silent no-op on any
+    /// failure.
+    async fn trigger_memory_prefetch(
+        prefetch_path: &Path,
+        mem_image_config_path: &Path,
+        mem_global_config_path: &Path,
+    ) {
+        let Ok(bytes) = tokio::fs::read(prefetch_path).await else {
+            return;
+        };
+        let Some(ranges) = parse_prefetch_manifest(&bytes) else {
+            return;
+        };
+        UblkDeviceManager::global()
+            .prefetch(mem_image_config_path, mem_global_config_path, ranges)
+            .await;
+    }
+
+    /// Best-effort: write the envd memory prefetch manifest into the snapshot
+    /// artifact dir (next to vm_state.bin). Silent no-op on any failure.
+    async fn write_memory_prefetch_file(&self, snapshot_dir: PathBuf) {
+        let Some(envd_instance) = self.envd_instance.clone() else {
+            return;
+        };
+        // `SandboxExecutor::run_command` borrows its arguments, so the export
+        // future is never `'static`. Drive it on a dedicated current-thread
+        // runtime inside `spawn_blocking` (the same pattern the overlaybd
+        // prefetch replay uses), keeping this method's future `Send`. The
+        // executor is constructed *inside* that runtime: using one built on
+        // the main runtime here would hang the export.
+        // Bound the whole export: a wedged envd or a pathological VMA must
+        // never stall the capture path. The timeout runs *inside* block_on so
+        // the export future is cancelled on timeout and the blocking thread
+        // (and its runtime) actually exits instead of lingering.
+        let ranges = tokio::task::spawn_blocking(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build pagedump export runtime");
+            runtime.block_on(async {
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    export_process_gpa_ranges(envd_instance, "envd".to_string()),
+                )
+                .await
+                .ok()
+                .flatten()
+            })
+        })
+        .await
+        .unwrap_or_default();
+        let Some(ranges) = ranges else {
+            return;
+        };
+        let file = MemoryPrefetchFile {
+            version: MEMORY_PREFETCH_VERSION,
+            ranges,
+        };
+        let Ok(bytes) = serde_json::to_vec_pretty(&file) else {
+            return;
+        };
+        if let Err(error) = tokio::fs::create_dir_all(&snapshot_dir).await {
+            debug!(%error, "memory prefetch: create artifact dir failed");
+            return;
+        }
+        if let Err(error) =
+            tokio::fs::write(snapshot_dir.join(MEMORY_PREFETCH_ARTIFACT), &bytes).await
+        {
+            debug!(%error, "memory prefetch: write manifest failed");
+        }
+    }
+
     async fn recover_capture_failure<T>(
         &mut self,
         operation: &'static str,
@@ -1103,6 +1186,7 @@ impl FirecrackerSandbox {
             mem_overlaybd_config,
             mem_virtual_size,
             managed_snapshot_root: None,
+            memory_prefetch_path: None,
         };
 
         debug!(
@@ -1889,6 +1973,18 @@ impl FirecrackerSandbox {
             Some(config.mem_overlaybd_config.image_config_path.clone());
         self.mem_ublk_device = Some(mem_device);
 
+        // Best-effort: if a memory prefetch manifest was resolved for this
+        // launch, ask the daemon to bulk-prefetch envd's GPA ranges into the
+        // local remote-block cache before the guest resumes.
+        if let Some(prefetch_path) = &config.memory_prefetch_path {
+            Self::trigger_memory_prefetch(
+                prefetch_path,
+                &config.mem_overlaybd_config.image_config_path,
+                &global_config.memory_snapshot.overlaybd_global_config_path,
+            )
+            .await;
+        }
+
         if needs_socket_wait {
             self.fc_instance
                 .wait_for_ready(
@@ -2576,6 +2672,7 @@ mod tests {
             },
             mem_virtual_size: 4096,
             managed_snapshot_root: None,
+            memory_prefetch_path: None,
         });
 
         assert_eq!(
@@ -2607,6 +2704,7 @@ mod tests {
             },
             mem_virtual_size: 4096,
             managed_snapshot_root: None,
+            memory_prefetch_path: None,
         };
 
         let child = FirecrackerSandbox::from_snapshot_config_with_override(
@@ -2659,6 +2757,7 @@ mod tests {
             },
             mem_virtual_size: 4096,
             managed_snapshot_root: None,
+            memory_prefetch_path: None,
         })?;
         let common = value["common"]
             .as_object_mut()

--- a/src/sandbox/ublk/device.rs
+++ b/src/sandbox/ublk/device.rs
@@ -295,6 +295,26 @@ impl UblkDeviceManager {
         }
     }
 
+    /// Ask the daemon to bulk-prefetch ranges of a snapshot's memory image
+    /// into the local remote-block cache before the guest resumes.
+    /// Best-effort: failures only skip the prefetch optimization.
+    pub(crate) async fn prefetch(
+        &self,
+        image_config: &Path,
+        global_config: &Path,
+        ranges: Vec<(u64, u64)>,
+    ) {
+        let Ok(client) = self.require_client() else {
+            return;
+        };
+        if let Err(error) = client.prefetch(image_config, global_config, ranges).await {
+            tracing::warn!(
+                %error,
+                "memory prefetch RPC failed; continuing without prefetch"
+            );
+        }
+    }
+
     // ── Device lifecycle ────────────────────────────────────────────────
 
     /// Release a ublk device back to the warm pool (if enabled) or delete it.

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -4,13 +4,20 @@ mod manager;
 #[doc(hidden)]
 pub mod mock;
 mod p2p;
+mod prefetch;
 pub mod repository;
 pub(crate) mod runtime_support;
 mod types;
 
 pub use manager::SnapshotManager;
+pub use prefetch::{
+    parse_prefetch_manifest, MemoryPrefetchFile, MAX_PREFETCH_BYTES, MAX_PREFETCH_RANGES,
+    MEMORY_PREFETCH_ARTIFACT, MEMORY_PREFETCH_VERSION,
+};
 pub use repository::{RepositoryError, RepositoryResult, SnapshotListFilter};
 pub(crate) use types::rootfs_snapshot_image_tag;
+#[cfg(test)]
+pub(crate) use types::RuntimeArtifactLease;
 pub use types::{
     CommandContext, CommittedAttachedDrive, CommittedSnapshot, ExternalLayer, ManagedLayer,
     OverlaybdLayerRef, PersistedDiskImagePublication, ResolvedAttachedDrive, RunnableSnapshot,

--- a/src/snapshot/prefetch.rs
+++ b/src/snapshot/prefetch.rs
@@ -1,0 +1,121 @@
+use serde::{Deserialize, Serialize};
+
+/// File name of the per-snapshot memory prefetch artifact stored under
+/// `artifacts/{snapshot_id}/` in the snapshot repository.
+pub const MEMORY_PREFETCH_ARTIFACT: &str = "memory-prefetch.json";
+
+/// Hard caps applied when consuming a prefetch manifest. The prefetch is
+/// disabled for the snapshot when either cap is exceeded (with a warning).
+pub const MAX_PREFETCH_RANGES: usize = 4096;
+pub const MAX_PREFETCH_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Current manifest format version. Unknown versions must be ignored by
+/// consumers (fall back to the plain demand-read path).
+pub const MEMORY_PREFETCH_VERSION: u32 = 1;
+
+/// Parse and validate a prefetch manifest body. Returns the GPA ranges when
+/// the manifest is usable, or `None` when it is malformed, has an unknown
+/// version, is empty, or exceeds the caps (any of which silently disables
+/// the prefetch).
+pub fn parse_prefetch_manifest(bytes: &[u8]) -> Option<Vec<(u64, u64)>> {
+    let file: MemoryPrefetchFile = serde_json::from_slice(bytes).ok()?;
+    if file.version != MEMORY_PREFETCH_VERSION || file.ranges.is_empty() {
+        return None;
+    }
+    if file.ranges.len() > MAX_PREFETCH_RANGES {
+        return None;
+    }
+    // Reject ranges that would overflow `start + len` downstream
+    // (e.g. corrupt `start` near u64::MAX).
+    if file
+        .ranges
+        .iter()
+        .any(|(start, len)| start.checked_add(*len).is_none())
+    {
+        return None;
+    }
+    let total_bytes = file
+        .ranges
+        .iter()
+        .try_fold(0u64, |acc, (_, len)| acc.checked_add(*len))?;
+    if total_bytes > MAX_PREFETCH_BYTES {
+        return None;
+    }
+    Some(file.ranges)
+}
+
+/// Pages of a specific guest process (envd) that were resident at capture
+/// time, as guest-physical address ranges. Used to bulk-prefetch those pages
+/// into the remote-block cache before the guest resumes.
+///
+/// Note: the ranges are guest *physical* addresses, which equal the memory
+/// image's virtual offsets only for single-region Firecracker guests (the
+/// default mem size, up to 3328 MiB). Larger guests have a second region at
+/// GPA 64 GiB that is laid out sequentially in the memory file, so pages
+/// there would warm wrong offsets — harmless for this best-effort prefetch,
+/// but worth knowing if the memory layout ever changes.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryPrefetchFile {
+    pub version: u32,
+    /// (gpa_start, len), page-aligned, sorted, non-overlapping.
+    pub ranges: Vec<(u64, u64)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefetch_file_roundtrip() {
+        let file = MemoryPrefetchFile {
+            version: MEMORY_PREFETCH_VERSION,
+            ranges: vec![(4096, 8192)],
+        };
+        let s = serde_json::to_string(&file).unwrap();
+        let back: MemoryPrefetchFile = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.version, MEMORY_PREFETCH_VERSION);
+        assert_eq!(back.ranges, vec![(4096, 8192)]);
+    }
+
+    #[test]
+    fn parse_prefetch_manifest_accepts_valid_manifest() {
+        let bytes = br#"{"version":1,"ranges":[[4096,8192],[16384,4096]]}"#;
+        assert_eq!(
+            parse_prefetch_manifest(bytes),
+            Some(vec![(4096, 8192), (16384, 4096)])
+        );
+    }
+
+    #[test]
+    fn parse_prefetch_manifest_rejects_bad_inputs() {
+        // malformed JSON
+        assert!(parse_prefetch_manifest(b"not json").is_none());
+        // unknown version
+        assert!(parse_prefetch_manifest(br#"{"version":99,"ranges":[[4096,4096]]}"#).is_none());
+        // empty ranges
+        assert!(parse_prefetch_manifest(br#"{"version":1,"ranges":[]}"#).is_none());
+        // too many ranges
+        let too_many = MemoryPrefetchFile {
+            version: MEMORY_PREFETCH_VERSION,
+            ranges: (0..=MAX_PREFETCH_RANGES as u64)
+                .map(|i| (i * 4096, 4096))
+                .collect(),
+        };
+        let bytes = serde_json::to_vec(&too_many).unwrap();
+        assert!(parse_prefetch_manifest(&bytes).is_none());
+        // total bytes overflow / over cap
+        assert!(parse_prefetch_manifest(
+            br#"{"version":1,"ranges":[[4096,18446744073709551615]]}"#
+        )
+        .is_none());
+        // start + len overflow
+        assert!(parse_prefetch_manifest(
+            br#"{"version":1,"ranges":[[18446744073709547520,8192]]}"#
+        )
+        .is_none());
+        assert!(parse_prefetch_manifest(
+            br#"{"version":1,"ranges":[[4096,268435457],[268439552,4096]]}"#
+        )
+        .is_none());
+    }
+}

--- a/src/snapshot/prefetch.rs
+++ b/src/snapshot/prefetch.rs
@@ -16,7 +16,8 @@ pub const MEMORY_PREFETCH_VERSION: u32 = 1;
 /// Parse and validate a prefetch manifest body. Returns the GPA ranges when
 /// the manifest is usable, or `None` when it is malformed, has an unknown
 /// version, is empty, or exceeds the caps (any of which silently disables
-/// the prefetch).
+/// the prefetch). Ranges are normalized (sorted and coalesced) before being
+/// returned, so unsorted or overlapping input cannot cause duplicate reads.
 pub fn parse_prefetch_manifest(bytes: &[u8]) -> Option<Vec<(u64, u64)>> {
     let file: MemoryPrefetchFile = serde_json::from_slice(bytes).ok()?;
     if file.version != MEMORY_PREFETCH_VERSION || file.ranges.is_empty() {
@@ -41,7 +42,29 @@ pub fn parse_prefetch_manifest(bytes: &[u8]) -> Option<Vec<(u64, u64)>> {
     if total_bytes > MAX_PREFETCH_BYTES {
         return None;
     }
-    Some(file.ranges)
+    Some(normalize_ranges(file.ranges))
+}
+
+/// Sort ranges by start and coalesce overlapping or adjacent ones, so the
+/// consumer always sees sorted, non-overlapping ranges regardless of the
+/// order the producer emitted them in.
+fn normalize_ranges(mut ranges: Vec<(u64, u64)>) -> Vec<(u64, u64)> {
+    ranges.sort_unstable();
+    let mut out: Vec<(u64, u64)> = Vec::with_capacity(ranges.len());
+    for (start, len) in ranges {
+        if len == 0 {
+            continue;
+        }
+        if let Some((last_start, last_len)) = out.last_mut() {
+            let last_end = *last_start + *last_len;
+            if start <= last_end {
+                *last_len = (*last_len).max(start + len - *last_start);
+                continue;
+            }
+        }
+        out.push((start, len));
+    }
+    out
 }
 
 /// Pages of a specific guest process (envd) that were resident at capture
@@ -75,6 +98,12 @@ mod tests {
         let back: MemoryPrefetchFile = serde_json::from_str(&s).unwrap();
         assert_eq!(back.version, MEMORY_PREFETCH_VERSION);
         assert_eq!(back.ranges, vec![(4096, 8192)]);
+    }
+
+    #[test]
+    fn parse_prefetch_manifest_normalizes_unsorted_overlapping_ranges() {
+        let bytes = br#"{"version":1,"ranges":[[8192,4096],[4096,8192],[12288,4096],[0,0]]}"#;
+        assert_eq!(parse_prefetch_manifest(bytes), Some(vec![(4096, 12288)]));
     }
 
     #[test]

--- a/src/snapshot/repository/backends/oss/client.rs
+++ b/src/snapshot/repository/backends/oss/client.rs
@@ -46,6 +46,7 @@ pub(crate) enum OssUploadArtifact {
     MemoryLayer,
     VmState,
     FirecrackerManifest,
+    MemoryPrefetch,
     CatalogRecord,
     Alias,
 }
@@ -58,6 +59,7 @@ impl OssUploadArtifact {
             Self::MemoryLayer => "memory_layer",
             Self::VmState => "vm_state",
             Self::FirecrackerManifest => "manifest",
+            Self::MemoryPrefetch => "memory_prefetch",
             Self::CatalogRecord => "record",
             Self::Alias => "alias",
         }

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -30,7 +30,7 @@ use crate::snapshot::{
     PersistedDiskImagePublication, SnapshotAlias, SnapshotId, SnapshotListFilter,
     SnapshotPublishMetadata, SnapshotPublishSource, SnapshotRecord, SnapshotSource,
     SnapshotSourceKind, TemplateBuildErrorReason, TemplateBuildInfo, TemplateBuildStatus,
-    SNAPSHOT_ARTIFACT_LAYOUT,
+    MEMORY_PREFETCH_ARTIFACT, SNAPSHOT_ARTIFACT_LAYOUT,
 };
 use crate::volume::{is_valid_volume_component, VolumeMode, VolumeRecord, VolumeStatus};
 
@@ -323,6 +323,40 @@ impl SnapshotRepository for OssSnapshotRepository {
                 )
                 .await
                 .map_err(|e| RepositoryError::backend("write firecracker manifest to oss", e))?;
+
+            // Best-effort: upload the memory prefetch manifest produced at
+            // capture time (sits next to vm_state.bin in the artifact dir).
+            // Missing/invalid files are skipped silently — resume must never
+            // depend on this artifact existing.
+            if let Some(prefetch_path) = manifest
+                .vm_state
+                .path
+                .parent()
+                .map(|dir| dir.join(MEMORY_PREFETCH_ARTIFACT))
+            {
+                match tokio::fs::read(&prefetch_path).await {
+                    Ok(bytes) => {
+                        if let Err(error) = self
+                            .client
+                            .put_bytes(
+                                &layout.artifact_key(MEMORY_PREFETCH_ARTIFACT),
+                                bytes,
+                                OssUploadArtifact::MemoryPrefetch,
+                            )
+                            .await
+                        {
+                            warn!(
+                                %error,
+                                snapshot_id = %id,
+                                "upload memory prefetch artifact failed (best-effort)"
+                            );
+                        }
+                    }
+                    Err(_) => {
+                        debug!(snapshot_id = %id, "no memory prefetch manifest captured");
+                    }
+                }
+            }
 
             // 3. Export attached-drive disk images and derive their committed metadata.
             let attached_drives = self

--- a/src/snapshot/repository/backends/oss/repository.rs
+++ b/src/snapshot/repository/backends/oss/repository.rs
@@ -352,8 +352,29 @@ impl SnapshotRepository for OssSnapshotRepository {
                             );
                         }
                     }
-                    Err(_) => {
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                         debug!(snapshot_id = %id, "no memory prefetch manifest captured");
+                        // A publication retry after a crash may leave a stale
+                        // manifest from an earlier attempt; drop it so the new
+                        // memory image is not associated with old ranges.
+                        if let Err(error) = self
+                            .client
+                            .delete(&layout.artifact_key(MEMORY_PREFETCH_ARTIFACT))
+                            .await
+                        {
+                            debug!(
+                                %error,
+                                snapshot_id = %id,
+                                "delete stale memory prefetch artifact failed (best-effort)"
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        debug!(
+                            %error,
+                            snapshot_id = %id,
+                            "read memory prefetch manifest failed; keeping existing artifact"
+                        );
                     }
                 }
             }

--- a/src/snapshot/repository/backends/oss/resolver.rs
+++ b/src/snapshot/repository/backends/oss/resolver.rs
@@ -21,7 +21,8 @@ use crate::snapshot::runtime_support::{
 use crate::snapshot::types::RuntimeArtifactLease;
 use crate::snapshot::{
     CommittedAttachedDrive, OverlaybdLayerRef, RepositoryError, RepositoryResult,
-    ResolvedAttachedDrive, RunnableSnapshot, SnapshotId, SnapshotRecord, SNAPSHOT_ARTIFACT_LAYOUT,
+    ResolvedAttachedDrive, RunnableSnapshot, SnapshotId, SnapshotRecord, MEMORY_PREFETCH_ARTIFACT,
+    SNAPSHOT_ARTIFACT_LAYOUT,
 };
 
 const MANAGED_LAYER_EXISTS_CONCURRENCY: usize = 16;
@@ -149,6 +150,25 @@ impl SnapshotRuntimeResolver for OssRuntimeResolver {
             .load_committed_firecracker_manifest(&layout, &id)
             .await?;
 
+        // ── memory prefetch manifest (best-effort; older snapshots lack it) ──
+        let prefetch_key = layout.artifact_key(MEMORY_PREFETCH_ARTIFACT);
+        let prefetch_path = match self
+            .cache
+            .ensure_cached(&prefetch_key, |dest| {
+                let client = Arc::clone(&self.client);
+                let key = prefetch_key.clone();
+                async move { client.get_to_file(&key, &dest).await }
+            })
+            .await
+        {
+            Ok(handle) => {
+                let path = handle.path().to_path_buf();
+                handles.push(handle);
+                Some(path)
+            }
+            Err(_) => None,
+        };
+
         // ── memory image config ────────────────────────────────────
         let memory_layers: Vec<OverlaybdLayerRef> = committed
             .memory_layers
@@ -204,6 +224,8 @@ impl SnapshotRuntimeResolver for OssRuntimeResolver {
             rootfs_image_config_path,
             &attached_drives,
         )?;
+        let mut runtime_manifest = runtime_manifest;
+        runtime_manifest.memory_prefetch_path = prefetch_path;
 
         let runnable = RunnableSnapshot::new((*snapshot).clone(), runtime_manifest, cache_lease);
         debug!(snapshot_id = %id, "resolved oss snapshot to local runnable paths");

--- a/src/snapshot/repository/backends/posixfs/artifacts.rs
+++ b/src/snapshot/repository/backends/posixfs/artifacts.rs
@@ -82,7 +82,18 @@ impl PosixFsArtifactStore {
                         warn!(%error, "import memory prefetch artifact failed (best-effort)");
                     }
                 }
-                false => debug!("no memory prefetch manifest captured"),
+                false => {
+                    debug!("no memory prefetch manifest captured");
+                    // A publication retry after a crash/failed cleanup reuses
+                    // the snapshot directory; a stale manifest from an earlier
+                    // attempt must not be associated with the new memory image.
+                    let stale = committed_layout.path(MEMORY_PREFETCH_ARTIFACT);
+                    if stale.exists() {
+                        if let Err(error) = fs::remove_file(&stale) {
+                            warn!(%error, path = %stale.display(), "remove stale memory prefetch artifact failed (best-effort)");
+                        }
+                    }
+                }
             }
         }
         self.persist_firecracker_manifest(

--- a/src/snapshot/repository/backends/posixfs/artifacts.rs
+++ b/src/snapshot/repository/backends/posixfs/artifacts.rs
@@ -12,8 +12,9 @@ use crate::digest::{self, FileDigest};
 use crate::sandbox::FirecrackerSnapshotManifest;
 use crate::snapshot::{
     CommittedAttachedDrive, ManagedLayer, OverlaybdLayerRef, RepositoryError, RepositoryResult,
-    SnapshotId, SNAPSHOT_ARTIFACT_LAYOUT,
+    SnapshotId, MEMORY_PREFETCH_ARTIFACT, SNAPSHOT_ARTIFACT_LAYOUT,
 };
+use tracing::{debug, warn};
 
 /// Artifact store backed by files in a POSIX-compatible shared filesystem.
 pub struct PosixFsArtifactStore {
@@ -63,6 +64,27 @@ impl PosixFsArtifactStore {
             committed_layout.path(SNAPSHOT_ARTIFACT_LAYOUT.vm_state),
             &manifest.vm_state.path,
         )?;
+        // Best-effort: import the memory prefetch manifest produced at
+        // capture time (next to vm_state.bin). Absence is normal for older
+        // snapshots and must not fail the import.
+        if let Some(prefetch_src) = manifest
+            .vm_state
+            .path
+            .parent()
+            .map(|dir| dir.join(MEMORY_PREFETCH_ARTIFACT))
+        {
+            match prefetch_src.exists() {
+                true => {
+                    if let Err(error) = self.copy_local_artifact(
+                        committed_layout.path(MEMORY_PREFETCH_ARTIFACT),
+                        &prefetch_src,
+                    ) {
+                        warn!(%error, "import memory prefetch artifact failed (best-effort)");
+                    }
+                }
+                false => debug!("no memory prefetch manifest captured"),
+            }
+        }
         self.persist_firecracker_manifest(
             committed_layout.path(SNAPSHOT_ARTIFACT_LAYOUT.firecracker_manifest),
             manifest,
@@ -735,7 +757,7 @@ mod tests {
     use crate::snapshot::mock::write_mock_built_artifacts;
     use crate::snapshot::{
         CommittedAttachedDrive, ExternalLayer, OverlaybdLayerRef, SnapshotId,
-        SNAPSHOT_ARTIFACT_LAYOUT,
+        MEMORY_PREFETCH_ARTIFACT, SNAPSHOT_ARTIFACT_LAYOUT,
     };
 
     fn test_store(root: &std::path::Path) -> PosixFsArtifactStore {
@@ -872,6 +894,48 @@ mod tests {
         };
         assert!(path.contains("managed-layers"));
         assert!(tempdir.path().join(&path).exists());
+    }
+
+    #[test]
+    fn import_built_artifacts_copies_memory_prefetch_when_present_and_skips_when_absent() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let store = test_store(tempdir.path());
+        let snapshot_id = SnapshotId::generate();
+        let local_dir = tempdir.path().join("local");
+        let (_, _, manifest) = write_mock_built_artifacts(local_dir.as_path())
+            .expect("mock built artifacts should write");
+
+        // 有 prefetch 清单 → 复制到 committed 布局且内容一致
+        fs::write(
+            local_dir.join(MEMORY_PREFETCH_ARTIFACT),
+            br#"{"version":1,"ranges":[[4096,8192]]}"#,
+        )
+        .expect("write prefetch manifest");
+        store
+            .import_built_artifacts(&snapshot_id, &manifest)
+            .expect("import with prefetch");
+        let committed = tempdir
+            .path()
+            .join("snapshots")
+            .join(snapshot_id.to_string())
+            .join(MEMORY_PREFETCH_ARTIFACT);
+        assert_eq!(
+            fs::read(&committed).expect("committed prefetch manifest"),
+            br#"{"version":1,"ranges":[[4096,8192]]}"#.to_vec()
+        );
+
+        // 无 prefetch 清单 → 正常导入且不产生该文件
+        let snapshot_id2 = SnapshotId::generate();
+        fs::remove_file(local_dir.join(MEMORY_PREFETCH_ARTIFACT)).expect("remove prefetch");
+        store
+            .import_built_artifacts(&snapshot_id2, &manifest)
+            .expect("import without prefetch");
+        assert!(!tempdir
+            .path()
+            .join("snapshots")
+            .join(snapshot_id2.to_string())
+            .join(MEMORY_PREFETCH_ARTIFACT)
+            .exists());
     }
 
     #[test]

--- a/src/snapshot/repository/backends/posixfs/runtime.rs
+++ b/src/snapshot/repository/backends/posixfs/runtime.rs
@@ -16,7 +16,7 @@ use crate::snapshot::types::RuntimeArtifactLease;
 use crate::snapshot::{
     CommittedAttachedDrive, CommittedSnapshot, OverlaybdLayerRef, RepositoryError,
     RepositoryResult, ResolvedAttachedDrive, RunnableSnapshot, SnapshotId, SnapshotRecord,
-    SNAPSHOT_ARTIFACT_LAYOUT,
+    MEMORY_PREFETCH_ARTIFACT, SNAPSHOT_ARTIFACT_LAYOUT,
 };
 
 /// Resolves committed snapshot artifacts into node-local runnable paths on a POSIX filesystem.
@@ -95,11 +95,15 @@ impl SnapshotRuntimeResolver for PosixFsRuntimeResolver {
             .await?;
         let runtime_manifest = hydrate_runtime_manifest(
             committed_manifest,
-            vm_state_path,
+            vm_state_path.clone(),
             mem_image_config_path,
             rootfs_image_config_path,
             &attached_drives,
         )?;
+        let mut runtime_manifest = runtime_manifest;
+        // Best-effort: the memory prefetch manifest sits next to vm_state.bin
+        // when the capture produced one (older snapshots lack it).
+        runtime_manifest.memory_prefetch_path = self.memory_prefetch_path(&vm_state_path);
         // Runtime artifacts are protected by the sandbox start-window lease (over
         // local-only commits) + the orchestrator running set; the resolved-handle
         // needs no separate local image ref pin.
@@ -113,6 +117,15 @@ impl SnapshotRuntimeResolver for PosixFsRuntimeResolver {
 impl PosixFsRuntimeResolver {
     fn snapshot_layout(&self, snapshot_id: &SnapshotId) -> PosixFsSnapshotArtifactLayout {
         PosixFsSnapshotArtifactLayout::new(&self.repository_root, snapshot_id)
+    }
+
+    /// Returns the local path of the optional memory prefetch manifest that
+    /// sits next to `vm_state.bin` (when the capture produced one).
+    fn memory_prefetch_path(&self, vm_state_path: &Path) -> Option<PathBuf> {
+        vm_state_path
+            .parent()
+            .map(|dir| dir.join(MEMORY_PREFETCH_ARTIFACT))
+            .filter(|path| path.exists())
     }
 
     fn snapshot_vm_state_path(&self, snapshot_id: &SnapshotId) -> RepositoryResult<PathBuf> {
@@ -333,7 +346,7 @@ mod tests {
     use super::{MaterializeSpec, PosixFsRuntimeResolver};
     use crate::image::cache::{OverlaybdLayerLocation, OverlaybdLayerStore};
     use crate::snapshot::artifact_cache::LocalArtifactCache;
-    use crate::snapshot::{OverlaybdLayerRef, RepositoryError};
+    use crate::snapshot::{OverlaybdLayerRef, RepositoryError, MEMORY_PREFETCH_ARTIFACT};
     use tempfile::TempDir;
 
     #[derive(Debug)]
@@ -351,6 +364,25 @@ mod tests {
 
     fn test_overlaybd_layer_store() -> Arc<dyn OverlaybdLayerStore> {
         Arc::new(TestOverlaybdLayerStore)
+    }
+
+    #[test]
+    fn memory_prefetch_path_detects_artifact_presence() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let resolver = PosixFsRuntimeResolver::new(
+            tempdir.path().join("repository"),
+            tempdir.path().join("runtime-cache"),
+            test_overlaybd_layer_store(),
+            LocalArtifactCache::new(tempdir.path().join("cache"), None).unwrap(),
+        );
+        let vm_state = tempdir.path().join("vm_state.bin");
+        std::fs::write(&vm_state, b"vm").expect("write vm_state");
+
+        assert!(resolver.memory_prefetch_path(&vm_state).is_none());
+
+        let prefetch = tempdir.path().join(MEMORY_PREFETCH_ARTIFACT);
+        std::fs::write(&prefetch, b"{}").expect("write prefetch");
+        assert_eq!(resolver.memory_prefetch_path(&vm_state), Some(prefetch));
     }
 
     #[tokio::test]

--- a/src/snapshot/repository/backends/posixfs/runtime.rs
+++ b/src/snapshot/repository/backends/posixfs/runtime.rs
@@ -102,8 +102,10 @@ impl SnapshotRuntimeResolver for PosixFsRuntimeResolver {
         )?;
         let mut runtime_manifest = runtime_manifest;
         // Best-effort: the memory prefetch manifest sits next to vm_state.bin
-        // when the capture produced one (older snapshots lack it).
-        runtime_manifest.memory_prefetch_path = self.memory_prefetch_path(&vm_state_path);
+        // when the capture produced one (older snapshots lack it). Async
+        // existence check so a slow shared repository filesystem cannot stall
+        // the executor.
+        runtime_manifest.memory_prefetch_path = self.memory_prefetch_path(&vm_state_path).await;
         // Runtime artifacts are protected by the sandbox start-window lease (over
         // local-only commits) + the orchestrator running set; the resolved-handle
         // needs no separate local image ref pin.
@@ -121,11 +123,14 @@ impl PosixFsRuntimeResolver {
 
     /// Returns the local path of the optional memory prefetch manifest that
     /// sits next to `vm_state.bin` (when the capture produced one).
-    fn memory_prefetch_path(&self, vm_state_path: &Path) -> Option<PathBuf> {
-        vm_state_path
+    async fn memory_prefetch_path(&self, vm_state_path: &Path) -> Option<PathBuf> {
+        let candidate = vm_state_path
             .parent()
-            .map(|dir| dir.join(MEMORY_PREFETCH_ARTIFACT))
-            .filter(|path| path.exists())
+            .map(|dir| dir.join(MEMORY_PREFETCH_ARTIFACT))?;
+        match tokio::fs::try_exists(&candidate).await {
+            Ok(true) => Some(candidate),
+            Ok(false) | Err(_) => None,
+        }
     }
 
     fn snapshot_vm_state_path(&self, snapshot_id: &SnapshotId) -> RepositoryResult<PathBuf> {
@@ -366,8 +371,8 @@ mod tests {
         Arc::new(TestOverlaybdLayerStore)
     }
 
-    #[test]
-    fn memory_prefetch_path_detects_artifact_presence() {
+    #[tokio::test]
+    async fn memory_prefetch_path_detects_artifact_presence() {
         let tempdir = TempDir::new().expect("tempdir");
         let resolver = PosixFsRuntimeResolver::new(
             tempdir.path().join("repository"),
@@ -378,11 +383,14 @@ mod tests {
         let vm_state = tempdir.path().join("vm_state.bin");
         std::fs::write(&vm_state, b"vm").expect("write vm_state");
 
-        assert!(resolver.memory_prefetch_path(&vm_state).is_none());
+        assert!(resolver.memory_prefetch_path(&vm_state).await.is_none());
 
         let prefetch = tempdir.path().join(MEMORY_PREFETCH_ARTIFACT);
         std::fs::write(&prefetch, b"{}").expect("write prefetch");
-        assert_eq!(resolver.memory_prefetch_path(&vm_state), Some(prefetch));
+        assert_eq!(
+            resolver.memory_prefetch_path(&vm_state).await,
+            Some(prefetch)
+        );
     }
 
     #[tokio::test]

--- a/storage/ublk-daemon/Cargo.toml
+++ b/storage/ublk-daemon/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4.5.38", features = ["derive"] }
 dashmap = "6.1.0"
 io-uring = "0.7.9"
 libc = "0.2.174"
+metrics = "0.24"
 nix = { version = "0.30.1", features = ["process", "signal", "resource"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/storage/ublk-daemon/src/client.rs
+++ b/storage/ublk-daemon/src/client.rs
@@ -366,6 +366,33 @@ impl UblkDaemonClient {
         }
     }
 
+    /// Ask the daemon to bulk-prefetch ranges of a snapshot's memory image
+    /// into the local remote-block cache before the guest resumes.
+    /// Best-effort; the daemon acknowledges immediately and prefetches in the
+    /// background.
+    pub async fn prefetch(
+        &self,
+        image_config: &Path,
+        global_config: &Path,
+        ranges: Vec<(u64, u64)>,
+    ) -> Result<()> {
+        let request = DaemonRequest::Prefetch {
+            image_config: image_config.to_path_buf(),
+            global_config: global_config.to_path_buf(),
+            ranges,
+        };
+        match self.call(request, DEFAULT_TIMEOUT).await? {
+            DaemonResponse::Ok => Ok(()),
+            DaemonResponse::TerminalError { message } => {
+                bail!("daemon: prefetch failed terminally: {message}")
+            }
+            DaemonResponse::Error { message } => {
+                bail!("daemon: prefetch failed: {message}")
+            }
+            other => bail!("daemon: unexpected response for prefetch: {other:?}"),
+        }
+    }
+
     /// Report that the sandbox owning `device_key` (the image.json path its
     /// memory device was opened with) finished booting, releasing any held
     /// background downloads. Best-effort: a failed notification only means the

--- a/storage/ublk-daemon/src/protocol.rs
+++ b/storage/ublk-daemon/src/protocol.rs
@@ -55,6 +55,17 @@ pub enum DaemonRequest {
     NotifySandboxReady {
         device_key: String,
     },
+    /// Bulk-prefetch ranges of a snapshot's memory image into the local
+    /// remote-block cache before the guest resumes. Best-effort: the daemon
+    /// acknowledges immediately and prefetches in the background.
+    Prefetch {
+        /// Path to the memory overlaybd image config (image.json).
+        image_config: PathBuf,
+        /// Path to the overlaybd global config JSON for the memory image.
+        global_config: PathBuf,
+        /// (offset, len) ranges in the image's virtual address space.
+        ranges: Vec<(u64, u64)>,
+    },
     /// Acquire a warm overlaybd device from the pool.
     AcquireOverlaybd {
         image_config: PathBuf,

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -834,6 +834,9 @@ async fn create_overlaybd_device(
 const PREFETCH_CHUNK_BYTES: u64 = 4 * 1024 * 1024;
 const PREFETCH_CONCURRENCY: usize = 6;
 
+const PREFETCH_MAX_RANGES: usize = 4096;
+const PREFETCH_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
+
 async fn handle_prefetch(
     pool_state: &Option<Arc<PoolState>>,
     image_service_cache: &ImageServiceCache,
@@ -841,39 +844,83 @@ async fn handle_prefetch(
     global_config: &Path,
     ranges: Vec<(u64, u64)>,
 ) -> Result<DaemonResponse> {
+    // Validate at the RPC boundary: never trust client-supplied ranges. A
+    // malicious or corrupt request must not expand into unbounded allocation
+    // or overflowing offset arithmetic.
+    if ranges.len() > PREFETCH_MAX_RANGES {
+        return Ok(DaemonResponse::InvalidRequest {
+            message: format!(
+                "prefetch range count exceeds limit ({} > {})",
+                ranges.len(),
+                PREFETCH_MAX_RANGES
+            ),
+        });
+    }
+    if ranges
+        .iter()
+        .any(|(start, len)| start.checked_add(*len).is_none())
+    {
+        return Ok(DaemonResponse::InvalidRequest {
+            message: "prefetch range overflows start + len".to_string(),
+        });
+    }
+    let total_bytes = match ranges
+        .iter()
+        .try_fold(0u64, |acc, (_, len)| acc.checked_add(*len))
+    {
+        Some(total) => total,
+        None => {
+            return Ok(DaemonResponse::InvalidRequest {
+                message: "prefetch total bytes overflow".to_string(),
+            })
+        }
+    };
+    if total_bytes > PREFETCH_MAX_TOTAL_BYTES {
+        return Ok(DaemonResponse::InvalidRequest {
+            message: format!(
+                "prefetch total bytes exceed limit ({} > {})",
+                total_bytes, PREFETCH_MAX_TOTAL_BYTES
+            ),
+        });
+    }
+
     let image_service = image_service_cache
         .get_or_create(global_config)
         .await
         .context("resolve image service for memory prefetch")?;
     // Hold the per-image read lock while opening, matching every other image
-    // open in the daemon (restack takes the write side).
+    // open in the daemon (restack takes the write side). The open-time guard
+    // is scoped so the lock can then be moved into the background task and
+    // held for the whole prefetch, so a restack cannot mutate the image
+    // while reads are in flight.
     let image_lock = pool_state
         .as_ref()
         .map(|pool| pool.image_lock(image_config));
-    let _image_guard = match &image_lock {
-        Some(lock) => Some(lock.read().await),
-        None => None,
+    let image = {
+        let _open_guard = match &image_lock {
+            Some(lock) => Some(lock.read().await),
+            None => None,
+        };
+        Arc::new(
+            image_service
+                .create_image_file(image_config)
+                .await
+                .with_context(|| {
+                    format!(
+                        "open overlaybd image for prefetch: {}",
+                        image_config.display()
+                    )
+                })?,
+        )
     };
-    let image = Arc::new(
-        image_service
-            .create_image_file(image_config)
-            .await
-            .with_context(|| {
-                format!(
-                    "open overlaybd image for prefetch: {}",
-                    image_config.display()
-                )
-            })?,
-    );
     let chunks = chunk_ranges(&ranges, PREFETCH_CHUNK_BYTES);
-    let total_bytes: u64 = chunks.iter().map(|(_, len)| len).sum();
     tracing::info!(
         image_config = %image_config.display(),
         chunks = chunks.len(),
         total_bytes,
         "start memory prefetch"
     );
-    tokio::spawn(prefetch_chunks(image, chunks));
+    tokio::spawn(prefetch_chunks(image, chunks, image_lock));
     Ok(DaemonResponse::Ok)
 }
 
@@ -892,7 +939,17 @@ fn chunk_ranges(ranges: &[(u64, u64)], max_chunk: u64) -> Vec<(u64, u64)> {
     out
 }
 
-async fn prefetch_chunks(image: Arc<ImageFile>, chunks: Vec<(u64, u64)>) {
+async fn prefetch_chunks(
+    image: Arc<ImageFile>,
+    chunks: Vec<(u64, u64)>,
+    image_lock: Option<Arc<RwLock<()>>>,
+) {
+    // Hold the read guard for the whole prefetch: a restack must not acquire
+    // the write side and mutate the image while reads are in flight.
+    let _image_guard = match &image_lock {
+        Some(lock) => Some(lock.read().await),
+        None => None,
+    };
     let queue = Arc::new(tokio::sync::Mutex::new(std::collections::VecDeque::from(
         chunks,
     )));

--- a/storage/ublk-daemon/src/server.rs
+++ b/storage/ublk-daemon/src/server.rs
@@ -12,6 +12,7 @@ use overlaybd::config::{ImageConfig, UpperConfig, UpperMode};
 use overlaybd::helper::prepare_runtime_upper;
 use overlaybd::image_file::ImageFile;
 use overlaybd::image_service::ImageService;
+use overlaybd::virtual_file::VirtualFile;
 use overlaybd::RestackSnapshotTerminalFailure;
 use tokio::net::UnixListener;
 use tokio::sync::{Mutex, Notify, RwLock};
@@ -559,6 +560,20 @@ async fn handle_connection(
             overlaybd::download_gate::notify_sandbox_ready(&device_key);
             Ok(DaemonResponse::Ok)
         }
+        DaemonRequest::Prefetch {
+            image_config,
+            global_config,
+            ranges,
+        } => {
+            handle_prefetch(
+                &pool_state,
+                &image_service_cache,
+                &image_config,
+                &global_config,
+                ranges,
+            )
+            .await
+        }
         DaemonRequest::AcquireOverlaybd {
             image_config,
             global_config,
@@ -812,6 +827,99 @@ async fn create_overlaybd_device(
         "overlaybd device created"
     );
     Ok((dev_id, device_path))
+}
+
+// ── Memory prefetch ─────────────────────────────────────────────────────────
+
+const PREFETCH_CHUNK_BYTES: u64 = 4 * 1024 * 1024;
+const PREFETCH_CONCURRENCY: usize = 6;
+
+async fn handle_prefetch(
+    pool_state: &Option<Arc<PoolState>>,
+    image_service_cache: &ImageServiceCache,
+    image_config: &Path,
+    global_config: &Path,
+    ranges: Vec<(u64, u64)>,
+) -> Result<DaemonResponse> {
+    let image_service = image_service_cache
+        .get_or_create(global_config)
+        .await
+        .context("resolve image service for memory prefetch")?;
+    // Hold the per-image read lock while opening, matching every other image
+    // open in the daemon (restack takes the write side).
+    let image_lock = pool_state
+        .as_ref()
+        .map(|pool| pool.image_lock(image_config));
+    let _image_guard = match &image_lock {
+        Some(lock) => Some(lock.read().await),
+        None => None,
+    };
+    let image = Arc::new(
+        image_service
+            .create_image_file(image_config)
+            .await
+            .with_context(|| {
+                format!(
+                    "open overlaybd image for prefetch: {}",
+                    image_config.display()
+                )
+            })?,
+    );
+    let chunks = chunk_ranges(&ranges, PREFETCH_CHUNK_BYTES);
+    let total_bytes: u64 = chunks.iter().map(|(_, len)| len).sum();
+    tracing::info!(
+        image_config = %image_config.display(),
+        chunks = chunks.len(),
+        total_bytes,
+        "start memory prefetch"
+    );
+    tokio::spawn(prefetch_chunks(image, chunks));
+    Ok(DaemonResponse::Ok)
+}
+
+fn chunk_ranges(ranges: &[(u64, u64)], max_chunk: u64) -> Vec<(u64, u64)> {
+    let mut out = Vec::with_capacity(ranges.len());
+    for &(start, len) in ranges {
+        let mut offset = start;
+        let mut remaining = len;
+        while remaining > 0 {
+            let take = remaining.min(max_chunk);
+            out.push((offset, take));
+            offset += take;
+            remaining -= take;
+        }
+    }
+    out
+}
+
+async fn prefetch_chunks(image: Arc<ImageFile>, chunks: Vec<(u64, u64)>) {
+    let queue = Arc::new(tokio::sync::Mutex::new(std::collections::VecDeque::from(
+        chunks,
+    )));
+    let mut workers = Vec::new();
+    for _ in 0..PREFETCH_CONCURRENCY {
+        let image = Arc::clone(&image);
+        let queue = Arc::clone(&queue);
+        workers.push(tokio::spawn(async move {
+            loop {
+                let next = queue.lock().await.pop_front();
+                let Some((offset, len)) = next else { return };
+                match image.read_at(offset, len as usize).await {
+                    Ok(bytes) => {
+                        metrics::counter!("agentenv_ublk_prefetch_bytes_total")
+                            .increment(bytes.len() as u64);
+                    }
+                    Err(error) => {
+                        metrics::counter!("agentenv_ublk_prefetch_errors_total").increment(1);
+                        tracing::debug!(%error, offset, len, "prefetch chunk failed");
+                    }
+                }
+            }
+        }));
+    }
+    for worker in workers {
+        let _ = worker.await;
+    }
 }
 
 async fn handle_delete(
@@ -1635,6 +1743,33 @@ fn clear_page_cache(device_path: &Path) {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn chunk_ranges_splits_and_preserves_order() {
+        let chunks = chunk_ranges(
+            &[(0, 12 * 1024 * 1024), (16 * 1024 * 1024, 4096)],
+            4 * 1024 * 1024,
+        );
+        assert_eq!(
+            chunks,
+            vec![
+                (0, 4 * 1024 * 1024),
+                (4 * 1024 * 1024, 4 * 1024 * 1024),
+                (8 * 1024 * 1024, 4 * 1024 * 1024),
+                (16 * 1024 * 1024, 4096),
+            ]
+        );
+    }
+
+    #[test]
+    fn chunk_ranges_handles_small_and_empty_ranges() {
+        assert!(chunk_ranges(&[], 1024).is_empty());
+        assert_eq!(
+            chunk_ranges(&[(100, 10), (200, 5)], 1024),
+            vec![(100, 10), (200, 5)]
+        );
+        assert_eq!(chunk_ranges(&[(0, 0)], 1024), Vec::<(u64, u64)>::new());
+    }
 
     /// Minimal local `ImageService`; placeholder images have no lowers, so this
     /// is never used for registry access.

--- a/storage/ublk-daemon/tests/ublk_daemon_test.rs
+++ b/storage/ublk-daemon/tests/ublk_daemon_test.rs
@@ -722,6 +722,7 @@ mod client_tests {
                 DaemonRequest::ReleaseOverlaybd { .. } => DaemonResponse::Released,
                 DaemonRequest::UpdateSize { .. } => DaemonResponse::SizeUpdated,
                 DaemonRequest::NotifySandboxReady { .. } => DaemonResponse::Ok,
+                DaemonRequest::Prefetch { .. } => DaemonResponse::Ok,
             }
         }))
         .await;

--- a/tools-image/.dockerignore
+++ b/tools-image/.dockerignore
@@ -3,3 +3,4 @@
 !init
 !pivot-init
 !Makefile
+!pagedump

--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -44,6 +44,7 @@ FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${DEBIAN_VERSION} AS envd-bu
 
 ARG ENVD_REF=2026.17
 ARG ENVD_UPSTREAM_REPO=https://github.com/e2b-dev/infra.git
+ARG GOPROXY
 ARG TARGETARCH
 
 RUN apt-get update \

--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -1,6 +1,8 @@
-# syntax=docker/dockerfile:1.7
-
 # AgentENV envd tools drive.
+#
+# (Intentionally no `# syntax=` line: the default buildkit frontend avoids an
+# external docker/dockerfile image pull, which fails on builders without
+# direct registry access.)
 #
 # This image is a reproducible build recipe for the small ext4 tools drive that
 # AgentENV attaches to each Firecracker guest as /dev/vda. The guest boots from
@@ -82,6 +84,33 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     fi
 
 # ---------------------------------------------------------------------------
+# Stage 1b: compile aenv-pagedump from the vendored source.
+#
+# Static musl binary that exports a process's present GPA ranges as JSON for
+# the snapshot memory-prefetch path. std-only, no network crates.
+# ---------------------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM rust:1.93.0-${DEBIAN_VERSION} AS pagedump-builder
+
+ARG TARGETARCH
+
+RUN rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+
+WORKDIR /src
+COPY pagedump/Cargo.toml pagedump/Cargo.toml
+COPY pagedump/src/main.rs pagedump/src/main.rs
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    set -eux; \
+    case "$TARGETARCH" in \
+      amd64) target=x86_64-unknown-linux-musl ;; \
+      arm64) target=aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    cd pagedump; \
+    cargo build --release --target "$target"; \
+    install -Dm0755 "target/$target/release/aenv-pagedump" /out/aenv-pagedump
+
+# ---------------------------------------------------------------------------
 # Stage 2: assemble the guest-visible tools rootfs.
 #
 # This is not a normal Linux distribution rootfs. It only contains the minimal
@@ -90,6 +119,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 #   /agentenv/pivot-init          post-pivot bootstrap
 #   /agentenv/envd                compiled control-plane daemon
 #   /agentenv/bin/busybox         stable helper binary for init scripts
+#   /agentenv/bin/aenv-pagedump   GPA range exporter for memory prefetch
 # ---------------------------------------------------------------------------
 FROM --platform=${TARGETPLATFORM} ${BUSYBOX_IMAGE} AS rootfs
 
@@ -98,6 +128,7 @@ ARG TOOLS_VERSION
 COPY --chmod=0755 init /tools-rootfs/init
 COPY --chmod=0755 pivot-init /tools-rootfs/agentenv/pivot-init
 COPY --chmod=0755 --from=envd-builder /out/envd /tools-rootfs/agentenv/envd
+COPY --chmod=0755 --from=pagedump-builder /out/aenv-pagedump /tools-rootfs/agentenv/bin/aenv-pagedump
 
 RUN set -eux; \
     mkdir -p \

--- a/tools-image/Makefile
+++ b/tools-image/Makefile
@@ -75,9 +75,9 @@ build: check-buildx check-tools-version
 		--build-arg "TOOLS_VERSION=$(TOOLS_VERSION)" \
 		--build-arg "ENVD_REF=$(ENVD_REF)" \
 		--build-arg "ENVD_UPSTREAM_REPO=$(ENVD_UPSTREAM_REPO)" \
-		--build-arg "HTTP_PROXY=$(or $(HTTP_PROXY),$(http_proxy))" \
-		--build-arg "HTTPS_PROXY=$(or $(HTTPS_PROXY),$(https_proxy))" \
 		--build-arg "GOPROXY=$(GOPROXY)" \
+		--build-arg HTTP_PROXY --build-arg HTTPS_PROXY \
+		--build-arg http_proxy --build-arg https_proxy \
 		--output "type=local,dest=$(OUTPUT_DIR)" \
 		.
 	mv "$(OUTPUT_DIR)/tools.ext4" "$(OUTPUT_PATH)"
@@ -89,6 +89,9 @@ publish: check-buildx check-tools-version check-publish-image
 		--build-arg "TOOLS_VERSION=$(TOOLS_VERSION)" \
 		--build-arg "ENVD_REF=$(ENVD_REF)" \
 		--build-arg "ENVD_UPSTREAM_REPO=$(ENVD_UPSTREAM_REPO)" \
+		--build-arg "GOPROXY=$(GOPROXY)" \
+		--build-arg HTTP_PROXY --build-arg HTTPS_PROXY \
+		--build-arg http_proxy --build-arg https_proxy \
 		-t "$(IMAGE)" \
 		--push \
 		.

--- a/tools-image/Makefile
+++ b/tools-image/Makefile
@@ -75,6 +75,9 @@ build: check-buildx check-tools-version
 		--build-arg "TOOLS_VERSION=$(TOOLS_VERSION)" \
 		--build-arg "ENVD_REF=$(ENVD_REF)" \
 		--build-arg "ENVD_UPSTREAM_REPO=$(ENVD_UPSTREAM_REPO)" \
+		--build-arg "HTTP_PROXY=$(or $(HTTP_PROXY),$(http_proxy))" \
+		--build-arg "HTTPS_PROXY=$(or $(HTTPS_PROXY),$(https_proxy))" \
+		--build-arg "GOPROXY=$(GOPROXY)" \
 		--output "type=local,dest=$(OUTPUT_DIR)" \
 		.
 	mv "$(OUTPUT_DIR)/tools.ext4" "$(OUTPUT_PATH)"

--- a/tools-image/pagedump/Cargo.toml
+++ b/tools-image/pagedump/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "aenv-pagedump"
+version = "0.1.0"
+edition = "2021"
+
+# Standalone crate used only by the tools-image Docker build; keep it out of
+# the agentenv workspace so `cargo build` in this directory works too.
+[workspace]
+
+[[bin]]
+name = "aenv-pagedump"
+path = "src/main.rs"
+
+[profile.release]
+opt-level = 2
+lto = true
+strip = true

--- a/tools-image/pagedump/src/main.rs
+++ b/tools-image/pagedump/src/main.rs
@@ -1,0 +1,92 @@
+//! aenv-pagedump: dump a process's present guest-physical address ranges.
+//!
+//! Usage: `aenv-pagedump <pid>`
+//!
+//! Reads `/proc/<pid>/maps` and `/proc/<pid>/pagemap`, and prints the GPA
+//! ranges of pages currently present in RAM as JSON:
+//! `{"ranges":[[gpa,len],...]}` (sorted, coalesced). Used at snapshot
+//! capture time to record a guest process's resident working set for
+//! later bulk prefetch at resume.
+
+use std::os::unix::fs::FileExt;
+use std::process::ExitCode;
+
+const PAGE_SIZE: u64 = 4096;
+const PAGEMAP_ENTRY_SIZE: u64 = 8;
+const PM_PRESENT: u64 = 1 << 63;
+const PM_PFN_MASK: u64 = (1 << 55) - 1;
+const CHUNK_PAGES: u64 = 65536; // 512 KiB of pagemap entries per read
+
+fn main() -> ExitCode {
+    let Some(pid) = std::env::args().nth(1) else {
+        eprintln!("usage: aenv-pagedump <pid>");
+        return ExitCode::from(2);
+    };
+    match run(&pid) {
+        Ok(ranges) => {
+            let body = ranges
+                .iter()
+                .map(|(gpa, len)| format!("[{gpa},{len}]"))
+                .collect::<Vec<_>>()
+                .join(",");
+            println!("{{\"ranges\":[{body}]}}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("aenv-pagedump: {error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run(pid: &str) -> Result<Vec<(u64, u64)>, Box<dyn std::error::Error>> {
+    let maps = std::fs::read_to_string(format!("/proc/{pid}/maps"))?;
+    let pagemap = std::fs::File::open(format!("/proc/{pid}/pagemap"))?;
+
+    let mut out: Vec<(u64, u64)> = Vec::new();
+    for line in maps.lines() {
+        let Some((range, _)) = line.split_once(' ') else {
+            continue;
+        };
+        let Some((start_s, end_s)) = range.split_once('-') else {
+            continue;
+        };
+        let (Ok(start), Ok(end)) = (
+            u64::from_str_radix(start_s, 16),
+            u64::from_str_radix(end_s, 16),
+        ) else {
+            continue;
+        };
+        if end <= start {
+            continue;
+        }
+        let first_vpn = start / PAGE_SIZE;
+        let npages = (end - start) / PAGE_SIZE;
+        let mut done = 0u64;
+        while done < npages {
+            let take = CHUNK_PAGES.min(npages - done);
+            let mut buf = vec![0u8; (take * PAGEMAP_ENTRY_SIZE) as usize];
+            let offset = (first_vpn + done) * PAGEMAP_ENTRY_SIZE;
+            // Entries that fail to read (e.g. special VMAs or truncated
+            // reads) are treated as absent — this export is best-effort.
+            if pagemap.read_exact_at(&mut buf, offset).is_ok() {
+                for chunk in buf.chunks_exact(PAGEMAP_ENTRY_SIZE as usize) {
+                    let entry = u64::from_le_bytes(chunk.try_into().expect("8-byte chunk"));
+                    if entry & PM_PRESENT == 0 {
+                        continue;
+                    }
+                    let gpa = (entry & PM_PFN_MASK) * PAGE_SIZE;
+                    if let Some((last_start, last_len)) = out.last_mut() {
+                        if gpa == *last_start + *last_len {
+                            *last_len += PAGE_SIZE;
+                            continue;
+                        }
+                    }
+                    out.push((gpa, PAGE_SIZE));
+                }
+            }
+            done += take;
+        }
+    }
+    Ok(out)
+}

--- a/tools-image/pagedump/src/main.rs
+++ b/tools-image/pagedump/src/main.rs
@@ -1,12 +1,16 @@
 //! aenv-pagedump: dump a process's present guest-physical address ranges.
 //!
-//! Usage: `aenv-pagedump <pid>`
+//! Usage: `aenv-pagedump <pid-or-process-name>`
 //!
 //! Reads `/proc/<pid>/maps` and `/proc/<pid>/pagemap`, and prints the GPA
 //! ranges of pages currently present in RAM as JSON:
 //! `{"ranges":[[gpa,len],...]}` (sorted, coalesced). Used at snapshot
 //! capture time to record a guest process's resident working set for
 //! later bulk prefetch at resume.
+//!
+//! When given a process name instead of a numeric pid, the first process
+//! whose `/proc/<pid>/comm` matches is used. Collection is bounded so a
+//! pathological process cannot exhaust this guest (see MAX_* below).
 
 use std::os::unix::fs::FileExt;
 use std::process::ExitCode;
@@ -16,13 +20,17 @@ const PAGEMAP_ENTRY_SIZE: u64 = 8;
 const PM_PRESENT: u64 = 1 << 63;
 const PM_PFN_MASK: u64 = (1 << 55) - 1;
 const CHUNK_PAGES: u64 = 65536; // 512 KiB of pagemap entries per read
+/// Hard collection bounds: stop before unbounded memory/formatting work.
+/// Matches the host-side manifest caps (MAX_PREFETCH_RANGES/BYTES).
+const MAX_RANGES: usize = 4096;
+const MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
 
 fn main() -> ExitCode {
-    let Some(pid) = std::env::args().nth(1) else {
-        eprintln!("usage: aenv-pagedump <pid>");
+    let Some(target) = std::env::args().nth(1) else {
+        eprintln!("usage: aenv-pagedump <pid-or-process-name>");
         return ExitCode::from(2);
     };
-    match run(&pid) {
+    match run(&target) {
         Ok(ranges) => {
             let body = ranges
                 .iter()
@@ -39,11 +47,39 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(pid: &str) -> Result<Vec<(u64, u64)>, Box<dyn std::error::Error>> {
+/// Resolve the target to a pid: numeric pid as-is, otherwise the first
+/// process whose `/proc/<pid>/comm` matches the name.
+fn resolve_pid(target: &str) -> Result<u32, Box<dyn std::error::Error>> {
+    if let Ok(pid) = target.parse::<u32>() {
+        return Ok(pid);
+    }
+    for entry in std::fs::read_dir("/proc")? {
+        let Ok(entry) = entry else { continue };
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.bytes().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(comm) = std::fs::read_to_string(entry.path().join("comm")) else {
+            continue;
+        };
+        if comm.trim() == target {
+            return name
+                .parse::<u32>()
+                .map_err(|error| format!("parse pid '{name}': {error}").into());
+        }
+    }
+    Err(format!("no process named '{target}'").into())
+}
+
+fn run(target: &str) -> Result<Vec<(u64, u64)>, Box<dyn std::error::Error>> {
+    let pid = resolve_pid(target)?;
     let maps = std::fs::read_to_string(format!("/proc/{pid}/maps"))?;
     let pagemap = std::fs::File::open(format!("/proc/{pid}/pagemap"))?;
 
     let mut out: Vec<(u64, u64)> = Vec::new();
+    let mut total_bytes: u64 = 0;
+    let mut truncated = false;
     for line in maps.lines() {
         let Some((range, _)) = line.split_once(' ') else {
             continue;
@@ -63,7 +99,7 @@ fn run(pid: &str) -> Result<Vec<(u64, u64)>, Box<dyn std::error::Error>> {
         let first_vpn = start / PAGE_SIZE;
         let npages = (end - start) / PAGE_SIZE;
         let mut done = 0u64;
-        while done < npages {
+        while done < npages && !truncated {
             let take = CHUNK_PAGES.min(npages - done);
             let mut buf = vec![0u8; (take * PAGEMAP_ENTRY_SIZE) as usize];
             let offset = (first_vpn + done) * PAGEMAP_ENTRY_SIZE;
@@ -79,13 +115,22 @@ fn run(pid: &str) -> Result<Vec<(u64, u64)>, Box<dyn std::error::Error>> {
                     if let Some((last_start, last_len)) = out.last_mut() {
                         if gpa == *last_start + *last_len {
                             *last_len += PAGE_SIZE;
+                            total_bytes += PAGE_SIZE;
                             continue;
                         }
                     }
                     out.push((gpa, PAGE_SIZE));
+                    total_bytes += PAGE_SIZE;
+                    if out.len() >= MAX_RANGES || total_bytes >= MAX_TOTAL_BYTES {
+                        truncated = true;
+                        break;
+                    }
                 }
             }
             done += take;
+        }
+        if truncated {
+            break;
         }
     }
     Ok(out)


### PR DESCRIPTION
## What

Record the guest init daemon's (envd) resident guest-physical address ranges at snapshot capture and bulk-prefetch those pages into the node's remote-block cache before the VM resumes, so envd's early startup no longer waits on one-at-a-time remote reads.

## Why

Resuming a snapshot stalls envd-ready on a serial demand-page-fault chain (~256 KiB × ~21 ms OSS RTT per read, bounded by vCPU count). Measured on a cold OSS-backed snapshot: envd-ready improves from **5.47 s to 2.13 s (-61%)** with prefetch enabled.

## Related issue

Closes #

## Scope and non-goals

- Included: GPA-range export via a new `aenv-pagedump` tools-drive binary; `memory-prefetch.json` artifact publish/resolve on OSS and posix_fs; a `Prefetch` RPC on the ublk daemon; resume-time trigger; tests and docs.
- Excluded (non-goals): KVM pre-fault / `KVM_PRE_FAULT_MEMORY` (requires kernel ≥ 6.11, not available on the fleet); page-fault trace recording/replay; changes to snapshot layering or capture content; any modification of the guest kernel.

## Design and behavior changes

```
capture: tools-drive aenv-pagedump reads /proc/<envd-pid>/maps+pagemap
         → GPA ranges → artifacts/{id}/memory-prefetch.json (best-effort)
resume:  resolver downloads manifest (404 tolerated) → start_resume triggers
         ublk-daemon Prefetch RPC (fire-and-forget) → 6 workers × 4 MiB chunks
         via ImageFile::read_at → remote-block cache warmed before guest runs
```

- Strictly best-effort at every hop: missing binary, missing/invalid/oversized manifest, or RPC failure all fall back silently to the existing on-demand path; resume never fails because of prefetch.
- Manifest stores GPA ranges only, so chained snapshots (delta layers) stay valid.
- Export runs inside a bounded `spawn_blocking` + dedicated runtime with a 10 s timeout so a wedged envd can never stall capture.
- Older tools drives (no `aenv-pagedump`) simply produce no manifest — behavior unchanged from today.

## Compatibility and operations

- Public API or generated protocol: additive `Prefetch` variant on the internal ublk-daemon Unix-socket protocol; old client → new daemon fails safe (warn only); new client → old daemon unaffected. No external API change.
- Configuration or defaults: N/A — feature is always on, no new config keys.
- Snapshot manifest, artifact layout, or storage format: adds one optional fixed artifact `artifacts/{id}/memory-prefetch.json`; `FirecrackerSnapshotManifest` gains a `#[serde(skip)]` runtime-only field; both are backward compatible.
- Upgrade and rollback: safe — snapshots with or without the manifest resume identically; rolling back simply stops producing/consuming manifests.
- Host requirements, permissions, ports, or dependencies: tools drive must be rebuilt to include `aenv-pagedump` (new `tools-image/pagedump` crate + Dockerfile stage); older tools drives degrade gracefully.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes) — N/A
- [x] Documentation updated
- [x] Benchmarks or performance comparison completed

Commands and results:

```text
cargo test -p agentenv --lib         → 838 passed, 0 failed
cargo test -p uvm-ublk-daemon        → 48 + 37 passed, 0 failed
cargo fmt --all -- --check           → clean
cargo clippy --all-targets -D warnings → clean
E2E on OSS validation bucket (cold resume):
  without prefetch: envd-ready 5.47 s | with prefetch: 2.13 s (-61%)
  export path verified in guest: "exported via aenv-pagedump binary"
  capture export overhead: ~0.68 s (shell pipeline) → ~0.1 s (tools-drive binary)
```

Skipped checks and reasons: `make -C services test` — no `services/` changes. Generated-code regeneration — N/A (hand-written protocol variant, no codegen involved).

## Risks and reviewer notes

- Capture makes bounded (10 s timeout) guest RPCs before pause — a new dependency on envd liveness at capture time; mitigated by the timeout and silent fallback.
- Prefetch is bounded by MAX_PREFETCH_RANGES (4096) / MAX_PREFETCH_BYTES (256 MiB); over-cap manifests are disabled, never truncated.
- GPA ranges equal memory-image offsets only for single-region guests (mem ≤ 3328 MiB); documented as best-effort for larger guests.
- Key files: `src/sandbox/firecracker/pagedump.rs`, `src/snapshot/prefetch.rs`, `storage/ublk-daemon/src/server.rs` (`handle_prefetch`), `tools-image/pagedump/src/main.rs`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
