### PR TITLE
fix(overlaybd): derive direct I/O alignment from each file

### DIFF
--- a/storage/overlaybd/src/backend/local.rs
+++ b/storage/overlaybd/src/backend/local.rs
@@ -433,7 +433,14 @@ impl LocalFileInner {
         // For O_DIRECT, we must use aligned memory.  io_uring still requires
         // aligned buffers for O_DIRECT files, so we submit the aligned read
         // and then slice out the requested region.
-        let got = io_ring::read_exact_at(submitter, fd, buffer.as_mut(), aligned_offset).await?;
+        let got = io_ring::read_exact_at_aligned(
+            submitter,
+            fd,
+            buffer.as_mut(),
+            aligned_offset,
+            self.alignment.memory,
+        )
+        .await?;
 
         if got <= head {
             return Ok(Bytes::new());
@@ -471,12 +478,22 @@ impl LocalFileInner {
 
         if (buf.as_ptr() as usize).is_multiple_of(self.alignment.memory) {
             // Buffer pointer is already aligned — submit directly, no copy.
-            Ok(io_ring::write_exact_at(submitter, fd, buf, offset).await?)
+            Ok(
+                io_ring::write_exact_at_aligned(submitter, fd, buf, offset, self.alignment.memory)
+                    .await?,
+            )
         } else {
             // Buffer pointer is unaligned — copy into an aligned bounce buffer first.
             let mut aligned = AlignedBuffer::new(buf.len(), self.alignment.memory)?;
             aligned.as_mut().copy_from_slice(buf);
-            Ok(io_ring::write_exact_at(submitter, fd, aligned.as_ref(), offset).await?)
+            Ok(io_ring::write_exact_at_aligned(
+                submitter,
+                fd,
+                aligned.as_ref(),
+                offset,
+                self.alignment.memory,
+            )
+            .await?)
         }
     }
 
@@ -580,7 +597,10 @@ impl LocalFileInner {
         }
 
         let fd = self.file.as_raw_fd();
-        Ok(io_ring::write_exact_at(submitter, fd, buf, offset).await?)
+        Ok(
+            io_ring::write_exact_at_aligned(submitter, fd, buf, offset, self.alignment.memory)
+                .await?,
+        )
     }
 }
 

--- a/storage/overlaybd/src/backend/local.rs
+++ b/storage/overlaybd/src/backend/local.rs
@@ -19,7 +19,6 @@ use crate::sys;
 use storage_util::io_ring::{self, IoUringSubmitter};
 use storage_util::AlignedBuffer;
 
-const DIRECT_IO_ALIGNMENT: usize = 512;
 #[cfg(any(test, feature = "io-uring"))]
 const BUFFERED_PWRITE_FAST_PATH_MAX: usize = 4096;
 
@@ -125,11 +124,19 @@ impl LocalFileBuilder {
                 .with_context(|| format!("enable direct io on {}", path.display()))?;
         }
 
