### PR TITLE
chore(release): bump version to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aenv"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "agentenv"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "agentenv-observability",
  "agentenv_http_server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
## What

Bump the shared workspace version from `0.2.0` to `0.2.1` for `agentenv` and `aenv`, and update their `Cargo.lock` entries.

## Why

Prepare the `v0.2.1` release so package metadata, the CLI version, and the server's node identity agree with the release tag.

## Related issue

N/A — release version bump.

## Scope and non-goals

Three version values across `Cargo.toml` and `Cargo.lock`. Release publication follows the existing tagged-release workflow.

## Design and behavior changes

Both release packages inherit `workspace.package.version`. The CLI version and server node identity derive from that package version.

## Compatibility and operations

- Public API or generated protocol: Version reporting changes to `0.2.1`; schemas are unchanged.
- Configuration or defaults: N/A — metadata only.
- Snapshot manifest, artifact layout, or storage format: N/A — metadata only.
- Upgrade and rollback: Standard upgrade or rollback; no migrations.
- Host requirements, permissions, ports, or dependencies: Unchanged; verified all other lockfile contents remain identical.

## Validation

- [x] `make fmt`
- [x] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
git diff --check                                      passed
make fmt                                             passed
make clippy                                          passed
cargo test --locked -p aenv --bin aenv                 55 passed
cargo run --locked -p aenv -- --version                aenv 0.2.1
cargo metadata --no-deps --locked --format-version 1   passed
```

Verified `agentenv` and `aenv` resolve to `0.2.1` in Cargo metadata and the lockfile, and that all other lockfile contents are unchanged. Build checks reused the local Cargo target directory; CLI tests used isolated temporary state and dependency paths.

Skipped checks and reasons: The full unit target and VM integration suites are unnecessary for this metadata-only change; focused CLI tests and workspace Clippy cover the affected build. Go tests, code generation, documentation updates, and benchmarks are not applicable.

## Risks and reviewer notes

Low risk: the diff matches the previous release bump's two-file scope and contains no dependency upgrades.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
