### PR TITLE
fix(image): avoid ETXTBSY in fake regctl setup

### DIFF
--- a/src/image/resolver.rs
+++ b/src/image/resolver.rs
@@ -919,9 +919,6 @@ mod tests {
         stderr: &str,
         exit_code: i32,
     ) -> std::path::PathBuf {
-        use std::io::Write;
-        use std::os::unix::fs::PermissionsExt;
-
         let stdout_path = dir.join("stdout");
         let stderr_path = dir.join("stderr");
         std::fs::write(&stdout_path, stdout).expect("write stdout fixture");
@@ -930,25 +927,23 @@ mod tests {
         // The script locates its fixtures relative to `$0` rather than
         // embedding absolute paths, so a TMPDIR containing shell
         // metacharacters cannot break or inject into the generated script.
-        //
-        // Staged write + rename so the binary is never observed half-written or
-        // non-executable, matching how the real dependency installer stages
-        // downloads.
+        let script = format!(
+            "#!/bin/sh\ndir=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\nprintf '%s\\n' \"$@\" > \"$dir/argv\"\ncat \"$dir/stdout\"\ncat \"$dir/stderr\" >&2\nexit {exit_code}\n",
+        );
+
+        // Write in a child and wait for it to exit. Writing in this test process
+        // lets concurrent forks inherit the writable fd and cause ETXTBSY even
+        // after we close it and rename the file; CLOEXEC only closes it at exec.
         let binary = dir.join("regctl");
-        let staged = dir.join("regctl.staged");
-        {
-            let mut file = std::fs::File::create(&staged).expect("create fake regctl");
-            write!(
-                file,
-                "#!/bin/sh\ndir=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\nprintf '%s\\n' \"$@\" > \"$dir/argv\"\ncat \"$dir/stdout\"\ncat \"$dir/stderr\" >&2\nexit {exit_code}\n",
-            )
-            .expect("write fake regctl");
-            file.sync_all().expect("sync fake regctl");
-        }
-        let mut permissions = std::fs::metadata(&staged).expect("stat").permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&staged, permissions).expect("chmod fake regctl");
-        std::fs::rename(&staged, &binary).expect("publish fake regctl");
+        let status = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("printf '%s' \"$2\" > \"$1\" && chmod 755 \"$1\"")
+            .arg("install-fake-regctl")
+            .arg(&binary)
+            .arg(script)
+            .status()
+            .expect("install fake regctl");
+        assert!(status.success(), "install fake regctl: {status}");
         binary
     }
 


### PR DESCRIPTION
## What

Fix intermittent `Text file busy (os error 26)` failures in the resolver's fake `regctl` setup. Create the executable in a child shell and wait for successful completion before returning its path.

## Why

`discover_overlaybd_referrer_lists_referrers_unfiltered_and_finds_acr_streaming` can fail when another test forks while the helper has the script open for writing. The child inherits that descriptor until exec or exit, so closing the parent's handle, syncing, and renaming the file still leaves a window for `ETXTBSY`.

## Related issue

N/A — small fix for the reported intermittent unit-test failure.

## Scope and non-goals

Only the `fake_regctl` helper in `src/image/resolver.rs` changes. Production image resolution and registry behavior are unchanged.

## Design and behavior changes

The child shell owns the executable's writable descriptor, so sibling test processes cannot inherit it. The helper checks that installation succeeded before launching the fake command. The path and script are passed as quoted positional arguments; fixture lookup remains relative to `$0`, preserving support for temporary paths containing shell metacharacters.

## Compatibility and operations

- Public API or generated protocol: N/A; test helper only.
- Configuration or defaults: N/A; unchanged.
- Snapshot manifest, artifact layout, or storage format: N/A; unchanged.
- Upgrade and rollback: no operational impact.
- Host requirements, permissions, ports, or dependencies: uses the Unix shell and utilities already required by the fake executable; no new dependencies.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
make fmt
  Passed.
CARGO_TARGET_DIR=/tmp/aenv-target make clippy
  Passed: workspace, all targets/features, -D warnings.
CARGO_TARGET_DIR=/tmp/aenv-target cargo test -p agentenv --lib image::
  Passed: 116 tests, including both referrer-discovery command tests.
git diff --check
  Passed.
```

Tests used isolated temporary AENV state and dependency paths. A temporary standalone Rust harness exercised the actual helper with four concurrent fixture workers and four concurrent process-spawn workers, holding inherited descriptors for 10 ms before exec. The original helper failed 88 of 400 launches with `ETXTBSY`; the replacement completed 4,000 launches with zero failures. Successful launches verified argv, stdout, stderr, and both success/failure exit codes, including paths containing spaces, quotes, dollar signs, and backticks. This harness was a local validation tool and is not part of the patch.

Skipped checks and reasons: the focused library tests cover this helper; the aggregate capability/VM suites, Go tests, code generation, documentation, and benchmarks do not apply to this test-only change.

## Risks and reviewer notes

Adds a short-lived shell process to each of the two discovery tests. Existing assertions continue to verify the unfiltered registry command and error propagation. Review the descriptor ownership comment and the positional-argument quoting in `fake_regctl`.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
