### PR TITLE
fix(p2p): avoid duplicate storage of fetched image layers

### DIFF
--- a/src/image/cache/service.rs
+++ b/src/image/cache/service.rs
@@ -37,7 +37,9 @@ use crate::image::local_layer::LocalLayer;
 use crate::image::oci_image::{ConvertedLayerP2pMetadata, ImageConversion, LayerConversionKey};
 use crate::image::ImageResolutionMetadata;
 use crate::local_store::LocalStoreDurability;
-use crate::p2p::{P2pArtifactKey, P2pPublishMode, P2pPublishRequest, P2pTransport};
+use crate::p2p::{
+    P2pArtifactKey, P2pFetchOptions, P2pPublishMode, P2pPublishRequest, P2pTransport,
+};
 
 const IMAGE_CACHE_CONFIG_DIR: &str = "configs";
 const IMAGE_CACHE_INDEX_DIR: &str = "indexes";
@@ -1301,7 +1303,14 @@ impl ImageCacheOperationHold {
 
         let staging = self.create_temp_staging_dir()?;
         let destination = staging.path().join("overlaybd.commit");
-        if let Err(error) = transport.fetch(&descriptor, &destination).await {
+        if let Err(error) = transport
+            .fetch_with_options(
+                &descriptor,
+                &destination,
+                P2pFetchOptions { advertise: false },
+            )
+            .await
+        {
             debug!(key = %p2p_key, error = %error, "P2P converted image layer fetch failed; falling back to registry conversion");
             return Ok(None);
         }
@@ -1309,8 +1318,6 @@ impl ImageCacheOperationHold {
             Ok(described) => described,
             Err(error) => {
                 debug!(key = %p2p_key, error = %error, "P2P converted image layer digest failed; falling back to registry conversion");
-                // A successful fetch automatically republishes the P2P artifact, so if the file is invalid, we must unpublish it.
-                let _ = transport.unpublish(&p2p_key).await;
                 return Ok(None);
             }
         };
@@ -1323,36 +1330,31 @@ impl ImageCacheOperationHold {
                 actual_size = described.size,
                 "P2P converted image layer failed digest or size validation"
             );
-            let _ = transport.unpublish(&p2p_key).await;
             return Ok(None);
         }
         match read_overlaybd_layer_uuid(&destination) {
             Ok(uuid) if uuid == key.expected_layer_uuid => {}
             Ok(uuid) => {
                 debug!(key = %p2p_key, found_uuid = %uuid, expected_uuid = %key.expected_layer_uuid, "P2P converted image layer UUID mismatch");
-                let _ = transport.unpublish(&p2p_key).await;
                 return Ok(None);
             }
             Err(error) => {
                 debug!(key = %p2p_key, error = %error, "P2P converted image layer is not a sealed OverlayBD layer");
-                let _ = transport.unpublish(&p2p_key).await;
                 return Ok(None);
             }
         }
 
         let stored = self
-            .persist_overlaybd_commit(
-                &destination,
-                &metadata.commit_digest,
-                metadata.size,
-                std::slice::from_ref(&p2p_key),
-            )
+            .persist_overlaybd_commit(&destination, &metadata.commit_digest, metadata.size, &[])
             .await?;
         let layer = LocalLayer {
             path: stored,
             digest: metadata.commit_digest,
             size: metadata.size,
         };
+        if let Err(error) = self.image_cache.publish_converted_layer(key, &layer).await {
+            debug!(key = %p2p_key, error = %error, "failed to publish reused converted image layer to P2P");
+        }
         self.write_conversion_index(key, &layer).await?;
         info!(key = %p2p_key, digest = %layer.digest, "reused converted user image layer from P2P");
         Ok(Some(layer))

--- a/src/p2p/iroh/transport.rs
+++ b/src/p2p/iroh/transport.rs
@@ -36,7 +36,7 @@ use crate::p2p::error::{Error, Result};
 use crate::p2p::transport::P2pTransport;
 use crate::p2p::types::{
     P2pArtifactDescriptor, P2pArtifactKey, P2pArtifactProvider, P2pArtifactProviderHint,
-    P2pEndpoint, P2pPeer, P2pPublishMode, P2pPublishRequest, P2pPublishSource,
+    P2pEndpoint, P2pFetchOptions, P2pPeer, P2pPublishMode, P2pPublishRequest, P2pPublishSource,
 };
 use crate::p2p::P2pByteStream;
 
@@ -484,10 +484,15 @@ impl P2pTransport for IrohBlobsP2pTransport {
     }
 
     #[instrument(
-        skip(self, descriptor),
+        skip(self, descriptor, options),
         fields(key = %descriptor.key, destination = %destination.display())
     )]
