### PR TITLE
perf: enable sha2 asm feature for hardware SHA-256 acceleration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7015,6 +7015,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+ "sha2-asm",
 ]
 
 [[package]]
@@ -7026,6 +7027,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ storage-util = { path = "storage/util" }
 dashmap = "6.1.0"
 io-uring = "0.7.9"
 tokio-tungstenite = "0.28"
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["asm"] }
 hmac = "0.12"
 subtle = "2.6"
 hex = "0.4"

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ libc = "0.2"
 overlaybd = { path = "../../storage/overlaybd" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["asm"] }
 storage-util = { path = "../../storage/util" }
 tempfile = "3.22.0"
 tokio = { version = "1", features = ["full"] }

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -10,7 +10,7 @@ agentenv-test-support = { path = "../test-support" }
 anyhow = "1.0"
 overlaybd = { path = "../../storage/overlaybd" }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["asm"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 

--- a/storage/overlaybd/Cargo.toml
+++ b/storage/overlaybd/Cargo.toml
@@ -28,7 +28,7 @@ zstd = "0.13.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde"] }
-sha2 = "0.10.9"
+sha2 = { version = "0.10.9", features = ["asm"] }
 tracing = "0.1.41"
 metrics = "0.24"
 dashmap = "6.1.0"

--- a/storage/ublk/Cargo.toml
+++ b/storage/ublk/Cargo.toml
@@ -30,5 +30,5 @@ tracing-bunyan-formatter = "0.3.10"
 [dev-dependencies]
 tempfile = "3"
 axum = "0.8.6"
-sha2 = "0.10.9"
+sha2 = { version = "0.10.9", features = ["asm"] }
 storage-util = { path = "../util", features = ["io-uring"] }


### PR DESCRIPTION
## Motivation

SHA-256 is on the critical path of memory snapshot creation:

- `storage/overlaybd`'s `AppendDigestTracker` hashes every appended byte of the RW layer and the sealed layer at ZFile seal / `compact_to` time (memory snapshot commits),
- `registryfs_v2`'s uploader hashes full layers during registry publication,
- `src/digest.rs` streams whole-file digests for snapshot artifact publication/copy.

The `sha2` crate defaults to the portable **software** implementation. On aarch64, the ARMv8 SHA crypto extensions are only used when the optional `asm` feature is enabled explicitly — without it, multi-GB snapshot hashing runs entirely in software.

## Change

Enable `features = ["asm"]` on every `sha2` declaration in the workspace (runtime deps of `agentenv` and `overlaybd`, plus dev-deps of `uvm-ublk` tests, e2e-tests and benchmarks). `Cargo.lock` gains `sha2-asm v0.6.4`; no source code changes.

This is safe across all release targets (linux/darwin × x86_64/aarch64):

- **aarch64**: selects the ARMv8 crypto instruction implementation (SHA1/SHA256 instructions are mandatory from ARMv8.4 and present on all mainstream aarch64 servers).
- **x86_64**: selects SHA-NI **with runtime CPU feature detection** (via `cpufeatures` since sha2 0.10.5), falling back to the software implementation on CPUs without SHA extensions — no behavior regression on older x86 hosts, and a free speedup on SHA-NI ones.

## Benchmark

aarch64 host; create sandbox → `dd` 1 GiB into tmpfs → take snapshot; 10 successful rounds per variant:

| Step | Before (P50) | After (P50) | Before (Avg) | After (Avg) |
|---|---|---|---|---|
| Create sandbox | 0.067s | 0.069s | 0.070s | 0.078s |
| dd 1 GiB | 5.190s | 5.221s | 5.181s | 5.218s |
| **Create snapshot** | **9.608s** | **6.244s** | **9.733s** | **6.354s** |
| Total flow | 14.871s | 11.543s | 14.985s | 11.651s |

Snapshot creation is **~35% faster** (avg 9.733s → 6.354s); create and dd steps are unchanged within noise, isolating the win to the hashing-heavy snapshot path.

## Verification

- `cargo tree -i sha2@0.10.9 -e features` confirms the `asm` feature is active through both the `agentenv` and `overlaybd` dependency chains.
- `cargo check --workspace` passes on aarch64 (sha2-asm assembly builds).
- Hardware instructions confirmed in the compiled artifact (`objdump` shows `sha256h`/`sha256su` in the sha2 CGU).
- Digest correctness: `cargo test -p agentenv --lib digest::` and `cargo test -p overlaybd --lib` (338 passed) — hash outputs are unchanged; the only failures are pre-existing mock-HTTP-server environment failures that reproduce identically on unmodified `origin/main`.