+        let alignment = if self.direct_io {
+            sys::direct_io_alignment(&file)
+                .with_context(|| format!("query direct io alignment on {}", path.display()))?
+        } else {
+            sys::DirectIoAlignment::default()
+        };
+
         Ok(LocalFile {
             inner: Arc::new(LocalFileInner {
                 path,
                 file,
                 direct_io: self.direct_io,
+                alignment,
                 #[cfg(test)]
                 write_calls: std::sync::atomic::AtomicU64::new(0),
             }),
@@ -147,6 +154,7 @@ struct LocalFileInner {
     path: PathBuf,
     file: File,
     direct_io: bool,
+    alignment: sys::DirectIoAlignment,
     /// Test-only probe counting synchronous positional-write submissions (the
     /// buffered small-write fast path plus explicit sync-pwrite calls).
     #[cfg(test)]
@@ -315,14 +323,14 @@ impl LocalFileInner {
         }
 
         let expected = min((size - offset) as usize, len);
-        let alignment = DIRECT_IO_ALIGNMENT as u64;
+        let alignment = self.alignment.offset as u64;
         let aligned_offset = Self::align_down(offset, alignment);
         let head =
             usize::try_from(offset - aligned_offset).context("read offset delta overflow")?;
         let aligned_end = Self::align_up(offset + expected as u64, alignment);
         let aligned_len = usize::try_from(aligned_end.saturating_sub(aligned_offset))
             .context("aligned read length overflow")?;
-        let mut buffer = AlignedBuffer::new(aligned_len, DIRECT_IO_ALIGNMENT)?;
+        let mut buffer = AlignedBuffer::new(aligned_len, self.alignment.memory)?;
         let got = Self::read_into_at(&self.file, aligned_offset, buffer.as_mut())?;
         if got <= head {
             return Ok(Bytes::new());
@@ -361,20 +369,22 @@ impl LocalFileInner {
         }
         if self.direct_io {
             ensure!(
-                offset.is_multiple_of(DIRECT_IO_ALIGNMENT as u64),
-                "write_at_sync: offset {offset} is not aligned to {DIRECT_IO_ALIGNMENT}"
+                offset.is_multiple_of(self.alignment.offset as u64),
+                "write_at_sync: offset {offset} is not aligned to {}",
+                self.alignment.offset
             );
             ensure!(
-                buf.len().is_multiple_of(DIRECT_IO_ALIGNMENT),
-                "write_at_sync: buf len {} is not aligned to {DIRECT_IO_ALIGNMENT}",
-                buf.len()
+                buf.len().is_multiple_of(self.alignment.offset),
+                "write_at_sync: buf len {} is not aligned to {}",
+                buf.len(),
+                self.alignment.offset
             );
         }
         #[cfg(test)]
         self.write_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        if self.direct_io && !(buf.as_ptr() as usize).is_multiple_of(DIRECT_IO_ALIGNMENT) {
-            let mut aligned = AlignedBuffer::new(buf.len(), DIRECT_IO_ALIGNMENT)?;
+        if self.direct_io && !(buf.as_ptr() as usize).is_multiple_of(self.alignment.memory) {
+            let mut aligned = AlignedBuffer::new(buf.len(), self.alignment.memory)?;
             aligned.as_mut().copy_from_slice(buf);
             self.file.write_all_at(aligned.as_ref(), offset)?;
             return Ok(buf.len());
@@ -410,7 +420,7 @@ impl LocalFileInner {
         }
 
         let expected = min((size - offset) as usize, len);
-        let alignment = DIRECT_IO_ALIGNMENT as u64;
+        let alignment = self.alignment.offset as u64;
         let aligned_offset = Self::align_down(offset, alignment);
         let head =
             usize::try_from(offset - aligned_offset).context("read offset delta overflow")?;
@@ -419,7 +429,7 @@ impl LocalFileInner {
             .context("aligned read length overflow")?;
         let fd = self.file.as_raw_fd();
 
-        let mut buffer = AlignedBuffer::new(aligned_len, DIRECT_IO_ALIGNMENT)?;
+        let mut buffer = AlignedBuffer::new(aligned_len, self.alignment.memory)?;
         // For O_DIRECT, we must use aligned memory.  io_uring still requires
         // aligned buffers for O_DIRECT files, so we submit the aligned read
         // and then slice out the requested region.
@@ -435,10 +445,10 @@ impl LocalFileInner {
 
     /// Write `buf` to an O_DIRECT file at `offset`.
     ///
-    /// Both `offset` and `buf.len()` must be multiples of [`DIRECT_IO_ALIGNMENT`]; an
+    /// Both `offset` and `buf.len()` must be multiples of the file's offset alignment; an
     /// error is returned otherwise.
     ///
-    /// If the caller's buffer pointer is already 512-byte aligned the write is submitted
+    /// If the caller's buffer pointer meets the file's memory alignment the write is submitted
     /// directly with no extra allocation or copy.  If the pointer is unaligned, the data is
     /// first copied into a temporary [`AlignedBuffer`] before the io_uring submission.
     async fn write_direct_at_via<S>(&self, submitter: &S, offset: u64, buf: &[u8]) -> Result<usize>
@@ -446,23 +456,25 @@ impl LocalFileInner {
         S: IoUringSubmitter + ?Sized,
     {
         ensure!(
-            offset.is_multiple_of(DIRECT_IO_ALIGNMENT as u64),
-            "write_direct_at: offset {offset} is not aligned to {DIRECT_IO_ALIGNMENT}"
+            offset.is_multiple_of(self.alignment.offset as u64),
+            "write_direct_at: offset {offset} is not aligned to {}",
+            self.alignment.offset
         );
         ensure!(
-            buf.len().is_multiple_of(DIRECT_IO_ALIGNMENT),
-            "write_direct_at: buf len {} is not aligned to {DIRECT_IO_ALIGNMENT}",
-            buf.len()
+            buf.len().is_multiple_of(self.alignment.offset),
+            "write_direct_at: buf len {} is not aligned to {}",
+            buf.len(),
+            self.alignment.offset
         );
 
         let fd = self.file.as_raw_fd();
 
-        if (buf.as_ptr() as usize).is_multiple_of(DIRECT_IO_ALIGNMENT) {
+        if (buf.as_ptr() as usize).is_multiple_of(self.alignment.memory) {
             // Buffer pointer is already aligned — submit directly, no copy.
             Ok(io_ring::write_exact_at(submitter, fd, buf, offset).await?)
         } else {
             // Buffer pointer is unaligned — copy into an aligned bounce buffer first.
-            let mut aligned = AlignedBuffer::new(buf.len(), DIRECT_IO_ALIGNMENT)?;
+            let mut aligned = AlignedBuffer::new(buf.len(), self.alignment.memory)?;
             aligned.as_mut().copy_from_slice(buf);
             Ok(io_ring::write_exact_at(submitter, fd, aligned.as_ref(), offset).await?)
         }
@@ -496,9 +508,9 @@ impl LocalFileInner {
             let dst_ptr = dst.as_mut_ptr() as usize;
             let dst_len = dst.len();
 
-            if dst_ptr.is_multiple_of(DIRECT_IO_ALIGNMENT)
-                && dst_len.is_multiple_of(DIRECT_IO_ALIGNMENT)
-                && offset.is_multiple_of(DIRECT_IO_ALIGNMENT as u64)
+            if dst_ptr.is_multiple_of(self.alignment.memory)
+                && dst_len.is_multiple_of(self.alignment.offset)
+                && offset.is_multiple_of(self.alignment.offset as u64)
             {
                 // if dst is already aligned, just read into dst
                 Ok(io_ring::read_exact_at(submitter, fd, dst, offset).await?)
@@ -903,7 +915,7 @@ mod tests {
         assert_eq!(got.as_ref(), payload.as_slice());
     }
 
-    /// A 512-byte-aligned buffer pointer takes the fast path (no copy inside
+    /// A device-aligned buffer pointer takes the fast path (no copy inside
     /// `write_direct_at`).  We verify the data round-trips correctly.
     #[tokio::test]
     async fn test_write_direct_at_aligned_ptr_fast_path() {
@@ -911,35 +923,36 @@ mod tests {
         let path = temp.path().join("aligned.bin");
         let file = open_direct_io_file(&path);
 
-        // AlignedBuffer guarantees a 512-byte-aligned pointer — fast path.
-        let mut wbuf = AlignedBuffer::new(512, DIRECT_IO_ALIGNMENT).expect("alloc");
+        // Use the file's memory and offset limits for the no-copy path.
+        let alignment = file.inner.alignment;
+        let mut wbuf = AlignedBuffer::new(alignment.offset, alignment.memory).expect("alloc");
         wbuf.as_mut().fill(0xAB);
         file.write_at(0, wbuf.as_ref())
             .await
             .expect("aligned write");
 
-        let got = file.read_at(0, 512).await.expect("read back");
-        assert_eq!(got.as_ref(), &[0xAB_u8; 512]);
+        let got = file.read_at(0, alignment.offset).await.expect("read back");
+        assert_eq!(got.as_ref(), vec![0xAB; alignment.offset]);
     }
 
     /// An unaligned buffer pointer triggers the bounce-buffer copy path inside
     /// `write_direct_at`.  We synthesise a guaranteed-unaligned pointer by
-    /// allocating a 513-byte `AlignedBuffer` (512-aligned base) and using
-    /// `into_sub_range(1..513)` — the resulting slice starts at base+1, which
-    /// is never a multiple of 512.
+    /// shifting an aligned allocation by one byte.
     #[tokio::test]
     async fn test_write_direct_at_unaligned_ptr_bounce() {
         let temp = TempDir::new().expect("tempdir");
         let path = temp.path().join("bounce.bin");
         let file = open_direct_io_file(&path);
 
-        // Allocate 513 bytes with 512-byte alignment.  The base pointer is
-        // aligned, but sub_range(1..513) shifts it by one byte — guaranteed unaligned.
-        let mut wbuf = AlignedBuffer::new(513, DIRECT_IO_ALIGNMENT).expect("alloc 513-byte buffer");
+        // Shift the aligned base by one byte while preserving an aligned length.
+        let alignment = file.inner.alignment;
+        let mut wbuf = AlignedBuffer::new(alignment.offset + 1, alignment.memory).expect("alloc");
         wbuf.as_mut().fill(0xCD);
-        let unaligned = wbuf.into_sub_range(1..513).expect("sub-range");
+        let unaligned = wbuf
+            .into_sub_range(1..alignment.offset + 1)
+            .expect("sub-range");
         assert_ne!(
-            unaligned.as_ref().as_ptr() as usize % DIRECT_IO_ALIGNMENT,
+            unaligned.as_ref().as_ptr() as usize % alignment.memory,
             0,
             "pointer must be unaligned for this test to be meaningful"
         );
@@ -948,12 +961,12 @@ mod tests {
             .await
             .expect("unaligned-ptr write via bounce buffer");
 
-        let got = file.read_at(0, 512).await.expect("read back");
-        assert_eq!(got.as_ref(), &[0xCD_u8; 512]);
+        let got = file.read_at(0, alignment.offset).await.expect("read back");
+        assert_eq!(got.as_ref(), vec![0xCD; alignment.offset]);
     }
 
     /// `write_at` on a direct-IO file must reject an offset that is not a
-    /// multiple of 512.
+    /// multiple of the file's offset alignment.
     #[tokio::test]
     async fn test_write_direct_at_unaligned_offset_rejected() {
         let temp = TempDir::new().expect("tempdir");
@@ -972,7 +985,7 @@ mod tests {
     }
 
     /// `write_at` on a direct-IO file must reject a buffer whose length is not
-    /// a multiple of 512.
+    /// a multiple of the file's offset alignment.
     #[tokio::test]
     async fn test_write_direct_at_unaligned_len_rejected() {
         let temp = TempDir::new().expect("tempdir");
@@ -998,11 +1011,120 @@ mod tests {
         let path = temp.path().join("bytes_at.bin");
         let file = open_direct_io_file(&path);
 
-        let data = bytes::Bytes::from(vec![0xBB_u8; 512]);
+        let alignment = file.inner.alignment;
+        let data = bytes::Bytes::from(vec![0xBB_u8; alignment.offset]);
         file.write_bytes_at(0, data).await.expect("write_bytes_at");
 
-        let got = file.read_at(0, 512).await.expect("read back");
-        assert_eq!(got.as_ref(), &[0xBB_u8; 512]);
+        let got = file.read_at(0, alignment.offset).await.expect("read back");
+        assert_eq!(got.as_ref(), vec![0xBB; alignment.offset]);
+    }
+
+    /// Lower-layer reads may begin and end inside a device sector, including EOF.
+    #[tokio::test]
+    async fn test_direct_io_read_subsector_ranges() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("lower.bin");
+        let data: Vec<u8> = (0..8704).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&path, &data).unwrap();
+        let file = LocalFile::builder()
+            .write(false)
+            .create(false)
+            .direct_io(true)
+            .open(&path)
+            .unwrap();
+
+        for (offset, len) in [(512, 512), (4095, 513), (8193, 1024), (8704, 512)] {
+            let end = (offset + len).min(data.len());
+            let expected = &data[offset..end];
+            assert_eq!(file.read_at(offset as u64, len).await.unwrap(), expected);
+            let mut dst = vec![0xFF; len + 1];
+            let n = file
+                .read_at_into(offset as u64, &mut dst[1..])
+                .await
+                .unwrap();
+            assert_eq!(&dst[1..1 + n], expected);
+            assert!(dst[1 + n..].iter().all(|&byte| byte == 0xFF));
+        }
+    }
+
+    #[cfg(feature = "io-uring")]
+    #[test]
+    #[ignore = "requires a host with io-uring enabled; run explicitly with --ignored"]
+    fn test_direct_io_context_alignment() {
+        use storage_util::io_ring::{AsyncIoRing, AsyncIoRingBuilder, URING};
+
+        let ring: AsyncIoRing = AsyncIoRingBuilder::new().build().unwrap();
+        assert!(URING.with(|slot| slot.set(ring.clone())).is_ok());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .on_thread_park(|| {
+                URING.with(|slot| slot.get().unwrap().borrow().submit().unwrap());
+            })
+            .build()
+            .unwrap();
+        tokio::task::LocalSet::new().block_on(&runtime, async {
+            let run = async {
+                let temp = TempDir::new().unwrap();
+                let path = temp.path().join("uring.bin");
+                let data: Vec<u8> = (0..8704).map(|i| (i % 251) as u8).collect();
+                std::fs::write(&path, &data).unwrap();
+                let file = LocalFile::builder()
+                    .create(false)
+                    .direct_io(true)
+                    .open(&path)
+                    .unwrap();
+                let ctx = IoCtx::new(&ring);
+                for (offset, len) in [(512, 512), (4095, 513), (8193, 1024)] {
+                    let expected = &data[offset..(offset + len).min(data.len())];
+                    assert_eq!(
+                        file.read_at_with_ctx(ctx, offset as u64, len)
+                            .await
+                            .unwrap(),
+                        expected
+                    );
+                    // 512-aligned memory still requires a bounce on a 4K device.
+                    let mut dst = AlignedBuffer::new(len, 512).unwrap();
+                    let n = file
+                        .read_at_into_with_ctx(ctx, offset as u64, dst.as_mut())
+                        .await
+                        .unwrap();
+                    assert_eq!(&dst.as_ref()[..n], expected);
+                }
+                let mut aligned = AlignedBuffer::new(4096, 4096).unwrap();
+                aligned.as_mut().fill(0xAB);
+                assert_eq!(
+                    file.write_at_with_ctx(ctx, 0, aligned.as_ref())
+                        .await
+                        .unwrap(),
+                    4096
+                );
+                let mut bounce = AlignedBuffer::new(4097, 4096).unwrap();
+                bounce.as_mut().fill(0xCD);
+                assert_eq!(
+                    file.write_at_with_ctx(ctx, 4096, &bounce.as_ref()[1..])
+                        .await
+                        .unwrap(),
+                    4096
+                );
+                assert_eq!(
+                    file.read_at_with_ctx(ctx, 0, 4096).await.unwrap().as_ref(),
+                    &[0xAB; 4096]
+                );
+                assert_eq!(
+                    file.read_at_with_ctx(ctx, 4096, 4096)
+                        .await
+                        .unwrap()
+                        .as_ref(),
+                    &[0xCD; 4096]
+                );
+            };
+            tokio::select! {
+                result = tokio::time::timeout(std::time::Duration::from_secs(30), run) => {
+                    result.expect("io-uring test timed out");
+                }
+                result = ring.handle_completion() => panic!("io-uring stopped: {result:?}"),
+            }
+        });
     }
 
     #[tokio::test]

--- a/storage/overlaybd/src/sys/mod.rs
+++ b/storage/overlaybd/src/sys/mod.rs
@@ -27,7 +27,9 @@ mod sparse;
 mod xattr;
 
 pub use fs_space::fs_space;
-pub use open_flags::{direct_io_open_flag, enable_direct_io};
+pub use open_flags::{
+    direct_io_alignment, direct_io_open_flag, enable_direct_io, DirectIoAlignment,
+};
 pub use page_cache::evict_page_cache;
 pub use release_space::release_space_hint;
 pub use reserve_space::reserve_space;

--- a/storage/overlaybd/src/sys/open_flags.rs
+++ b/storage/overlaybd/src/sys/open_flags.rs
@@ -4,6 +4,28 @@ use std::fs::File;
 
 use super::SysResult;
 
+/// Alignment requirements for a file opened with direct I/O.
+#[derive(Clone, Copy)]
+pub struct DirectIoAlignment {
+    pub memory: usize,
+    pub offset: usize,
+}
+
+impl Default for DirectIoAlignment {
+    fn default() -> Self {
+        // Preserve the existing contract when the OS cannot report file limits.
+        Self {
+            memory: 512,
+            offset: 512,
+        }
+    }
+}
+
+/// Query the already-open file, without resolving its backing device or path.
+pub fn direct_io_alignment(file: &File) -> SysResult<DirectIoAlignment> {
+    imp::direct_io_alignment(file)
+}
+
 /// The open flag requesting cache-bypassing I/O, or `None` on platforms that
 /// express it after open instead (see [`enable_direct_io`]).
 pub fn direct_io_open_flag() -> Option<i32> {
@@ -46,6 +68,45 @@ mod imp {
 
     pub(super) const DIRECT_IO_OPEN_FLAG: Option<i32> = Some(libc::O_DIRECT);
 
+    pub(super) fn direct_io_alignment(file: &File) -> SysResult<super::DirectIoAlignment> {
+        use std::os::fd::AsRawFd;
+
+        use nix::errno::Errno;
+
+        use super::super::SysError;
+
+        let mut stat = std::mem::MaybeUninit::<libc::statx>::zeroed();
+        // SAFETY: file owns a live descriptor, the empty path is NUL terminated,
+        // and stat points to writable storage for the complete statx result.
+        let ret = unsafe {
+            libc::statx(
+                file.as_raw_fd(),
+                c"".as_ptr(),
+                libc::AT_EMPTY_PATH,
+                libc::STATX_DIOALIGN,
+                stat.as_mut_ptr(),
+            )
+        };
+        if ret != 0 {
+            return match Errno::last() {
+                Errno::ENOSYS | Errno::EINVAL | Errno::EOPNOTSUPP => Ok(Default::default()),
+                errno => Err(SysError::Errno(errno)),
+            };
+        }
+        // SAFETY: statx succeeded and initialized the output.
+        let stat = unsafe { stat.assume_init() };
+        if stat.stx_mask & libc::STATX_DIOALIGN == 0 {
+            return Ok(Default::default());
+        }
+        if stat.stx_dio_mem_align == 0 {
+            return Err(SysError::Unsupported("direct_io on this file"));
+        }
+        Ok(super::DirectIoAlignment {
+            memory: stat.stx_dio_mem_align as usize,
+            offset: stat.stx_dio_offset_align as usize,
+        })
+    }
+
     /// `O_DIRECT` was set at open time, so there is nothing left to do.
     pub(super) fn enable_direct_io(_file: &File) -> SysResult<()> {
         Ok(())
@@ -58,6 +119,10 @@ mod imp {
     use std::os::fd::AsRawFd;
 
     use super::super::{SysError, SysResult};
+
+    pub(super) fn direct_io_alignment(_file: &File) -> SysResult<super::DirectIoAlignment> {
+        Ok(Default::default())
+    }
 
     /// Darwin has no open-time flag for this; see [`enable_direct_io`].
     pub(super) const DIRECT_IO_OPEN_FLAG: Option<i32> = None;
@@ -78,6 +143,10 @@ mod imp {
     use std::fs::File;
 
     use super::super::{SysError, SysResult};
+
+    pub(super) fn direct_io_alignment(_file: &File) -> SysResult<super::DirectIoAlignment> {
+        Ok(Default::default())
+    }
 
     pub(super) const DIRECT_IO_OPEN_FLAG: Option<i32> = None;
 

--- a/storage/overlaybd/src/sys/open_flags.rs
+++ b/storage/overlaybd/src/sys/open_flags.rs
@@ -98,13 +98,19 @@ mod imp {
         if stat.stx_mask & libc::STATX_DIOALIGN == 0 {
             return Ok(Default::default());
         }
-        if stat.stx_dio_mem_align == 0 {
+        if stat.stx_dio_mem_align == 0 || stat.stx_dio_offset_align == 0 {
             return Err(SysError::Unsupported("direct_io on this file"));
         }
-        Ok(super::DirectIoAlignment {
-            memory: stat.stx_dio_mem_align as usize,
-            offset: stat.stx_dio_offset_align as usize,
-        })
+        let memory = usize::try_from(stat.stx_dio_mem_align)
+            .map_err(|_| SysError::Unsupported("direct_io alignment does not fit usize"))?;
+        let offset = usize::try_from(stat.stx_dio_offset_align)
+            .map_err(|_| SysError::Unsupported("direct_io alignment does not fit usize"))?;
+        if !memory.is_power_of_two() || !offset.is_power_of_two() {
+            return Err(SysError::Unsupported(
+                "direct_io alignment is not a power of two",
+            ));
+        }
+        Ok(super::DirectIoAlignment { memory, offset })
     }
 
     /// `O_DIRECT` was set at open time, so there is nothing left to do.

--- a/storage/util/src/io_ring/mod.rs
+++ b/storage/util/src/io_ring/mod.rs
@@ -172,6 +172,39 @@ pub async fn read_exact_at<S: IoUringSubmitter + ?Sized>(
     Ok(bytes_read)
 }
 
+pub async fn read_exact_at_aligned<S: IoUringSubmitter + ?Sized>(
+    submitter: &S,
+    fd: RawFd,
+    mut buf: &mut [u8],
+    mut offset: u64,
+    alignment: usize,
+) -> std::io::Result<usize> {
+    let mut total = 0;
+    while !buf.is_empty() {
+        let entry = opcode::Read::new(io_uring::types::Fd(fd), buf.as_mut_ptr(), buf.len() as _)
+            .offset(offset)
+            .build();
+        let res = submitter.submit(entry).await?;
+        if res <= 0 {
+            if res == 0 {
+                break;
+            }
+            if res == -libc::EINTR {
+                continue;
+            }
+            return Err(std::io::Error::from_raw_os_error(-res));
+        }
+        let n = res as usize;
+        total += n;
+        if n < buf.len() && !n.is_multiple_of(alignment) {
+            break;
+        }
+        buf = &mut buf[n..];
+        offset += n as u64;
+    }
+    Ok(total)
+}
+
 /// Try to write the `buf` into the file as much as possible.
 /// Similar to [write_exact_at_fixed], expect the `fd` is not
 /// an index to sparse file table, but a file descriptor.
@@ -203,4 +236,37 @@ pub async fn write_exact_at<S: IoUringSubmitter + ?Sized>(
         }
     }
     Ok(bytes_written)
+}
+
+pub async fn write_exact_at_aligned<S: IoUringSubmitter + ?Sized>(
+    submitter: &S,
+    fd: RawFd,
+    mut buf: &[u8],
+    mut offset: u64,
+    alignment: usize,
+) -> std::io::Result<usize> {
+    let mut total = 0;
+    while !buf.is_empty() {
+        let entry = opcode::Write::new(io_uring::types::Fd(fd), buf.as_ptr(), buf.len() as _)
+            .offset(offset)
+            .build();
+        let res = submitter.submit(entry).await?;
+        if res <= 0 {
+            if res == 0 {
+                break;
+            }
+            if res == -libc::EINTR {
+                continue;
+            }
+            return Err(std::io::Error::from_raw_os_error(-res));
+        }
+        let n = res as usize;
+        total += n;
+        if n < buf.len() && !n.is_multiple_of(alignment) {
+            break;
+        }
+        buf = &buf[n..];
+        offset += n as u64;
+    }
+    Ok(total)
 }


### PR DESCRIPTION
## What

<!-- Summarize the change. Keep the PR focused on one problem. -->

Query each direct-I/O file’s memory and offset alignment with Linux STATX_DIOALIGN and use those limits for LocalFile reads and writes, including io_uring. This allows sub-sector reads from local lower layers on filesystems requiring 4096-byte direct I/O.

## Why

<!-- Explain the user or maintainer problem this solves. -->

The fixed 512-byte alignment causes EINVAL when the backing file requires 4096-byte requests. The libaio image path opens local lower layers with direct I/O, so even reading their headers can fail.

## Related issue

<!-- Use "Closes #123" for an issue resolved by this PR. Non-trivial changes should normally have an issue or prior design discussion. -->

Related to #274. This addresses lower-layer reads and aligned LocalFile I/O; writable LSMT operations that issue 512-byte requests on a 4K-required file remain unsupported.

## Scope and non-goals

<!-- State what is intentionally included and excluded. Call out unrelated refactors. -->

The change is limited to LocalFile and its existing platform syscall boundary. The LSMT data/index layout remains unchanged; it does not add read-modify-write or buffered fallback.

## Design and behavior changes

<!-- Describe important data flow, lifecycle, failure handling, concurrency, or operational changes. Include diagrams for substantial changes. -->

Alignment is queried once using the opened descriptor. Read ranges use the reported offset alignment, while bounce buffers use the memory alignment. Writes still require aligned offsets and lengths, and invalid requests report the required alignment. If the kernel/filesystem cannot report the limits, or on macOS, the existing 512-byte behavior is retained. Other query errors are propagated.

## Compatibility and operations

<!-- Explain applicable compatibility and deployment impact. Write "N/A" with a reason where appropriate. -->

- Public API or generated protocol: unchanged.
- Configuration or defaults: unchanged; buffered files do not query alignment.
- Snapshot manifest, artifact layout, or storage format: unchanged.
- Upgrade and rollback: no migration; rollback restores the old alignment assumption.
- Host requirements, permissions, ports, or dependencies: no new dependency or privilege; STATX_DIOALIGN is used when available (Linux 6.1+ with filesystem support).

## Validation

<!-- Check only commands you actually ran. Add focused tests and exact commands below. -->

- [x] `make fmt`
- [x] `make clippy`
- [ ] `make test-unit`
- [ ] Relevant Rust integration tests
- [ ] `make -C services test` (required when `services/` changes)
- [ ] Generated clients/server regenerated with the documented `make` target
- [ ] Documentation updated
- [ ] Benchmarks or performance comparison completed

Commands and results:

```text
cargo test --locked -p overlaybd --lib --all-features
  359 passed, 4 ignored
cargo clippy --locked -p overlaybd --all-targets --all-features -- -D warnings
  passed
make fmt
  passed
make clippy
  passed with locally extracted libclang and explicit resource directory
git diff --check
  passed
```

Full workspace clippy passed after supplying libclang/LLVM and Clang builtin headers from locally extracted distribution packages; no host packages were installed.

The no-default-features library suite also passed (299 tests, 2 ignored). A process-local syscall probe reporting and enforcing 4K constraints makes the same new lower-read regression fail on base with EINVAL and pass with this patch. The libaio image-open test passes under that probe. This models alignment constraints; it is not native 4K hardware validation, and it does not intercept io_uring submissions.

Skipped checks and reasons:

- Native 4K validation and macOS execution were unavailable.
- The new explicit context/io_uring test was attempted but failed before I/O during ring setup on local WSL 5.15 (EINVAL); the existing ring builder requires newer kernel setup flags.
- Privileged ublk, VM and full E2E tiers were not run on this host. Go, generated-code, documentation and benchmark checks are unrelated to this change.

## Risks and reviewer notes

<!-- Identify correctness, security, compatibility, resource, and operational risks. Point reviewers to the most important files or commits. -->

This is a partial fix for #274. LSMT uses 512-byte data and seal-index/padding writes, which cannot be submitted as direct I/O to a file requiring 4096-byte requests. Such writes now fail with the required alignment in the error. Supporting them needs a separate storage design. Filesystems that cannot report STATX_DIOALIGN retain the existing 512-byte assumption.

## Checklist

- [x] The PR contains one coherent change and no unrelated formatting or refactoring.
- [x] New behavior is covered by tests, or I explained why testing is impractical.
- [x] Logs and examples contain no credentials, tokens, or private registry information.
- [x] I did not manually edit generated code without updating its source and regenerating it.
