### PR TITLE
ci: use ubuntu-latest for non-release workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,8 +8,7 @@ permissions:
 
 jobs:
   bench:
-    # Ubuntu 24.04's Linux 6.17 kernel can crash in ublk ADD_DEV.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   fmt:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup
@@ -44,7 +44,7 @@ jobs:
         run: make fmt
 
   clippy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup
@@ -54,8 +54,7 @@ jobs:
         run: make clippy
 
   unit-tests:
-    # Ubuntu 24.04's Linux 6.17 kernel can crash in ublk ADD_DEV.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,8 +24,7 @@ jobs:
   coverage:
     outputs:
       coverage_outcome: ${{ steps.coverage.outcome }}
-    # Ubuntu 24.04's Linux 6.17 kernel can crash in ublk ADD_DEV.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup
@@ -65,7 +64,7 @@ jobs:
   publish-coverage-data:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.coverage.outputs.coverage_outcome == 'success'
     needs: coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/e2b-benchmark.yml
+++ b/.github/workflows/e2b-benchmark.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   setup-and-benchmark:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/envd-tests.yml
+++ b/.github/workflows/envd-tests.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   envd-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,8 +34,7 @@ permissions:
 
 jobs:
   agentenv-tests:
-    # Ubuntu 24.04's Linux 6.17 kernel can crash in ublk ADD_DEV.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup
@@ -52,8 +51,7 @@ jobs:
 
   e2e-tests:
     name: e2e-tests (${{ matrix.e2e_name }})
-    # Ubuntu 24.04's Linux 6.17 kernel can crash in ublk ADD_DEV.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   mutation-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 720
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-tools-image.yml
+++ b/.github/workflows/publish-tools-image.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   validate:
     name: Validate publication
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read
@@ -58,9 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             platform: linux/amd64
             arch: amd64
+          # GitHub provides no ubuntu-latest alias for ARM runners.
           - os: ubuntu-24.04-arm
             platform: linux/arm64
             arch: arm64
@@ -95,7 +96,7 @@ jobs:
   publish-manifest:
     name: Publish multi-platform manifest
     needs: publish-images
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       packages: write
     steps:

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   go-services:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: services

--- a/.github/workflows/ublk-tests.yml
+++ b/.github/workflows/ublk-tests.yml
@@ -38,8 +38,7 @@ env:
 
 jobs:
   ublk-tests:
-    # Ubuntu 24.04's Linux 6.17 kernel can crash in ublk ADD_DEV.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup


### PR DESCRIPTION
## What

Move 16 runner selections across 10 non-release workflows to `ubuntu-latest`.

## Why

Keep CI on GitHub's current default Ubuntu image while preserving the older glibc build baseline for distributed release binaries. The Linux CLI and server release builds remain on Ubuntu 22.04.

## Related issue

None; small CI configuration update.

## Scope and non-goals

Covers Rust CI, integration/E2E tests, envd tests, ublk tests, coverage, benchmarks, mutation tests, Go services CI, and the x64 tools-image publication jobs. The entire release workflow is unchanged.

The tools-image ARM build retains `ubuntu-24.04-arm`: [GitHub's supported runner labels](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) provide no `ubuntu-latest` ARM equivalent. A comment documents this exception.

## Design and behavior changes

Only runner labels and their explanatory comments change. Remove comments explaining the superseded Ubuntu 22.04 ublk pins. Triggers, build/test commands, permissions, and architecture matrices retain their existing behavior.

## Compatibility and operations

- Public API or generated protocol: N/A; workflow-only change.
- Configuration or defaults: Non-release x64 jobs now follow `ubuntu-latest`.
- Snapshot manifest, artifact layout, or storage format: N/A.
- Upgrade and rollback: No runtime migration; revert this PR to restore the prior CI runners.
- Host requirements, permissions, ports, or dependencies: CI uses the packages and kernel shipped with `ubuntu-latest`. Release runner versions and the ARM tools-image runner remain pinned.

## Validation

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
git diff --check: PASS
actionlint 1.7.12, all 10 modified workflows, including ShellCheck: PASS
actionlint -shellcheck='', all 13 workflows: PASS
Inline Python/PyYAML comparison against origin/main: PASS
  - Exactly 16 runner selections changed.
  - release.yml is byte-identical.
  - ARM architecture is preserved.
  - No other parsed workflow values changed.
actionlint, all workflows: existing ShellCheck SC2317 in docs.yml:99
  - Reproduced against the unchanged main checkout.
```

Skipped checks and reasons: Rust/Go builds, runtime tests, code generation, and benchmarks were not run locally because only workflow runner settings changed. Actual runner compatibility requires GitHub-hosted CI execution.

## Risks and reviewer notes

Draft pending hosted-runner validation. The previous pins documented an Ubuntu 24.04 / Linux 6.17 kernel crash in ublk `ADD_DEV`. This PR removes that workaround as part of switching to `ubuntu-latest`; it does not establish that the kernel issue is fixed. Verify the unit, ublk, and integration/E2E jobs before merging. Coverage and benchmark workflows also exercise ublk and need hosted-runner validation.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