-    async fn fetch(&self, descriptor: &P2pArtifactDescriptor, destination: &Path) -> Result<u64> {
+    async fn fetch_with_options(
+        &self,
+        descriptor: &P2pArtifactDescriptor,
+        destination: &Path,
+        options: P2pFetchOptions,
+    ) -> Result<u64> {
         if let Some(parent) = destination.parent() {
             tokio::fs::create_dir_all(parent).await.with_context(|| {
                 format!("create P2P fetch destination dir {}", parent.display())
@@ -512,14 +517,20 @@ impl P2pTransport for IrohBlobsP2pTransport {
         // Download into the local FsStore first, then export to the caller's destination.
         self.download_blob(GetRequest::blob(blob_hash), providers)
             .await?;
-        self.try_advertise_fetched_blob(descriptor, blob_hash).await;
+        if options.advertise {
+            self.try_advertise_fetched_blob(descriptor, blob_hash).await;
+        }
         let size = self.export_local_blob(blob_hash, destination).await?;
         debug!(providers_count, size, "fetched artifact from P2P provider");
         Ok(size)
     }
 
-    #[instrument(skip(self, descriptor), fields(key = %descriptor.key))]
-    async fn fetch_bytes(&self, descriptor: &P2pArtifactDescriptor) -> Result<Bytes> {
+    #[instrument(skip(self, descriptor, options), fields(key = %descriptor.key))]
+    async fn fetch_bytes_with_options(
+        &self,
+        descriptor: &P2pArtifactDescriptor,
+        options: P2pFetchOptions,
+    ) -> Result<Bytes> {
         let (blob_hash, providers) = match self.resolve_fetch_source(descriptor)? {
             BlobFetchSource::Local { blob_hash } => {
                 let bytes = self.read_local_blob_bytes(blob_hash).await?;
@@ -541,7 +552,9 @@ impl P2pTransport for IrohBlobsP2pTransport {
         // the artifact to later peers.
         self.download_blob(GetRequest::blob(blob_hash), providers)
             .await?;
-        self.try_advertise_fetched_blob(descriptor, blob_hash).await;
+        if options.advertise {
+            self.try_advertise_fetched_blob(descriptor, blob_hash).await;
+        }
         let bytes = self.read_local_blob_bytes(blob_hash).await?;
         debug!(
             providers_count,
@@ -1222,6 +1235,26 @@ mod tests {
 
         consumer.shutdown().await.context("shutdown consumer P2P")?;
         provider.shutdown().await.context("shutdown provider P2P")?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn transport_fetch_bytes_can_skip_advertising() -> Result<()> {
+        let temp = tempfile::tempdir().context("create temp test dir")?;
+        let (provider, consumer) = test_provider_consumer(&temp).await?;
+        let key = "test/p2p/iroh/bytes-fetch-no-advertise".to_string();
+        let bytes = Bytes::from_static(b"fetched without catalog publication");
+        provider
+            .publish(&P2pPublishRequest::bytes(key.clone(), bytes.clone()))
+            .await?;
+        let descriptor = consumer.lookup(&key).await?.context("descriptor")?;
+        let fetched = consumer
+            .fetch_bytes_with_options(&descriptor, P2pFetchOptions { advertise: false })
+            .await?;
+        assert_eq!(fetched, bytes);
+        assert!(consumer.get_local(&key).await.is_none());
+        consumer.shutdown().await?;
+        provider.shutdown().await?;
         Ok(())
     }
 

--- a/src/p2p/iroh/transport.rs
+++ b/src/p2p/iroh/transport.rs
@@ -18,6 +18,7 @@ use iroh::{Endpoint, EndpointAddr, Watcher};
 use iroh_blobs::api::blobs::{AddPathOptions, ImportMode};
 use iroh_blobs::api::downloader::Downloader;
 use iroh_blobs::api::proto::ExportRangesItem;
+use iroh_blobs::api::TempTag;
 use iroh_blobs::protocol::{ChunkRanges, ChunkRangesExt, GetRequest};
 use iroh_blobs::store::fs::{options::Options as FsStoreOptions, FsStore};
 use iroh_blobs::store::{GcConfig, ProtectOutcome};
@@ -253,6 +254,14 @@ impl IrohBlobsP2pTransport {
         self.published_catalog.descriptor_for(key).await
     }
 
+    async fn pin_blob(&self, blob_hash: iroh_blobs::Hash) -> Result<TempTag> {
+        self.store
+            .tags()
+            .temp_tag(HashAndFormat::raw(blob_hash))
+            .await
+            .map_err(|err| Error::internal_message("protect P2P fetch from GC", err))
+    }
+
     /// Export a local blob to a caller-requested destination path and return its size in bytes.
     async fn export_local_blob(
         &self,
@@ -269,6 +278,7 @@ impl IrohBlobsP2pTransport {
         &self,
         blob_hash: iroh_blobs::Hash,
         range: Range<u64>,
+        tag: TempTag,
     ) -> Result<P2pByteStream> {
         let expected_len =
             range
@@ -280,9 +290,10 @@ impl IrohBlobsP2pTransport {
         let range_start = range.start;
         let range_end = range.end;
         let inner = Box::pin(self.store.export_ranges(blob_hash, range).stream());
+        // Keep the tag in the lazy stream until EOF or caller cancellation.
         let stream = stream::unfold(
-            (inner, expected_len, false),
-            move |(mut inner, mut remaining, done_after_error)| async move {
+            (inner, expected_len, false, tag),
+            move |(mut inner, mut remaining, done_after_error, tag)| async move {
                 if done_after_error || remaining == 0 {
                     return None;
                 }
@@ -296,7 +307,7 @@ impl IrohBlobsP2pTransport {
                                         reason: "exported range chunk length does not fit u64"
                                             .to_string(),
                                     }),
-                                    (inner, 0, true),
+                                    (inner, 0, true, tag),
                                 ));
                             };
                             let Some(leaf_end) = leaf.offset.checked_add(data_len) else {
@@ -304,7 +315,7 @@ impl IrohBlobsP2pTransport {
                                     Err(Error::InvalidDescriptor {
                                         reason: "exported range chunk end overflow".to_string(),
                                     }),
-                                    (inner, 0, true),
+                                    (inner, 0, true, tag),
                                 ));
                             };
                             let overlap_start = leaf.offset.max(range_start);
@@ -316,12 +327,12 @@ impl IrohBlobsP2pTransport {
                             let end = (overlap_end - leaf.offset) as usize;
                             let bytes = leaf.data.slice(start..end);
                             remaining = remaining.saturating_sub(bytes.len() as u64);
-                            return Some((Ok(bytes), (inner, remaining, false)));
+                            return Some((Ok(bytes), (inner, remaining, false, tag)));
                         }
                         ExportRangesItem::Error(err) => {
                             return Some((
                                 Err(Error::internal_message("export local P2P blob range", err)),
-                                (inner, 0, true),
+                                (inner, 0, true, tag),
                             ));
                         }
                     }
@@ -333,7 +344,7 @@ impl IrohBlobsP2pTransport {
                         Err(Error::InvalidDescriptor {
                             reason: format!("exported range ended {remaining} bytes short"),
                         }),
-                        (inner, 0, true),
+                        (inner, 0, true, tag),
                     ))
                 }
             },
@@ -391,18 +402,21 @@ impl IrohBlobsP2pTransport {
         }
     }
 
+    // The caller must retain this tag through export/read, or transfer it to
+    // the returned stream. Download completion alone does not retain the blob.
     async fn download_blob(
         &self,
         request: GetRequest,
         providers: Vec<iroh::EndpointId>,
-    ) -> Result<()> {
+    ) -> Result<TempTag> {
+        let tag = self.pin_blob(request.hash).await?;
         let operation = "download P2P artifact blob";
         let download = self.downloader.download(request, providers);
         tokio::time::timeout(self.fetch_timeout, download)
             .await
             .map_err(|_| Error::Timeout { operation })?
             .map_err(|err| Error::internal_message(operation, err))?;
-        Ok(())
+        Ok(tag)
     }
 
     fn resolve_fetch_source(&self, descriptor: &P2pArtifactDescriptor) -> Result<BlobFetchSource> {
@@ -501,6 +515,7 @@ impl P2pTransport for IrohBlobsP2pTransport {
 
         let (blob_hash, providers) = match self.resolve_fetch_source(descriptor)? {
             BlobFetchSource::Local { blob_hash } => {
+                let _tag = self.pin_blob(blob_hash).await?;
                 // A local lookup hit still goes through export so callers get the
                 // artifact at the requested destination rather than a store path.
                 let size = self.export_local_blob(blob_hash, destination).await?;
@@ -515,7 +530,8 @@ impl P2pTransport for IrohBlobsP2pTransport {
         let providers_count = providers.len();
 
         // Download into the local FsStore first, then export to the caller's destination.
-        self.download_blob(GetRequest::blob(blob_hash), providers)
+        let _tag = self
+            .download_blob(GetRequest::blob(blob_hash), providers)
             .await?;
         if options.advertise {
             self.try_advertise_fetched_blob(descriptor, blob_hash).await;
@@ -533,6 +549,7 @@ impl P2pTransport for IrohBlobsP2pTransport {
     ) -> Result<Bytes> {
         let (blob_hash, providers) = match self.resolve_fetch_source(descriptor)? {
             BlobFetchSource::Local { blob_hash } => {
+                let _tag = self.pin_blob(blob_hash).await?;
                 let bytes = self.read_local_blob_bytes(blob_hash).await?;
                 debug!(
                     size = bytes.len(),
@@ -550,7 +567,8 @@ impl P2pTransport for IrohBlobsP2pTransport {
         // Full in-memory fetches download the complete blob into the local store
         // first, matching file fetch semantics and allowing this node to serve
         // the artifact to later peers.
-        self.download_blob(GetRequest::blob(blob_hash), providers)
+        let _tag = self
+            .download_blob(GetRequest::blob(blob_hash), providers)
             .await?;
         if options.advertise {
             self.try_advertise_fetched_blob(descriptor, blob_hash).await;
@@ -588,7 +606,8 @@ impl P2pTransport for IrohBlobsP2pTransport {
 
         let (blob_hash, providers) = match self.resolve_fetch_source(descriptor)? {
             BlobFetchSource::Local { blob_hash } => {
-                let stream = self.export_local_blob_range(blob_hash, range).await?;
+                let tag = self.pin_blob(blob_hash).await?;
+                let stream = self.export_local_blob_range(blob_hash, range, tag).await?;
                 debug!("fetched artifact range from local P2P store");
                 return Ok(stream);
             }
@@ -599,14 +618,13 @@ impl P2pTransport for IrohBlobsP2pTransport {
         };
         let providers_count = providers.len();
 
-        // Range reads are foreground acceleration only: the downloaded bytes
-        // land in the iroh store but are not retention-tagged here, so GC may
-        // reclaim them unless the full layer is later published by background
-        // download.
+        // A temporary tag protects downloaded bytes until the stream finishes or is dropped.
+        // After that, GC may reclaim them unless background publication retains the full layer.
         let ranges = ChunkRanges::bytes(range.clone());
-        self.download_blob(GetRequest::blob_ranges(blob_hash, ranges), providers)
+        let tag = self
+            .download_blob(GetRequest::blob_ranges(blob_hash, ranges), providers)
             .await?;
-        let stream = self.export_local_blob_range(blob_hash, range).await?;
+        let stream = self.export_local_blob_range(blob_hash, range, tag).await?;
         debug!(providers_count, "fetched artifact range from P2P provider");
         Ok(stream)
     }
@@ -960,6 +978,13 @@ mod tests {
     async fn test_provider_consumer(
         temp: &tempfile::TempDir,
     ) -> Result<(IrohBlobsP2pTransport, IrohBlobsP2pTransport)> {
+        test_provider_consumer_with_gc_interval(temp, DEFAULT_STORE_GC_INTERVAL).await
+    }
+
+    async fn test_provider_consumer_with_gc_interval(
+        temp: &tempfile::TempDir,
+        gc_interval: Duration,
+    ) -> Result<(IrohBlobsP2pTransport, IrohBlobsP2pTransport)> {
         let provider = test_transport(
             &p2p_config(temp.path().join("provider-store")),
             "provider-node",
@@ -970,17 +995,40 @@ mod tests {
         let provider_endpoint = provider
             .local_endpoint()
             .context("provider transport should expose a local endpoint")?;
-        let consumer = test_transport(
+        let consumer = test_transport_with_gc_interval(
             &p2p_config(temp.path().join("consumer-store")),
             "consumer-node",
             Arc::new(StaticP2pPeerDiscovery::new(vec![P2pPeer {
                 node_id: "provider-node".to_string(),
                 endpoint: provider_endpoint,
             }])),
+            gc_interval,
         )
         .await
         .context("start consumer P2P transport")?;
         Ok((provider, consumer))
+    }
+
+    // Deletion of an untagged sentinel confirms that a real GC sweep has run,
+    // rather than assuming completion after an arbitrary delay.
+    async fn run_gc_and_wait(transport: &IrohBlobsP2pTransport) -> anyhow::Result<()> {
+        let sentinel = transport
+            .store
+            .add_bytes(Bytes::from_static(b"GC sweep sentinel"))
+            .temp_tag()
+            .await?;
+        let hash = sentinel.hash();
+        drop(sentinel);
+        transport.pending_gc.store(true, Ordering::Release);
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            while transport.store.blobs().has(hash).await? {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            anyhow::Ok(())
+        })
+        .await
+        .context("wait for GC sweep")??;
+        Ok(())
     }
 
     fn invalid_endpoint() -> P2pEndpoint {
@@ -1165,10 +1213,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transport_fetch_range_reads_exact_bytes_without_advertising_partial_blob() -> Result<()>
-    {
+    async fn transport_fetch_range_reads_exact_bytes_without_advertising_partial_blob(
+    ) -> anyhow::Result<()> {
         let temp = tempfile::tempdir().context("create temp test dir")?;
-        let (provider, consumer) = test_provider_consumer(&temp).await?;
+        let (provider, consumer) =
+            test_provider_consumer_with_gc_interval(&temp, Duration::from_millis(10)).await?;
 
         let key = "test/p2p/iroh/range-fetch".to_string();
         let bytes: Vec<u8> = (0..(128 * 1024)).map(|idx| (idx % 251) as u8).collect();
@@ -1187,6 +1236,9 @@ mod tests {
             .fetch_byte_range(&descriptor, offset, len)
             .await
             .context("fetch range from provider")?;
+        // The stream has not been polled yet: its guard must protect even
+        // partial data from a new GC pass before any export reader opens it.
+        run_gc_and_wait(&consumer).await?;
         let fetched = collect_range_stream(fetched).await?;
         assert_eq!(
             fetched.as_slice(),
@@ -1196,9 +1248,104 @@ mod tests {
             consumer.get_local(&key).await.is_none(),
             "range-only fetch must not advertise this node as a full artifact provider"
         );
+        run_gc_and_wait(&consumer).await?;
+        assert!(consumer.store.blobs().list().hashes().await?.is_empty());
+
+        // Dropping an unconsumed stream must release protection as well.
+        let stream = consumer.fetch_byte_range(&descriptor, offset, len).await?;
+        drop(stream);
+        run_gc_and_wait(&consumer).await?;
+        assert!(consumer.store.blobs().list().hashes().await?.is_empty());
 
         consumer.shutdown().await.context("shutdown consumer P2P")?;
         provider.shutdown().await.context("shutdown provider P2P")?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn downloaded_blob_survives_gc_until_export_and_read_finish() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let (provider, consumer) =
+            test_provider_consumer_with_gc_interval(&temp, Duration::from_millis(10)).await?;
+        let key = "test/p2p/iroh/download-gc".to_string();
+        let bytes = vec![0x5a; 256 * 1024];
+        provider
+            .publish(&P2pPublishRequest::bytes(key.clone(), bytes.clone()))
+            .await?;
+        let descriptor = consumer.lookup(&key).await?.context("descriptor")?;
+        let BlobFetchSource::Remote {
+            blob_hash,
+            providers,
+        } = consumer.resolve_fetch_source(&descriptor)?
+        else {
+            anyhow::bail!("expected remote provider");
+        };
+
+        let tag = consumer
+            .download_blob(GetRequest::blob(blob_hash), providers)
+            .await?;
+        // Force the precise gap between download completion and export/read.
+        // A fresh GC pass clears iroh's protection from previous writes.
+        run_gc_and_wait(&consumer).await?;
+        let destination = temp.path().join("downloaded.bin");
+        assert_eq!(
+            consumer.export_local_blob(blob_hash, &destination).await?,
+            bytes.len() as u64
+        );
+        assert_eq!(tokio::fs::read(&destination).await?, bytes);
+        assert_eq!(
+            consumer.read_local_blob_bytes(blob_hash).await?.as_ref(),
+            bytes
+        );
+        assert!(consumer.get_local(&key).await.is_none());
+        assert!(consumer
+            .store
+            .tags()
+            .get(publish_tag_name(&key))
+            .await?
+            .is_none());
+
+        drop(tag);
+        run_gc_and_wait(&consumer).await?;
+        assert!(!consumer.store.blobs().has(blob_hash).await?);
+        consumer.shutdown().await?;
+        provider.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_file_export_releases_fetch_tag() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let (provider, consumer) =
+            test_provider_consumer_with_gc_interval(&temp, Duration::from_millis(10)).await?;
+        let key = "test/p2p/iroh/export-error-gc".to_string();
+        provider
+            .publish(&P2pPublishRequest::bytes(
+                key.clone(),
+                vec![0x5a; 256 * 1024],
+            ))
+            .await?;
+        let descriptor = consumer.lookup(&key).await?.context("descriptor")?;
+        // Exporting to an existing directory fails after a successful download.
+        assert!(consumer
+            .fetch_with_options(
+                &descriptor,
+                temp.path(),
+                P2pFetchOptions { advertise: false }
+            )
+            .await
+            .is_err());
+        assert!(consumer.get_local(&key).await.is_none());
+        run_gc_and_wait(&consumer).await?;
+        assert!(
+            !consumer
+                .store
+                .blobs()
+                .has(blob_hash_from_descriptor(&descriptor)?)
+                .await?
+        );
+        consumer.shutdown().await?;
+        provider.shutdown().await?;
         Ok(())
     }
 

--- a/src/p2p/mock.rs
+++ b/src/p2p/mock.rs
@@ -13,8 +13,8 @@ use tracing::{debug, warn};
 
 use super::{
     P2pArtifactDescriptor, P2pArtifactKey, P2pArtifactProvider, P2pArtifactProviderHint,
-    P2pByteStream, P2pEndpoint, P2pError, P2pPublishRequest, P2pPublishSource, P2pResult,
-    P2pTransport,
+    P2pByteStream, P2pEndpoint, P2pError, P2pFetchOptions, P2pPublishRequest, P2pPublishSource,
+    P2pResult, P2pTransport,
 };
 
 #[derive(Clone, Default)]
@@ -57,10 +57,11 @@ impl P2pTransport for MockTransport {
         Ok(result)
     }
 
-    async fn fetch(
+    async fn fetch_with_options(
         &self,
         descriptor: &P2pArtifactDescriptor,
         destination: &Path,
+        _options: P2pFetchOptions,
     ) -> P2pResult<u64> {
         debug!(key = ?descriptor.key, dest = %destination.display(), "fetching");
         self.fetch_count.fetch_add(1, Ordering::Relaxed);
@@ -77,7 +78,11 @@ impl P2pTransport for MockTransport {
         Ok(bytes.len() as u64)
     }
 
-    async fn fetch_bytes(&self, descriptor: &P2pArtifactDescriptor) -> P2pResult<Bytes> {
+    async fn fetch_bytes_with_options(
+        &self,
+        descriptor: &P2pArtifactDescriptor,
+        _options: P2pFetchOptions,
+    ) -> P2pResult<Bytes> {
         debug!(key = ?descriptor.key, "fetch bytes");
         self.fetch_bytes_count.fetch_add(1, Ordering::Relaxed);
         let blobs = self.blobs.read().await;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -19,7 +19,7 @@ pub use error::{Error as P2pError, Result as P2pResult};
 pub use transport::{DisabledP2pTransport, P2pByteStream, P2pTransport};
 pub use types::{
     P2pArtifactDescriptor, P2pArtifactKey, P2pArtifactProvider, P2pArtifactProviderHint,
-    P2pEndpoint, P2pPeer, P2pPublishMode, P2pPublishRequest, P2pPublishSource,
+    P2pEndpoint, P2pFetchOptions, P2pPeer, P2pPublishMode, P2pPublishRequest, P2pPublishSource,
 };
 
 /// Construct an artifact transport from the app config, returning an error if the configured transport is invalid or fails to initialize.

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -3,7 +3,8 @@ use std::pin::Pin;
 
 use super::error::{Error, Result};
 use super::types::{
-    P2pArtifactDescriptor, P2pArtifactKey, P2pArtifactProviderHint, P2pEndpoint, P2pPublishRequest,
+    P2pArtifactDescriptor, P2pArtifactKey, P2pArtifactProviderHint, P2pEndpoint, P2pFetchOptions,
+    P2pPublishRequest,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -26,14 +27,38 @@ pub trait P2pTransport: Send + Sync {
         hints: &[P2pArtifactProviderHint],
     ) -> Result<Option<P2pArtifactDescriptor>>;
 
-    /// Download the artifact described by `descriptor` into `destination` and return its size in bytes.
-    async fn fetch(&self, descriptor: &P2pArtifactDescriptor, destination: &Path) -> Result<u64>;
+    /// Download the artifact described by `descriptor` into `destination` using default options and return its size in bytes.
+    async fn fetch(&self, descriptor: &P2pArtifactDescriptor, destination: &Path) -> Result<u64> {
+        self.fetch_with_options(descriptor, destination, P2pFetchOptions::default())
+            .await
+    }
 
-    /// Download the full artifact described by `descriptor` into memory.
+    /// Download the artifact described by `descriptor` into `destination` and return its size in bytes.
+    async fn fetch_with_options(
+        &self,
+        descriptor: &P2pArtifactDescriptor,
+        destination: &Path,
+        options: P2pFetchOptions,
+    ) -> Result<u64>;
+
+    /// Download the full artifact described by `descriptor` into memory using default options.
     ///
     /// Callers should prefer [`Self::fetch`] for large artifacts to avoid buffering
     /// the full artifact in the process.
-    async fn fetch_bytes(&self, descriptor: &P2pArtifactDescriptor) -> Result<Bytes>;
+    async fn fetch_bytes(&self, descriptor: &P2pArtifactDescriptor) -> Result<Bytes> {
+        self.fetch_bytes_with_options(descriptor, P2pFetchOptions::default())
+            .await
+    }
+
+    /// Download the full artifact described by `descriptor` into memory.
+    ///
+    /// Callers should prefer [`Self::fetch_with_options`] for large artifacts to avoid buffering
+    /// the full artifact in the process.
+    async fn fetch_bytes_with_options(
+        &self,
+        descriptor: &P2pArtifactDescriptor,
+        options: P2pFetchOptions,
+    ) -> Result<Bytes>;
 
     /// Stream an exact byte range from the artifact described by `descriptor`.
     ///
@@ -82,11 +107,20 @@ impl P2pTransport for DisabledP2pTransport {
         Ok(None)
     }
 
-    async fn fetch(&self, _descriptor: &P2pArtifactDescriptor, _destination: &Path) -> Result<u64> {
+    async fn fetch_with_options(
+        &self,
+        _descriptor: &P2pArtifactDescriptor,
+        _destination: &Path,
+        _options: P2pFetchOptions,
+    ) -> Result<u64> {
         Err(Error::TransportDisabled)
     }
 
-    async fn fetch_bytes(&self, _descriptor: &P2pArtifactDescriptor) -> Result<Bytes> {
+    async fn fetch_bytes_with_options(
+        &self,
+        _descriptor: &P2pArtifactDescriptor,
+        _options: P2pFetchOptions,
+    ) -> Result<Bytes> {
         Err(Error::TransportDisabled)
     }
 

--- a/src/p2p/types.rs
+++ b/src/p2p/types.rs
@@ -148,3 +148,16 @@ pub struct P2pArtifactProviderHint {
     /// Transport endpoint if the producer endpoint is known.
     pub endpoint: Option<P2pEndpoint>,
 }
+
+/// Options to fetch an artifact from a transport backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct P2pFetchOptions {
+    /// The transport backend should automatically advertise the fetched artifact.
+    pub advertise: bool,
+}
+
+impl Default for P2pFetchOptions {
+    fn default() -> Self {
+        Self { advertise: true }
+    }
+}


### PR DESCRIPTION
## What

Skip automatic P2P advertisement when fetching converted image layers. After validation, publish the persisted image-cache file through the existing `Reference` path so the fetched blob is not retained as a second advertised artifact.

## Why

The current code stores two copies of the converted image layer: one in P2P's internal blob store and the other in the image cache. This duplication of storage takes up twice as much space.

## Scope and non-goals

Scope:

- Image cache and p2p.

Non-Goals:

- Make p2p fetch zero-copy.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [x] `make test-unit`
- [x] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
